### PR TITLE
Add CountryCodes view and store

### DIFF
--- a/src/components/CountryCodes_List.vue
+++ b/src/components/CountryCodes_List.vue
@@ -5,11 +5,14 @@ import { useAlertStore } from '@/stores/alert.store.js'
 import { useAuthStore } from '@/stores/auth.store.js'
 import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
 import { mdiMagnify } from '@mdi/js'
+import { onMounted } from 'vue'
 
 const countryCodesStore = useCountryCodesStore()
 const { items, loading, error } = storeToRefs(countryCodesStore)
-countryCodesStore.getAll()
 
+onMounted(() => {
+  countryCodesStore.getAll()
+})
 const alertStore = useAlertStore()
 const { alert } = storeToRefs(alertStore)
 

--- a/src/components/CountryCodes_List.vue
+++ b/src/components/CountryCodes_List.vue
@@ -1,0 +1,107 @@
+<script setup>
+import { storeToRefs } from 'pinia'
+import { useCountryCodesStore } from '@/stores/countrycodes.store.js'
+import { useAlertStore } from '@/stores/alert.store.js'
+import { useAuthStore } from '@/stores/auth.store.js'
+import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
+import { mdiMagnify } from '@mdi/js'
+
+const countryCodesStore = useCountryCodesStore()
+const { items, loading, error } = storeToRefs(countryCodesStore)
+countryCodesStore.getAll()
+
+const alertStore = useAlertStore()
+const { alert } = storeToRefs(alertStore)
+
+const authStore = useAuthStore()
+const {
+  codes_per_page,
+  codes_search,
+  codes_sort_by,
+  codes_page,
+  isAdmin
+} = storeToRefs(authStore)
+
+function filterCodes(value, query, item) {
+  if (!query) return true
+  const q = query.toString().toUpperCase()
+  const i = item.raw
+  return (
+    i.IsoNumeric.toString().includes(q) ||
+    i.IsoAlpha2.toUpperCase().includes(q) ||
+    i.NameEnOfficial.toUpperCase().includes(q) ||
+    i.NameRuOfficial.toUpperCase().includes(q)
+  )
+}
+
+async function updateCodes() {
+  try {
+    await countryCodesStore.update()
+    await countryCodesStore.getAll()
+    alertStore.success('Коды стран обновлены')
+  } catch (err) {
+    alertStore.error(err)
+  }
+}
+
+const headers = [
+  { title: 'ISO Num', key: 'IsoNumeric', align: 'start', width: '80px' },
+  { title: 'ISO 2', key: 'IsoAlpha2', align: 'start', width: '80px' },
+  { title: 'English', key: 'NameEnOfficial', align: 'start' },
+  { title: 'Русский', key: 'NameRuOfficial', align: 'start' }
+]
+</script>
+
+<template>
+  <div class="settings table-2">
+    <h1 class="primary-heading">Коды стран</h1>
+    <hr class="hr" />
+
+    <div class="link-crt" v-if="isAdmin">
+      <button @click="updateCodes" class="link">
+        <font-awesome-icon size="1x" icon="fa-solid fa-download" class="link" />
+        &nbsp;&nbsp;&nbsp;Обновить коды стран
+      </button>
+    </div>
+
+    <v-card>
+      <v-data-table
+        v-if="items?.length"
+        v-model:items-per-page="codes_per_page"
+        items-per-page-text="Кодов на странице"
+        :items-per-page-options="itemsPerPageOptions"
+        page-text="{0}-{1} из {2}"
+        v-model:page="codes_page"
+        :headers="headers"
+        :items="items"
+        :search="codes_search"
+        v-model:sort-by="codes_sort_by"
+        :custom-filter="filterCodes"
+        density="compact"
+        class="elevation-1 interlaced-table"
+      />
+      <div v-if="!items?.length && !loading" class="text-center m-5">
+        Список кодов стран пуст
+      </div>
+      <div v-if="items?.length || codes_search">
+        <v-text-field
+          v-model="codes_search"
+          :append-inner-icon="mdiMagnify"
+          label="Поиск по таблице"
+          variant="solo"
+          hide-details
+        />
+      </div>
+    </v-card>
+    <div v-if="loading" class="text-center m-5">
+      <span class="spinner-border spinner-border-lg align-center"></span>
+    </div>
+    <div v-if="error" class="text-center m-5">
+      <div class="text-danger">Ошибка при загрузке кодов стран: {{ error }}</div>
+    </div>
+    <div v-if="alert" class="alert alert-dismissable mt-3 mb-0" :class="alert.type">
+      <button @click="alertStore.clear()" class="btn btn-link close">×</button>
+      {{ alert.message }}
+    </div>
+  </div>
+</template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -79,6 +79,12 @@ const router = createRouter({
       meta: { requiresAdmin: true }
     },
     {
+      path: '/countrycodes',
+      name: 'Коды стран',
+      component: () => import('@/views/CountryCodes_View.vue'),
+      meta: { requiresAdmin: true }
+    },
+    {
       path: '/registers',
       name: 'Реестры',
       component: () => import('@/views/Registers_View.vue'),

--- a/src/stores/auth.store.js
+++ b/src/stores/auth.store.js
@@ -54,6 +54,10 @@ export const useAuthStore = defineStore('auth', () => {
   const orders_page = ref(1)
   const orders_status = ref(null)
   const orders_tnved = ref('')
+  const codes_per_page = ref(10)
+  const codes_search = ref('')
+  const codes_sort_by = ref([{ key: 'IsoNumeric', order: 'asc' }])
+  const codes_page = ref(1)
   const returnUrl = ref(null)
   const re_jwt = ref(null)
   const re_tgt = ref(null)
@@ -148,6 +152,10 @@ export const useAuthStore = defineStore('auth', () => {
     orders_page,
     orders_status,
     orders_tnved,
+    codes_per_page,
+    codes_search,
+    codes_sort_by,
+    codes_page,
     returnUrl,
     re_jwt,
     re_tgt,

--- a/src/stores/countrycodes.store.js
+++ b/src/stores/countrycodes.store.js
@@ -1,0 +1,30 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/countrycodes`
+
+export const useCountryCodesStore = defineStore('countrycodes', () => {
+  const items = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function getAll() {
+    loading.value = true
+    error.value = null
+    try {
+      items.value = await fetchWrapper.get(`${baseUrl}/compact`)
+    } catch (err) {
+      error.value = err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function update() {
+    await fetchWrapper.post(`${baseUrl}/update`)
+  }
+
+  return { items, loading, error, getAll, update }
+})

--- a/src/views/CountryCodes_View.vue
+++ b/src/views/CountryCodes_View.vue
@@ -1,0 +1,7 @@
+<script setup>
+import CountryCodes from '@/components/CountryCodes_List.vue'
+</script>
+
+<template>
+  <CountryCodes />
+</template>

--- a/tests/countryCodesStore.spec.js
+++ b/tests/countryCodesStore.spec.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCountryCodesStore } from '@/stores/countrycodes.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: { get: vi.fn(), post: vi.fn() }
+}))
+
+vi.mock('@/helpers/config.js', () => ({
+  apiUrl: 'http://localhost:8080/api'
+}))
+
+describe('country codes store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('fetches codes from API', async () => {
+    const mockCodes = [{ IsoNumeric: 643, IsoAlpha2: 'RU', NameEnOfficial: 'Russia', NameRuOfficial: 'Россия' }]
+    fetchWrapper.get.mockResolvedValue(mockCodes)
+
+    const store = useCountryCodesStore()
+    await store.getAll()
+
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/countrycodes/compact`)
+    expect(store.items).toEqual(mockCodes)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('calls update endpoint', async () => {
+    fetchWrapper.post.mockResolvedValue({})
+
+    const store = useCountryCodesStore()
+    await store.update()
+
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/countrycodes/update`)
+  })
+})


### PR DESCRIPTION
## Summary
- add store for country codes and tests
- show codes in a new CountryCodes_List component
- integrate CountryCodes view and routing
- persist table state in auth store

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686edac0e2e48321b2d855c84d5a8cd0