### PR TITLE
Add customs codes view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -88,6 +88,9 @@ function getUserName() {
         <v-list-item v-if="authStore.isLogist">
           <RouterLink to="/registers" class="link">Реестры</RouterLink>
         </v-list-item>
+        <v-list-item>
+          <RouterLink to="/customs_codes" class="link">Коды ТН ВЭД</RouterLink>
+        </v-list-item>
         <v-list-item v-if="!authStore.isAdmin">
           <RouterLink :to="'/user/edit/' + authStore.user.id" class="link">Настройки</RouterLink>
         </v-list-item>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -293,6 +293,15 @@ a,
   transition: 0.4s;
 }
 
+.secondary-heading {
+  color: #1976d2;
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  text-decoration: none;
+  transition: 0.4s;
+}
+
 .link {
   font-size: 1.1rem;
 }

--- a/src/components/CustomsCodes_List.vue
+++ b/src/components/CustomsCodes_List.vue
@@ -14,7 +14,29 @@ const props = defineProps({
 })
 
 const authStore = useAuthStore()
-const { customs_codes_per_page, customs_codes_search, customs_codes_sort_by, customs_codes_page } = storeToRefs(authStore)
+
+// Use different state based on the table type
+const statePrefix = computed(() => props.title === 'Запреты' ? 'customs_items' : 'customs_exceptions')
+
+const per_page = computed({
+  get: () => authStore[`${statePrefix.value}_per_page`],
+  set: (val) => { authStore[`${statePrefix.value}_per_page`] = val }
+})
+
+const search = computed({
+  get: () => authStore[`${statePrefix.value}_search`],
+  set: (val) => { authStore[`${statePrefix.value}_search`] = val }
+})
+
+const sort_by = computed({
+  get: () => authStore[`${statePrefix.value}_sort_by`],
+  set: (val) => { authStore[`${statePrefix.value}_sort_by`] = val }
+})
+
+const page = computed({
+  get: () => authStore[`${statePrefix.value}_page`],
+  set: (val) => { authStore[`${statePrefix.value}_page`] = val }
+})
 
 const alertStore = useAlertStore()
 const { alert } = storeToRefs(alertStore)
