### PR TITLE
Display detailed login errors

### DIFF
--- a/src/helpers/__tests__/fetch.wrapper.spec.js
+++ b/src/helpers/__tests__/fetch.wrapper.spec.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { fetchWrapper } from '../fetch.wrapper.js'
+
+let originalFetch
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  originalFetch = global.fetch
+})
+
+afterEach(() => {
+  global.fetch = originalFetch
+})
+
+describe('fetchWrapper.handleResponse', () => {
+  it('returns detail message from server response', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ detail: 'Invalid credentials' }),
+          { status: 400, statusText: 'Bad Request' }
+        )
+      )
+    )
+
+    await expect(
+      fetchWrapper.post('http://example.com/login', { email: 'a', password: 'b' })
+    ).rejects.toBe('Invalid credentials')
+  })
+})

--- a/src/helpers/fetch.wrapper.js
+++ b/src/helpers/fetch.wrapper.js
@@ -86,7 +86,8 @@ function handleResponse(response) {
           }
         }
 
-        const error = (data && data.message) || response.statusText
+        const error =
+          (data && (data.message || data.detail)) || response.statusText
         return Promise.reject(error)
       }
       return data


### PR DESCRIPTION
## Summary
- forward detailed error message from server
- test fetch wrapper error handling

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6856ce4a54f883218ec6a194c6f0a7f4