### PR TITLE
Implement order edit dialog

### DIFF
--- a/src/components/Order_EditDialog.vue
+++ b/src/components/Order_EditDialog.vue
@@ -1,5 +1,4 @@
 <script setup>
-import { ref } from 'vue'
 import router from '@/router'
 import { Form, Field } from 'vee-validate'
 import * as Yup from 'yup'

--- a/src/components/Order_EditDialog.vue
+++ b/src/components/Order_EditDialog.vue
@@ -1,0 +1,77 @@
+<script setup>
+import { ref } from 'vue'
+import router from '@/router'
+import { Form, Field } from 'vee-validate'
+import * as Yup from 'yup'
+import { useOrdersStore } from '@/stores/orders.store.js'
+import { useOrderStatusStore } from '@/stores/order.status.store.js'
+import { storeToRefs } from 'pinia'
+
+const props = defineProps({
+  registerId: { type: Number, required: true },
+  id: { type: Number, required: true }
+})
+
+const ordersStore = useOrdersStore()
+const statusStore = useOrderStatusStore()
+
+const { item } = storeToRefs(ordersStore)
+
+statusStore.ensureStatusesLoaded()
+await ordersStore.getById(props.id)
+
+const schema = Yup.object().shape({
+  statusId: Yup.number().required('Необходимо выбрать статус'),
+  rowNumber: Yup.number().required('Необходимо указать номер строки'),
+  orderNumber: Yup.string().required('Необходимо указать номер заказа'),
+  tnVed: Yup.string().required('Необходимо указать ТН ВЭД')
+})
+
+function onSubmit(values, { setErrors }) {
+  return ordersStore
+    .update(props.id, values)
+    .then(() => router.push(`/registers/${props.registerId}/orders`))
+    .catch((error) => setErrors({ apiError: error.message || String(error) }))
+}
+</script>
+
+<template>
+  <div class="settings form-2">
+    <h1 class="primary-heading">Заказ {{ item?.value?.id }}</h1>
+    <hr class="hr" />
+    <Form @submit="onSubmit" :initial-values="item" :validation-schema="schema" v-slot="{ errors, isSubmitting }">
+      <div class="form-group">
+        <label for="rowNumber" class="label">Номер строки:</label>
+        <Field name="rowNumber" id="rowNumber" type="number" class="form-control input" :class="{ 'is-invalid': errors.rowNumber }" />
+      </div>
+      <div class="form-group">
+        <label for="orderNumber" class="label">Номер заказа:</label>
+        <Field name="orderNumber" id="orderNumber" type="text" class="form-control input" :class="{ 'is-invalid': errors.orderNumber }" />
+      </div>
+      <div class="form-group">
+        <label for="tnVed" class="label">ТН ВЭД:</label>
+        <Field name="tnVed" id="tnVed" type="text" class="form-control input" :class="{ 'is-invalid': errors.tnVed }" />
+      </div>
+      <div class="form-group">
+        <label for="statusId" class="label">Статус:</label>
+        <Field as="select" name="statusId" id="statusId" class="form-control input" :class="{ 'is-invalid': errors.statusId }">
+          <option v-for="s in statusStore.statuses" :key="s.id" :value="s.id">{{ s.title }}</option>
+        </Field>
+      </div>
+      <div class="form-group">
+        <button class="button" type="submit" :disabled="isSubmitting">
+          <span v-show="isSubmitting" class="spinner-border spinner-border-sm mr-1"></span>
+          Сохранить
+        </button>
+        <button class="button" type="button" @click="router.push(`/registers/${props.registerId}/orders`)">Отменить</button>
+      </div>
+      <div v-if="errors.apiError" class="alert alert-danger mt-3 mb-0">{{ errors.apiError }}</div>
+    </Form>
+    <div v-if="item?.loading" class="text-center m-5">
+      <span class="spinner-border spinner-border-lg align-center"></span>
+    </div>
+    <div v-if="item?.error" class="text-center m-5">
+      <div class="text-danger">Ошибка при загрузке заказа: {{ item.error }}</div>
+    </div>
+  </div>
+</template>

--- a/src/components/Orders_List.vue
+++ b/src/components/Orders_List.vue
@@ -3,6 +3,7 @@ import { watch, ref, computed, onMounted } from 'vue'
 import { useOrdersStore } from '@/stores/orders.store.js'
 import { useOrderStatusStore } from '@/stores/order.status.store.js'
 import { useAuthStore } from '@/stores/auth.store.js'
+import router from '@/router'
 import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
 import { storeToRefs } from 'pinia'
 import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