@@ -70,15 +92,15 @@ const errorMessage = computed(() => {
     <v-card>
       <v-data-table
         v-if="items?.length"
-        v-model:items-per-page="customs_codes_per_page"
+        v-model:items-per-page="per_page"
         items-per-page-text="Записей на странице"
         :items-per-page-options="itemsPerPageOptions"
         page-text="{0}-{1} из {2}"
-        v-model:page="customs_codes_page"
+        v-model:page="page"
         :headers="headers"
         :items="items"
-        :search="customs_codes_search"
-        v-model:sort-by="customs_codes_sort_by"
+        :search="search"
+        v-model:sort-by="sort_by"
         :custom-filter="filterCustomsCodes"
         item-value="code"
         density="compact"
@@ -91,7 +113,7 @@ const errorMessage = computed(() => {
       
       <div v-if="items?.length">
         <v-text-field
-          v-model="customs_codes_search"
+          v-model="search"
           :append-inner-icon="mdiMagnify"
           :label="searchLabel"
           variant="solo"

--- a/src/components/CustomsCodes_List.vue
+++ b/src/components/CustomsCodes_List.vue
@@ -1,0 +1,116 @@
+<script setup>
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useAuthStore } from '@/stores/auth.store.js'
+import { useAlertStore } from '@/stores/alert.store.js'
+import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
+import { mdiMagnify } from '@mdi/js'
+
+const props = defineProps({
+  title: { type: String, required: true },
+  items: { type: Array, required: true },
+  loading: { type: Boolean, default: false },
+  error: { type: String, default: null }
+})
+
+const authStore = useAuthStore()
+const { customs_codes_per_page, customs_codes_search, customs_codes_sort_by, customs_codes_page } = storeToRefs(authStore)
+
+const alertStore = useAlertStore()
+const { alert } = storeToRefs(alertStore)
+
+const headers = [
+  { title: 'Код', key: 'code', align: 'start' },
+  { title: 'Наименование', key: 'name', align: 'start' },
+  { title: 'Номер', key: 'number', align: 'start' },
+  { title: 'Комментарий', key: 'comment', align: 'start' }
+]
+
+function filterCustomsCodes(value, query, item) {
+  if (query === null || item === null) {
+    return false
+  }
+  const i = item.raw
+  if (i === null) {
+    return false
+  }
+  const q = query.toLocaleUpperCase()
+
+  if (
+    i.code?.toLocaleUpperCase().indexOf(q) !== -1 ||
+    i.name?.toLocaleUpperCase().indexOf(q) !== -1 ||
+    i.number?.toLocaleUpperCase().indexOf(q) !== -1 ||
+    i.comment?.toLocaleUpperCase().indexOf(q) !== -1
+  ) {
+    return true
+  }
+  return false
+}
+
+const emptyMessage = computed(() => {
+  return props.title === 'Запреты' ? 'Список запретов пуст' : 'Список исключений пуст'
+})
+
+const searchLabel = computed(() => {
+  return props.title === 'Запреты' ? 'Поиск по запретам ТН ВЭД' : 'Поиск по исключениям ТН ВЭД'
+})
+
+const errorMessage = computed(() => {
+  if (!props.error) return null
+  return props.title === 'Запреты' 
+    ? `Ошибка при загрузке списка запретов: ${props.error}`
+    : `Ошибка при загрузке списка исключений: ${props.error}`
+})
+</script>
+
+<template>
+  <div>
+    <h2 class="secondary-heading" :style="title === 'Запреты' ? '' : 'margin-top: 20px;'">{{ title }}</h2>
+    
+    <v-card>
+      <v-data-table
+        v-if="items?.length"
+        v-model:items-per-page="customs_codes_per_page"
+        items-per-page-text="Записей на странице"
+        :items-per-page-options="itemsPerPageOptions"
+        page-text="{0}-{1} из {2}"
+        v-model:page="customs_codes_page"
+        :headers="headers"
+        :items="items"
+        :search="customs_codes_search"
+        v-model:sort-by="customs_codes_sort_by"
+        :custom-filter="filterCustomsCodes"
+        item-value="code"
+        density="compact"
+        class="elevation-1 interlaced-table"
+      />
+      
+      <div v-if="!items?.length && !loading" class="text-center m-5">
+        {{ emptyMessage }}
+      </div>
+      
+      <div v-if="items?.length">
+        <v-text-field
+          v-model="customs_codes_search"
+          :append-inner-icon="mdiMagnify"
+          :label="searchLabel"
+          variant="solo"
+          hide-details
+        />
+      </div>
+    </v-card>
+    
+    <div v-if="loading" class="text-center m-5">
+      <span class="spinner-border spinner-border-lg align-center"></span>
+    </div>
+    
+    <div v-if="error" class="text-center m-5">
+      <div class="text-danger">{{ errorMessage }}</div>
+    </div>
+    
+    <div v-if="alert" class="alert alert-dismissable mt-3 mb-0" :class="alert.type">
+      <button @click="alertStore.clear()" class="btn btn-link close">×</button>
+      {{ alert.message }}
+    </div>
+  </div>
+</template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -79,6 +79,12 @@ const router = createRouter({
       meta: { requiresAdmin: true }
     },
     {
+      path: '/customs_codes',
+      name: 'Коды ТН ВЭД',
+      component: () => import('@/views/CustomsCodes_View.vue'),
+      meta: { requiresAdmin: true }
+    },
+    {
       path: '/registers',
       name: 'Реестры',
       component: () => import('@/views/Registers_View.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -81,8 +81,7 @@ const router = createRouter({
     {
       path: '/customs_codes',
       name: 'Коды ТН ВЭД',
-      component: () => import('@/views/CustomsCodes_View.vue'),
-      meta: { requiresAdmin: true }
+      component: () => import('@/views/CustomsCodes_View.vue')
     },
     {
       path: '/registers',

--- a/src/stores/alta.store.js
+++ b/src/stores/alta.store.js
@@ -1,0 +1,52 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/alta`
+
+export const useAltaStore = defineStore('alta', () => {
+  const items = ref([])
+  const exceptions = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function getItems() {
+    loading.value = true
+    error.value = null
+    try {
+      items.value = await fetchWrapper.get(`${baseUrl}/items`)
+    } catch (err) {
+      error.value = err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getExceptions() {
+    loading.value = true
+    error.value = null
+    try {
+      exceptions.value = await fetchWrapper.get(`${baseUrl}/exceptions`)
+    } catch (err) {
+      error.value = err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function parse() {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.post(`${baseUrl}/parse`)
+      await Promise.all([getItems(), getExceptions()])
+    } catch (err) {
+      error.value = err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { items, exceptions, loading, error, getItems, getExceptions, parse }
+})

--- a/src/stores/alta.store.js
+++ b/src/stores/alta.store.js
@@ -11,41 +11,29 @@ export const useAltaStore = defineStore('alta', () => {
   const loading = ref(false)
   const error = ref(null)
 
-  async function getItems(manageLoading = true) {
-    if (manageLoading) {
-      loading.value = true
-      error.value = null
-    }
+  async function getItems() {
+    loading.value = true
+    error.value = null
     try {
       items.value = await fetchWrapper.get(`${baseUrl}/items`)
     } catch (err) {
-      if (manageLoading) {
-        error.value = err
-      }
+      error.value = err
       throw err
     } finally {
-      if (manageLoading) {
-        loading.value = false
-      }
+      loading.value = false
     }
   }
 
-  async function getExceptions(manageLoading = true) {
-    if (manageLoading) {
-      loading.value = true
-      error.value = null
-    }
+  async function getExceptions() {
+    loading.value = true
+    error.value = null
     try {
       exceptions.value = await fetchWrapper.get(`${baseUrl}/exceptions`)
     } catch (err) {
-      if (manageLoading) {
-        error.value = err
-      }
+      error.value = err
       throw err
     } finally {
-      if (manageLoading) {
-        loading.value = false
-      }
+      loading.value = false
     }
   }
 
@@ -54,10 +42,13 @@ export const useAltaStore = defineStore('alta', () => {
     error.value = null
     try {
       await fetchWrapper.post(`${baseUrl}/parse`)
-      await Promise.all([
-        getItems(false),
-        getExceptions(false)
+      // Fetch items and exceptions directly instead of using functions that toggle loading state
+      const [itemsData, exceptionsData] = await Promise.all([
+        fetchWrapper.get(`${baseUrl}/items`),
+        fetchWrapper.get(`${baseUrl}/exceptions`)
       ])
+      items.value = itemsData
+      exceptions.value = exceptionsData
     } catch (err) {
       error.value = err
     } finally {

--- a/src/stores/alta.store.js
+++ b/src/stores/alta.store.js
@@ -11,27 +11,41 @@ export const useAltaStore = defineStore('alta', () => {
   const loading = ref(false)
   const error = ref(null)
 
-  async function getItems() {
-    loading.value = true
-    error.value = null
+  async function getItems(manageLoading = true) {
+    if (manageLoading) {
+      loading.value = true
+      error.value = null
+    }
     try {
       items.value = await fetchWrapper.get(`${baseUrl}/items`)
     } catch (err) {
-      error.value = err
+      if (manageLoading) {
+        error.value = err
+      }
+      throw err
     } finally {
-      loading.value = false
+      if (manageLoading) {
+        loading.value = false
+      }
     }
   }
 
-  async function getExceptions() {
-    loading.value = true
-    error.value = null
+  async function getExceptions(manageLoading = true) {
+    if (manageLoading) {
+      loading.value = true
+      error.value = null
+    }
     try {
       exceptions.value = await fetchWrapper.get(`${baseUrl}/exceptions`)
     } catch (err) {
-      error.value = err
+      if (manageLoading) {
+        error.value = err
+      }
+      throw err
     } finally {
-      loading.value = false
+      if (manageLoading) {
+        loading.value = false
+      }
     }
   }
 
@@ -40,7 +54,10 @@ export const useAltaStore = defineStore('alta', () => {
     error.value = null
     try {
       await fetchWrapper.post(`${baseUrl}/parse`)
-      await Promise.all([getItems(), getExceptions()])
+      await Promise.all([
+        getItems(false),
+        getExceptions(false)
+      ])
     } catch (err) {
       error.value = err
     } finally {

--- a/src/stores/auth.store.js
+++ b/src/stores/auth.store.js
@@ -54,10 +54,14 @@ export const useAuthStore = defineStore('auth', () => {
   const orders_page = ref(1)
   const orders_status = ref(null)
   const orders_tnved = ref('')
-  const customs_codes_per_page = ref(25)
-  const customs_codes_search = ref('')
-  const customs_codes_sort_by = ref([{ key: 'code', order: 'asc' }])
-  const customs_codes_page = ref(1)
+  const customs_items_per_page = ref(25)
+  const customs_items_search = ref('')
+  const customs_items_sort_by = ref([{ key: 'code', order: 'asc' }])
+  const customs_items_page = ref(1)
+  const customs_exceptions_per_page = ref(25)
+  const customs_exceptions_search = ref('')
+  const customs_exceptions_sort_by = ref([{ key: 'code', order: 'asc' }])
+  const customs_exceptions_page = ref(1)
   const returnUrl = ref(null)
   const re_jwt = ref(null)
   const re_tgt = ref(null)
@@ -152,10 +156,14 @@ export const useAuthStore = defineStore('auth', () => {
     orders_page,
     orders_status,
     orders_tnved,
-    customs_codes_per_page,
-    customs_codes_search,
-    customs_codes_sort_by,
-    customs_codes_page,
+    customs_items_per_page,
+    customs_items_search,
+    customs_items_sort_by,
+    customs_items_page,
+    customs_exceptions_per_page,
+    customs_exceptions_search,
+    customs_exceptions_sort_by,
+    customs_exceptions_page,
     returnUrl,
     re_jwt,
     re_tgt,

--- a/src/stores/auth.store.js
+++ b/src/stores/auth.store.js
@@ -54,6 +54,10 @@ export const useAuthStore = defineStore('auth', () => {
   const orders_page = ref(1)
   const orders_status = ref(null)
   const orders_tnved = ref('')
+  const customs_codes_per_page = ref(25)
+  const customs_codes_search = ref('')
+  const customs_codes_sort_by = ref([{ key: 'code', order: 'asc' }])
+  const customs_codes_page = ref(1)
   const returnUrl = ref(null)
   const re_jwt = ref(null)
   const re_tgt = ref(null)
@@ -148,6 +152,10 @@ export const useAuthStore = defineStore('auth', () => {
     orders_page,
     orders_status,
     orders_tnved,
+    customs_codes_per_page,
+    customs_codes_search,
+    customs_codes_sort_by,
+    customs_codes_page,
     returnUrl,
     re_jwt,
     re_tgt,

--- a/src/views/CustomsCodes_View.vue
+++ b/src/views/CustomsCodes_View.vue
@@ -1,0 +1,59 @@
+<script setup>
+import { onMounted } from 'vue'
+import { useAltaStore } from '@/stores/alta.store.js'
+
+const store = useAltaStore()
+
+const itemHeaders = [
+  { title: 'Код', key: 'code', align: 'start' },
+  { title: 'Наименование', key: 'name', align: 'start' },
+  { title: 'Номер', key: 'number', align: 'start' },
+  { title: 'Комментарий', key: 'comment', align: 'start' }
+]
+
+const exceptionHeaders = [...itemHeaders]
+
+onMounted(() => {
+  store.getItems()
+  store.getExceptions()
+})
+
+function parseAlta() {
+  store.parse()
+}
+</script>
+
+<template>
+  <div class="settings table-2">
+    <h1 class="primary-heading">Коды ТН ВЭД</h1>
+    <hr class="hr" />
+
+    <div class="link-crt">
+      <a @click="parseAlta" class="link" tabindex="0">
+        <font-awesome-icon size="1x" icon="fa-solid fa-download" class="link" />&nbsp;&nbsp;&nbsp;Запустить парсер
+      </a>
+    </div>
+
+    <h2 class="secondary-heading">Запреты</h2>
+    <v-card>
+      <v-data-table-server
+        :items="store.items"
+        :headers="itemHeaders"
+        :loading="store.loading"
+        density="compact"
+        class="elevation-1 single-line-table"
+      />
+    </v-card>
+
+    <h2 class="secondary-heading" style="margin-top: 20px;">Исключения</h2>
+    <v-card>
+      <v-data-table-server
+        :items="store.exceptions"
+        :headers="exceptionHeaders"
+        :loading="store.loading"
+        density="compact"
+        class="elevation-1 single-line-table"
+      />
+    </v-card>
+  </div>
+</template>

--- a/src/views/CustomsCodes_View.vue
+++ b/src/views/CustomsCodes_View.vue
@@ -30,12 +30,14 @@ function parseAlta() {
       title="Запреты"
       :items="store.items"
       :loading="store.loading"
+      :error="store.error"
     />
 
     <CustomsCodesList
       title="Исключения"
       :items="store.exceptions"
       :loading="store.loading"
+      :error="store.error"
     />
   </div>
 </template>

--- a/src/views/CustomsCodes_View.vue
+++ b/src/views/CustomsCodes_View.vue
@@ -1,17 +1,9 @@
 <script setup>
 import { onMounted } from 'vue'
 import { useAltaStore } from '@/stores/alta.store.js'
+import CustomsCodesList from '@/components/CustomsCodes_List.vue'
 
 const store = useAltaStore()
-
-const itemHeaders = [
-  { title: 'Код', key: 'code', align: 'start' },
-  { title: 'Наименование', key: 'name', align: 'start' },
-  { title: 'Номер', key: 'number', align: 'start' },
-  { title: 'Комментарий', key: 'comment', align: 'start' }
-]
-
-const exceptionHeaders = [...itemHeaders]
 
 onMounted(() => {
   store.getItems()
@@ -34,26 +26,16 @@ function parseAlta() {
       </a>
     </div>
 
-    <h2 class="secondary-heading">Запреты</h2>
-    <v-card>
-      <v-data-table-server
-        :items="store.items"
-        :headers="itemHeaders"
-        :loading="store.loading"
-        density="compact"
-        class="elevation-1 single-line-table"
-      />
-    </v-card>
+    <CustomsCodesList
+      title="Запреты"
+      :items="store.items"
+      :loading="store.loading"
+    />
 
-    <h2 class="secondary-heading" style="margin-top: 20px;">Исключения</h2>
-    <v-card>
-      <v-data-table-server
-        :items="store.exceptions"
-        :headers="exceptionHeaders"
-        :loading="store.loading"
-        density="compact"
-        class="elevation-1 single-line-table"
-      />
-    </v-card>
+    <CustomsCodesList
+      title="Исключения"
+      :items="store.exceptions"
+      :loading="store.loading"
+    />
   </div>
 </template>

--- a/tests/App.logout.spec.js
+++ b/tests/App.logout.spec.js
@@ -54,6 +54,7 @@ const router = createRouter({
     { path: '/login', component: { template: '<div>Login</div>' } },
     { path: '/users', component: { template: '<div>Users</div>' } },
     { path: '/registers', component: { template: '<div>Registers</div>' } },
+    { path: '/customs_codes', component: { template: '<div>Customs Codes</div>' } },
     { path: '/user/edit/:id', component: { template: '<div>Edit User</div>' } },
     { path: '/recover', component: { template: '<div>Recover</div>' } },
     { path: '/register', component: { template: '<div>Register</div>' } }
@@ -175,5 +176,69 @@ describe('App Logout Functionality', () => {
 
     const appBarTitle = wrapper.find('.primary-heading')
     expect(appBarTitle.text()).toBe('Logibooks')
+  })
+
+  it('should display navigation links for admin users', async () => {
+    // Set up admin user with proper roles
+    authStore.user = { 
+      id: 1, 
+      firstName: 'Admin', 
+      lastName: 'User', 
+      email: 'admin@example.com',
+      roles: ['administrator'] 
+    }
+    await wrapper.vm.$nextTick()
+
+    // Check that admin and common links are displayed
+    const links = wrapper.findAll('a[class="link"]')
+    const linkTexts = links.map(link => link.text())
+    
+    expect(linkTexts).toContain('Пользователи') // Admin only
+    expect(linkTexts).toContain('Коды ТН ВЭД') // Available to all users
+    expect(linkTexts).toContain('Выход')
+  })
+
+  it('should display navigation links for logist users', async () => {
+    // Set up logist user with proper roles
+    authStore.user = { 
+      id: 1, 
+      firstName: 'Regular', 
+      lastName: 'User', 
+      email: 'user@example.com',
+      roles: ['logist'] 
+    }
+    await wrapper.vm.$nextTick()
+
+    // Check that logist and common links are displayed, but not admin-only links
+    const links = wrapper.findAll('a[class="link"]')
+    const linkTexts = links.map(link => link.text())
+    
+    expect(linkTexts).not.toContain('Пользователи') // Admin only
+    expect(linkTexts).toContain('Коды ТН ВЭД') // Available to all users
+    expect(linkTexts).toContain('Реестры') // Logist only
+    expect(linkTexts).toContain('Настройки') // Non-admin users
+    expect(linkTexts).toContain('Выход')
+  })
+
+  it('should display navigation links for regular users (no special roles)', async () => {
+    // Set up regular user with no special roles
+    authStore.user = { 
+      id: 1, 
+      firstName: 'Regular', 
+      lastName: 'User', 
+      email: 'user@example.com',
+      roles: [] // No special roles
+    }
+    await wrapper.vm.$nextTick()
+
+    // Check that only basic user links are displayed
+    const links = wrapper.findAll('a[class="link"]')
+    const linkTexts = links.map(link => link.text())
+    
+    expect(linkTexts).not.toContain('Пользователи') // Admin only
+    expect(linkTexts).not.toContain('Реестры') // Logist only
+    expect(linkTexts).toContain('Коды ТН ВЭД') // Available to all users
+    expect(linkTexts).toContain('Настройки') // Non-admin users
+    expect(linkTexts).toContain('Выход')
   })
 })

--- a/tests/CustomsCodes_List.spec.js
+++ b/tests/CustomsCodes_List.spec.js
@@ -1,0 +1,114 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CustomsCodesList from '@/components/CustomsCodes_List.vue'
+import { defaultGlobalStubs } from './test-utils.js'
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return { 
+    ...actual, 
+    storeToRefs: (store) => ({
+      customs_codes_per_page: store.customs_codes_per_page,
+      customs_codes_search: store.customs_codes_search,
+      customs_codes_sort_by: store.customs_codes_sort_by,
+      customs_codes_page: store.customs_codes_page,
+      alert: store.alert
+    })
+  }
+})
+
+const mockAuthStore = {
+  customs_codes_per_page: { value: 25 },
+  customs_codes_search: { value: '' },
+  customs_codes_sort_by: { value: [{ key: 'code', order: 'asc' }] },
+  customs_codes_page: { value: 1 }
+}
+
+const mockAlertStore = {
+  alert: { value: null },
+  clear: vi.fn()
+}
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: () => mockAuthStore
+}))
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => mockAlertStore
+}))
+
+describe('CustomsCodes_List.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders with title and empty message when no items', () => {
+    const wrapper = mount(CustomsCodesList, {
+      props: {
+        title: 'Запреты',
+        items: [],
+        loading: false
+      },
+      global: { stubs: defaultGlobalStubs }
+    })
+
+    expect(wrapper.find('h2').text()).toBe('Запреты')
+    expect(wrapper.text()).toContain('Список запретов пуст')
+  })
+
+  it('renders different title and empty message for exceptions', () => {
+    const wrapper = mount(CustomsCodesList, {
+      props: {
+        title: 'Исключения',
+        items: [],
+        loading: false
+      },
+      global: { stubs: defaultGlobalStubs }
+    })
+
+    expect(wrapper.find('h2').text()).toBe('Исключения')
+    expect(wrapper.text()).toContain('Список исключений пуст')
+  })
+
+  it('shows loading spinner when loading', () => {
+    const wrapper = mount(CustomsCodesList, {
+      props: {
+        title: 'Запреты',
+        items: [],
+        loading: true
+      },
+      global: { stubs: defaultGlobalStubs }
+    })
+
+    expect(wrapper.find('.spinner-border').exists()).toBe(true)
+  })
+
+  it('shows error message when error is provided', () => {
+    const wrapper = mount(CustomsCodesList, {
+      props: {
+        title: 'Запреты',
+        items: [],
+        loading: false,
+        error: 'Test error'
+      },
+      global: { stubs: defaultGlobalStubs }
+    })
+
+    expect(wrapper.text()).toContain('Ошибка при загрузке списка запретов: Test error')
+  })
+
+  it('shows different error message for exceptions', () => {
+    const wrapper = mount(CustomsCodesList, {
+      props: {
+        title: 'Исключения',
+        items: [],
+        loading: false,
+        error: 'Test error'
+      },
+      global: { stubs: defaultGlobalStubs }
+    })
+
+    expect(wrapper.text()).toContain('Ошибка при загрузке списка исключений: Test error')
+  })
+})

--- a/tests/CustomsCodes_List.spec.js
+++ b/tests/CustomsCodes_List.spec.js
@@ -9,20 +9,20 @@ vi.mock('pinia', async () => {
   return { 
     ...actual, 
     storeToRefs: (store) => ({
-      customs_codes_per_page: store.customs_codes_per_page,
-      customs_codes_search: store.customs_codes_search,
-      customs_codes_sort_by: store.customs_codes_sort_by,
-      customs_codes_page: store.customs_codes_page,
       alert: store.alert
     })
   }
 })
 
 const mockAuthStore = {
-  customs_codes_per_page: { value: 25 },
-  customs_codes_search: { value: '' },
-  customs_codes_sort_by: { value: [{ key: 'code', order: 'asc' }] },
-  customs_codes_page: { value: 1 }
+  customs_items_per_page: 25,
+  customs_items_search: '',
+  customs_items_sort_by: [{ key: 'code', order: 'asc' }],
+  customs_items_page: 1,
+  customs_exceptions_per_page: 25,
+  customs_exceptions_search: '',
+  customs_exceptions_sort_by: [{ key: 'code', order: 'asc' }],
+  customs_exceptions_page: 1
 }
 
 const mockAlertStore = {

--- a/tests/CustomsCodes_View.spec.js
+++ b/tests/CustomsCodes_View.spec.js
@@ -1,0 +1,43 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CustomsCodesView from '@/views/CustomsCodes_View.vue'
+import { defaultGlobalStubs } from './test-utils.js'
+
+const getItems = vi.fn()
+const getExceptions = vi.fn()
+const parse = vi.fn()
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return { ...actual, storeToRefs: (store) => store }
+})
+
+vi.mock('@/stores/alta.store.js', () => ({
+  useAltaStore: () => ({
+    items: [],
+    exceptions: [],
+    loading: false,
+    getItems,
+    getExceptions,
+    parse
+  })
+}))
+
+describe('CustomsCodes_View.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls store methods on mount', () => {
+    mount(CustomsCodesView, { global: { stubs: defaultGlobalStubs } })
+    expect(getItems).toHaveBeenCalled()
+    expect(getExceptions).toHaveBeenCalled()
+  })
+
+  it('calls parse when button clicked', async () => {
+    const wrapper = mount(CustomsCodesView, { global: { stubs: defaultGlobalStubs } })
+    await wrapper.find('.link-crt a').trigger('click')
+    expect(parse).toHaveBeenCalled()
+  })
+})

--- a/tests/CustomsCodes_View.spec.js
+++ b/tests/CustomsCodes_View.spec.js
@@ -18,9 +18,25 @@ vi.mock('@/stores/alta.store.js', () => ({
     items: [],
     exceptions: [],
     loading: false,
+    error: null,
     getItems,
     getExceptions,
     parse
+  })
+}))
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: () => ({
+    customs_codes_per_page: { value: 25 },
+    customs_codes_search: { value: '' },
+    customs_codes_sort_by: { value: [{ key: 'code', order: 'asc' }] },
+    customs_codes_page: { value: 1 }
+  })
+}))
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => ({
+    clear: vi.fn()
   })
 }))
 

--- a/tests/CustomsCodes_View.spec.js
+++ b/tests/CustomsCodes_View.spec.js
@@ -27,10 +27,14 @@ vi.mock('@/stores/alta.store.js', () => ({
 
 vi.mock('@/stores/auth.store.js', () => ({
   useAuthStore: () => ({
-    customs_codes_per_page: { value: 25 },
-    customs_codes_search: { value: '' },
-    customs_codes_sort_by: { value: [{ key: 'code', order: 'asc' }] },
-    customs_codes_page: { value: 1 }
+    customs_items_per_page: 25,
+    customs_items_search: '',
+    customs_items_sort_by: [{ key: 'code', order: 'asc' }],
+    customs_items_page: 1,
+    customs_exceptions_per_page: 25,
+    customs_exceptions_search: '',
+    customs_exceptions_sort_by: [{ key: 'code', order: 'asc' }],
+    customs_exceptions_page: 1
   })
 }))
 

--- a/tests/altaStore.spec.js
+++ b/tests/altaStore.spec.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAltaStore } from '@/stores/alta.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: { get: vi.fn(), post: vi.fn() }
+}))
+
+vi.mock('@/helpers/config.js', () => ({
+  apiUrl: 'http://localhost:8080/api'
+}))
+
+describe('alta store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('fetches items', async () => {
+    fetchWrapper.get.mockResolvedValue([{ id: 1 }])
+    const store = useAltaStore()
+    await store.getItems()
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/alta/items`)
+    expect(store.items).toEqual([{ id: 1 }])
+  })
+
+  it('fetches exceptions', async () => {
+    fetchWrapper.get.mockResolvedValue([{ id: 2 }])
+    const store = useAltaStore()
+    await store.getExceptions()
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/alta/exceptions`)
+    expect(store.exceptions).toEqual([{ id: 2 }])
+  })
+
+  it('parses and refreshes data', async () => {
+    fetchWrapper.post.mockResolvedValue()
+    fetchWrapper.get
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+
+    const store = useAltaStore()
+    await store.parse()
+
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/alta/parse`)
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/alta/items`)
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/alta/exceptions`)
+  })
+})


### PR DESCRIPTION
## Summary
- add Alta store for viewing customs codes
- add `CustomsCodes_View` and route
- unit test Alta store and new view

## Testing
- `npx vitest run`
- `npm run coverage --silent`

------
https://chatgpt.com/codex/tasks/task_e_686adf48e44883219a588c0c53091837