### PR TITLE
Show core/db version in drawer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,12 +27,19 @@
 import { RouterLink, RouterView } from 'vue-router'
 import router from '@/router'
 import { version } from '@/../package'
+import { onMounted } from 'vue'
+import { useStatusStore } from '@/stores/status.store.js'
 
 import { useDisplay } from 'vuetify'
 const { height } = useDisplay()
 
 import { useAuthStore } from '@/stores/auth.store.js'
 const authStore = useAuthStore()
+
+const statusStore = useStatusStore()
+onMounted(() => {
+  statusStore.fetchStatus().catch(() => {})
+})
 
 import { drawer, toggleDrawer } from '@/helpers/drawer.js'
 
@@ -97,6 +104,18 @@ function getUserName() {
       <template v-slot:append>
         <div class="pa-2">
           <span class="orange version"> Версия {{ version }} </span>
+          <span
+            v-if="statusStore.coreVersion"
+            class="orange version"
+          >
+            Core {{ statusStore.coreVersion }}
+          </span>
+          <span
+            v-if="statusStore.dbVersion"
+            class="orange version"
+          >
+            DB {{ statusStore.dbVersion }}
+          </span>
         </div>
       </template>
     </v-navigation-drawer>

--- a/src/App.vue
+++ b/src/App.vue
@@ -103,18 +103,14 @@ function getUserName() {
       </v-list>
       <template v-slot:append>
         <div class="pa-2">
-          <span class="orange version"> Версия {{ version }} </span>
-          <span
-            v-if="statusStore.coreVersion"
-            class="orange version"
-          >
-            Core {{ statusStore.coreVersion }}
+          <span class="orange version"> Клиент {{ version }} </span>
+          <br v-if="statusStore.coreVersion"/>
+          <span v-if="statusStore.coreVersion" class="orange version">
+            Сервер {{ statusStore.coreVersion }}
           </span>
-          <span
-            v-if="statusStore.dbVersion"
-            class="orange version"
-          >
-            DB {{ statusStore.dbVersion }}
+          <br v-if="statusStore.dbVersion"/>
+          <span v-if="statusStore.dbVersion" class="orange version"          >
+            БД {{ statusStore.dbVersion }}
           </span>
         </div>
       </template>

--- a/src/stores/status.store.js
+++ b/src/stores/status.store.js
@@ -1,3 +1,28 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
@@ -11,8 +36,8 @@ export const useStatusStore = defineStore('status', () => {
 
   async function fetchStatus() {
     const res = await fetchWrapper.get(`${baseUrl}/status`)
-    coreVersion.value = res.AppVersion
-    dbVersion.value = res.DbVersion
+    coreVersion.value = res.appVersion
+    dbVersion.value = res.dbVersion
   }
 
   return { coreVersion, dbVersion, fetchStatus }

--- a/src/stores/status.store.js
+++ b/src/stores/status.store.js
@@ -35,6 +35,8 @@ export const useStatusStore = defineStore('status', () => {
   const dbVersion = ref('')
 
   async function fetchStatus() {
+    coreVersion.value = undefined
+    dbVersion.value = undefined
     const res = await fetchWrapper.get(`${baseUrl}/status`)
     coreVersion.value = res.appVersion
     dbVersion.value = res.dbVersion

--- a/src/stores/status.store.js
+++ b/src/stores/status.store.js
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/status`
+
+export const useStatusStore = defineStore('status', () => {
+  const coreVersion = ref('')
+  const dbVersion = ref('')
+
+  async function fetchStatus() {
+    const res = await fetchWrapper.get(`${baseUrl}/status`)
+    coreVersion.value = res.AppVersion
+    dbVersion.value = res.DbVersion
+  }
+
+  return { coreVersion, dbVersion, fetchStatus }
+})

--- a/tests/statusStore.spec.js
+++ b/tests/statusStore.spec.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useStatusStore } from '@/stores/status.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: {
+    get: vi.fn()
+  }
+}))
+
+vi.mock('@/helpers/config.js', () => ({
+  apiUrl: 'http://localhost:8080/api'
+}))
+
+describe('status store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('fetchStatus sets versions from API', async () => {
+    fetchWrapper.get.mockResolvedValue({
+      AppVersion: '1.2.3',
+      DbVersion: '20240624'
+    })
+
+    const store = useStatusStore()
+    await store.fetchStatus()
+
+    expect(fetchWrapper.get).toHaveBeenCalledWith(
+      `${apiUrl}/status/status`
+    )
+    expect(store.coreVersion).toBe('1.2.3')
+    expect(store.dbVersion).toBe('20240624')
+  })
+})

--- a/tests/statusStore.spec.js
+++ b/tests/statusStore.spec.js
@@ -22,8 +22,8 @@ describe('status store', () => {
 
   it('fetchStatus sets versions from API', async () => {
     fetchWrapper.get.mockResolvedValue({
-      AppVersion: '1.2.3',
-      DbVersion: '20240624'
+      appVersion: '1.2.3',
+      dbVersion: '20240624'
     })
 
     const store = useStatusStore()


### PR DESCRIPTION
## Summary
- add status store to load backend version info
- display core and database versions in left navigation drawer
- test status store

## Testing
- `npm run test:unit --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859a8d3345883219b75207478caf487