### PR TITLE
Add router and login view tests

### DIFF
--- a/tests/User_LoginView.spec.js
+++ b/tests/User_LoginView.spec.js
@@ -1,0 +1,72 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import UserLoginView from '@/views/User_LoginView.vue'
+
+const routerPush = vi.hoisted(() => vi.fn())
+const loginMock = vi.hoisted(() => vi.fn().mockResolvedValue())
+let authStore
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return { ...actual, storeToRefs: (store) => store }
+})
+
+vi.mock('@/router', () => ({
+  default: { push: routerPush }
+}))
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: () => authStore
+}))
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => ({ alert: null, clear: vi.fn() })
+}))
+
+const FormStub = {
+  template: '<form @submit.prevent="$emit(\'submit\')"><slot :errors="{}" :isSubmitting="false" /></form>'
+}
+const FieldStub = {
+  props: ['name', 'id', 'type'],
+  template: '<input :id="id" :type="type" />'
+}
+
+describe('User_LoginView.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authStore = { login: loginMock, isAdmin: false, user: { id: 1 } }
+  })
+
+  it('toggles password visibility', async () => {
+    const wrapper = mount(UserLoginView, {
+      global: { stubs: { Form: FormStub, Field: FieldStub, 'font-awesome-icon': true } }
+    })
+    const pwdInput = wrapper.find('#login_password')
+    expect(pwdInput.attributes('type')).toBe('password')
+    const toggle = wrapper.find('button[type="button"]')
+    await toggle.trigger('click')
+    expect(wrapper.find('#login_password').attributes('type')).toBe('text')
+  })
+
+  it('redirects after successful login', async () => {
+    authStore.isAdmin = true
+    const wrapper = mount(UserLoginView, {
+      global: { stubs: { Form: FormStub, Field: FieldStub, 'font-awesome-icon': true } }
+    })
+    await wrapper.vm.onSubmit({ login_email: 'a', login_password: 'b' }, { setErrors: vi.fn() })
+    await flushPromises()
+    expect(loginMock).toHaveBeenCalledWith('a', 'b')
+    expect(routerPush).toHaveBeenCalledWith('/users')
+  })
+
+  it('redirects non-admin to edit page', async () => {
+    authStore.isAdmin = false
+    const wrapper = mount(UserLoginView, {
+      global: { stubs: { Form: FormStub, Field: FieldStub, 'font-awesome-icon': true } }
+    })
+    await wrapper.vm.onSubmit({ login_email: 'a', login_password: 'b' }, { setErrors: vi.fn() })
+    await flushPromises()
+    expect(routerPush).toHaveBeenCalledWith('/user/edit/1')
+  })
+})

--- a/tests/router.spec.js
+++ b/tests/router.spec.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+let authStore
+const alertClear = vi.fn()
+const alertError = vi.fn()
+const checkMock = vi.fn()
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => ({ clear: alertClear, error: alertError })
+}))
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: () => authStore
+}))
+
+vi.mock('@/views/User_LoginView.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/views/User_RecoverView.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/views/User_RegisterView.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/views/Users_View.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/views/User_EditView.vue', () => ({ default: { template: '<div />' } }))
+
+import router from '@/router'
+
+async function resetRouter(to = "/recover") {
+  await router.replace(to);
+  await router.isReady();
+}
+
+describe('router guards', () => {
+  beforeEach(async () => {
+    authStore = { user: null, returnUrl: null, check: checkMock, isAdmin: false }
+    checkMock.mockResolvedValue()
+    alertClear.mockClear()
+    alertError.mockClear()
+    await resetRouter("/recover")
+  })
+
+  it('redirects unauthenticated users to login', async () => {
+    await router.push('/users')
+    await router.isReady()
+    expect(router.currentRoute.value.fullPath).toBe('/login')
+    expect(authStore.returnUrl).toBe('/users')
+  })
+
+  it('redirects authenticated admin away from login', async () => {
+    authStore.user = { id: 1 }
+    authStore.isAdmin = true
+    await router.push('/login')
+    await router.isReady()
+    expect(router.currentRoute.value.fullPath).toBe('/users')
+  })
+
+  it('redirects authenticated user to own edit page', async () => {
+    authStore.user = { id: 2 }
+    authStore.isAdmin = false
+    await router.push('/login')
+    await router.isReady()
+    expect(router.currentRoute.value.fullPath).toBe('/user/edit/2')
+  })
+})


### PR DESCRIPTION
## Summary
- add a new suite covering Vue router guards
- add tests for User_LoginView.vue

## Testing
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_685afb18855c832183fc381cf4b96a39