@@ -127,7 +128,7 @@ const headers = computed(() => {
 })
 
 function editOrder(item) {
-  ordersStore.update(item.id, {})
+  router.push(`/registers/${props.registerId}/orders/edit/${item.id}`)
 }
 
 function exportOrderXml(item) {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -92,6 +92,13 @@ const router = createRouter({
       meta: { requiresLogist: true }
     },
     {
+      path: '/registers/:registerId/orders/edit/:id',
+      name: 'Редактирование заказа',
+      component: () => import('@/views/Order_EditView.vue'),
+      props: true,
+      meta: { requiresLogist: true }
+    },
+    {
       path: '/user/edit/:id',
       name: 'Настройки',
       component: () => import('@/views/User_EditView.vue'),

--- a/src/stores/orders.store.js
+++ b/src/stores/orders.store.js
@@ -7,6 +7,7 @@ const baseUrl = `${apiUrl}/orders`
 
 export const useOrdersStore = defineStore('orders', () => {
   const items = ref([])
+  const item = ref({})
   const loading = ref(false)
   const error = ref(null)
   const totalCount = ref(0)
@@ -51,6 +52,15 @@ export const useOrdersStore = defineStore('orders', () => {
     }
   }
 
+  async function getById(id) {
+    item.value = { loading: true }
+    try {
+      item.value = await fetchWrapper.get(`${baseUrl}/${id}`)
+    } catch (err) {
+      item.value = { error: err }
+    }
+  }
+
   async function update(id, data) {
     console.log('stub update order', id, data)
   }
@@ -65,12 +75,14 @@ export const useOrdersStore = defineStore('orders', () => {
 
   return {
     items,
+    item,
     loading,
     error,
     totalCount,
     hasNextPage,
     hasPreviousPage,
     getAll,
+    getById,
     update,
     generate,
     generateAll

--- a/src/views/Order_EditView.vue
+++ b/src/views/Order_EditView.vue
@@ -1,0 +1,17 @@
+<script setup>
+import OrderEditDialog from '@/components/Order_EditDialog.vue'
+
+const props = defineProps({
+  registerId: { type: String, required: true },
+  id: { type: String, required: true }
+})
+
+const registerId = parseInt(props.registerId)
+const id = parseInt(props.id)
+</script>
+
+<template>
+  <Suspense>
+    <OrderEditDialog :register-id="registerId" :id="id" />
+  </Suspense>
+</template>

--- a/tests/ordersStore.spec.js
+++ b/tests/ordersStore.spec.js
@@ -48,4 +48,12 @@ describe('orders store', () => {
     expect(store.hasNextPage).toBe(false)
     expect(store.hasPreviousPage).toBe(false)
   })
+
+  it('fetches order by id', async () => {
+    fetchWrapper.get.mockResolvedValue({ id: 5 })
+    const store = useOrdersStore()
+    await store.getById(5)
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/orders/5`)
+    expect(store.item).toEqual({ id: 5 })
+  })
 })

--- a/tests/router.spec.js
+++ b/tests/router.spec.js
@@ -19,6 +19,7 @@ vi.mock('@/views/User_RegisterView.vue', () => ({ default: { template: '<div />'
 vi.mock('@/views/Users_View.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/views/User_EditView.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/views/Registers_View.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/views/Order_EditView.vue', () => ({ default: { template: '<div />' } }))
 
 import router from '@/router'
 
@@ -115,6 +116,27 @@ describe('router guards', () => {
     await router.push('/registers/1/orders')
     await router.isReady()
     expect(router.currentRoute.value.fullPath).toBe('/registers/1/orders')
+  })
+
+  it('prevents non-logist user from accessing order edit', async () => {
+    authStore.user = { id: 7 }
+    authStore.isLogist = false
+
+    await router.push('/registers/1/orders/edit/2')
+    await router.isReady()
+
+    expect(router.currentRoute.value.fullPath).toBe('/login')
+    expect(authStore.returnUrl).toBe('/registers/1/orders/edit/2')
+  })
+
+  it('allows logist user to access order edit', async () => {
+    authStore.user = { id: 8 }
+    authStore.isLogist = true
+
+    await router.push('/registers/1/orders/edit/2')
+    await router.isReady()
+
+    expect(router.currentRoute.value.fullPath).toBe('/registers/1/orders/edit/2')
   })
 
   describe('root path redirects', () => {


### PR DESCRIPTION
## Summary
- implement order edit component and view
- enable navigation from orders list to edit dialog
- fetch single order in order store
- add router route and store tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a35440f948321ac293c3246e5e257