### PR TITLE
Implement issue highlighting

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -79,6 +79,11 @@
   background-color: rgba(var(--v-theme-surface), 1);
 }
 
+/* Highlight rows that have issues */
+.row-has-issues {
+  background-color: #ffebee !important;
+}
+
 /* The link to download config */
 .link-crt {
   margin-bottom: 2rem;

--- a/src/components/Orders_List.vue
+++ b/src/components/Orders_List.vue
@@ -9,7 +9,7 @@ import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
 import { storeToRefs } from 'pinia'
 import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
 import { apiUrl } from '@/helpers/config.js'
-import { registerColumnTitles, registerColumnTooltips } from '@/helpers/register.mapping.js'
+import { registerColumnTitles, registerColumnTooltips, HasIssues } from '@/helpers/register.mapping.js'
 
 const props = defineProps({
   registerId: { type: Number, required: true }
@@ -153,6 +153,11 @@ function getCheckStatusColorClass(checkStatusId) {
     return 'check-status-green'
   }
 }
+
+// Function to determine row class based on checkStatusId
+function getRowClass(item) {
+  return HasIssues(item.checkStatusId) ? 'row-has-issues' : ''
+}
 </script>
 
 <template>
@@ -191,6 +196,7 @@ function getCheckStatusColorClass(checkStatusId) {
           v-model:sort-by="orders_sort_by"
           :headers="headers"
           :items="items"
+          :item-class="getRowClass"
           :items-length="totalCount"
           :loading="loading"
           density="compact"

--- a/src/helpers/register.mapping.js
+++ b/src/helpers/register.mapping.js
@@ -77,3 +77,12 @@ export function getStatusColor(statusId) {
     return 'green'  // statusId > 200
   }
 }
+
+/**
+ * Determine if a check status id indicates issues
+ * @param {number} checkStatusId - The check status identifier
+ * @returns {boolean} True if the id is > 100 and <= 200
+ */
+export function HasIssues(checkStatusId) {
+  return checkStatusId > 100 && checkStatusId <= 200
+}

--- a/tests/Orders_List.spec.js
+++ b/tests/Orders_List.spec.js
@@ -286,4 +286,17 @@ describe('Orders_List', () => {
     expect(wrapper.vm.getCheckStatusColorClass(250)).toBe('check-status-green')   // > 200
     expect(wrapper.vm.getCheckStatusColorClass(1000)).toBe('check-status-green')  // > 200
   })
+
+  it('marks rows with issues using getRowClass', () => {
+    const wrapper = mount(OrdersList, {
+      props: { registerId: 1 },
+      global: {
+        stubs: globalStubs
+      }
+    })
+
+    expect(wrapper.vm.getRowClass({ checkStatusId: 150 })).toBe('row-has-issues')
+    expect(wrapper.vm.getRowClass({ checkStatusId: 50 })).toBe('')
+    expect(wrapper.vm.getRowClass({ checkStatusId: 250 })).toBe('')
+  })
 })

--- a/tests/register.mapping.spec.js
+++ b/tests/register.mapping.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getStatusColor } from '@/helpers/register.mapping.js'
+import { getStatusColor, HasIssues } from '@/helpers/register.mapping.js'
 
 describe('register.mapping.js', () => {
   describe('getStatusColor', () => {
@@ -21,10 +21,24 @@ describe('register.mapping.js', () => {
       expect(getStatusColor(200)).toBe('red')
     })
 
-    it('should return "green" for statusId > 200', () => {
+  it('should return "green" for statusId > 200', () => {
       expect(getStatusColor(201)).toBe('green')
       expect(getStatusColor(300)).toBe('green')
       expect(getStatusColor(999)).toBe('green')
+    })
+  })
+
+  describe('HasIssues', () => {
+    it('returns true when checkStatusId is between 101 and 200', () => {
+      expect(HasIssues(101)).toBe(true)
+      expect(HasIssues(150)).toBe(true)
+      expect(HasIssues(200)).toBe(true)
+    })
+
+    it('returns false when checkStatusId is outside the range', () => {
+      expect(HasIssues(100)).toBe(false)
+      expect(HasIssues(201)).toBe(false)
+      expect(HasIssues(undefined)).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## Summary
- share `HasIssues` helper to check checkStatusId range
- use `HasIssues` in OrdersList to apply `row-has-issues` class
- style `row-has-issues` in main stylesheet
- test HasIssues helper and OrdersList row styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877dc88bcf48321a908660f6d2f3ba1