### PR TITLE
Add codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Logibooks UI
 
 [![CI workflow](https://github.com/maxirmx/logibooks.ui/actions/workflows/ci.yml/badge.svg)](https://github.com/maxirmx/logibooks.ui/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/maxirmx/logibooks.ui/branch/main/graph/badge.svg)](https://codecov.io/gh/maxirmx/logibooks.ui)


### PR DESCRIPTION
## Summary
- add codecov badge next to CI badge in README

## Testing
- `npm install`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_68571ac9d364832197aa258aed8edba4