### PR TITLE
Add FEACN codes view and store

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -103,6 +103,9 @@ function getUserName() {
           <v-list-item>
             <RouterLink to="/countries" class="link">Страны</RouterLink>
           </v-list-item>
+          <v-list-item>
+            <RouterLink to="/feacn" class="link">Коды ТН ВЭД</RouterLink>
+          </v-list-item>
            <v-list-item>
             <RouterLink to="/companies" class="link">Компании</RouterLink>
           </v-list-item>

--- a/src/components/FeacnCodes_List.vue
+++ b/src/components/FeacnCodes_List.vue
@@ -1,0 +1,270 @@
+<script setup>
+import { ref, onMounted, watch, computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
+import { useAuthStore } from '@/stores/auth.store.js'
+import { useAlertStore } from '@/stores/alert.store.js'
+import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
+import { mdiMagnify } from '@mdi/js'
+
+const feacnStore = useFeacnCodesStore()
+const alertStore = useAlertStore()
+const authStore = useAuthStore()
+
+const { orders, prefixes, loading, error } = storeToRefs(feacnStore)
+const { alert } = storeToRefs(alertStore)
+const {
+  feacnorders_per_page,
+  feacnorders_search,
+  feacnorders_sort_by,
+  feacnorders_page,
+  feacnprefixes_per_page,
+  feacnprefixes_search,
+  feacnprefixes_sort_by,
+  feacnprefixes_page,
+  isAdmin
+} = storeToRefs(authStore)
+
+const selectedOrderId = ref(null)
+watch(selectedOrderId, async (id) => {
+  await feacnStore.getPrefixes(id)
+})
+
+onMounted(async () => {
+  await feacnStore.getOrders()
+})
+
+async function updateCodes() {
+  try {
+    await feacnStore.update()
+    await feacnStore.getOrders()
+    if (selectedOrderId.value) {
+      await feacnStore.getPrefixes(selectedOrderId.value)
+    }
+    alertStore.success('Информация о кодах ТН ВЭД обновлена')
+  } catch (err) {
+    alertStore.error(err)
+  }
+}
+
+function filterOrders(value, query, item) {
+  if (!query) return true
+  const q = query.toString().toUpperCase()
+  const i = item.raw
+  return (
+    i.title.toUpperCase().includes(q) ||
+    (i.url || '').toUpperCase().includes(q)
+  )
+}
+
+function filterPrefixes(value, query, item) {
+  if (!query) return true
+  const q = query.toString().toUpperCase()
+  const i = item.raw
+  return (
+    i.code.toUpperCase().includes(q) ||
+    (i.description || '').toUpperCase().includes(q) ||
+    (i.comment || '').toUpperCase().includes(q) ||
+    (i.exceptions || '').toUpperCase().includes(q)
+  )
+}
+
+const prefixItems = computed(() =>
+  prefixes.value.map(p => ({
+    ...p,
+    exceptions: p.exceptions.map(e => e.code).join(', ')
+  }))
+)
+
+const orderHeaders = [
+  { title: 'Нормативный документ', key: 'title', align: 'start' },
+  { title: 'Ссылка', key: 'url', align: 'start' }
+]
+
+const prefixHeaders = [
+  { title: 'Код ТН ВЭД', key: 'code', align: 'start', width: '120px' },
+  { title: 'Описание', key: 'description', align: 'start' },
+  { title: 'Комментарий', key: 'comment', align: 'start' },
+  { title: 'Исключения', key: 'exceptions', align: 'start' }
+]
+</script>
+
+<template>
+  <div class="settings table-2" data-testid="feacn-codes-list">
+    <h1 class="primary-heading">Коды ТН ВЭД</h1>
+    <hr class="hr" />
+
+    <div class="link-crt" v-if="isAdmin">
+      <a @click="updateCodes" class="link">
+        <font-awesome-icon size="1x" icon="fa-solid fa-download" class="link" />
+        &nbsp;&nbsp;&nbsp;Обновить информацию о кодах
+      </a>
+    </div>
+
+    <v-card>
+      <v-data-table
+        v-if="orders?.length"
+        v-model:items-per-page="feacnorders_per_page"
+        items-per-page-text="Документов на странице"
+        :items-per-page-options="itemsPerPageOptions"
+        page-text="{0}-{1} из {2}"
+        v-model:page="feacnorders_page"
+        :headers="orderHeaders"
+        :items="orders"
+        :search="authStore.feacnorders_search"
+        v-model:sort-by="feacnorders_sort_by"
+        :custom-filter="filterOrders"
+        density="compact"
+        class="elevation-1 interlaced-table single-line-table"
+        @click:row="(_, { item }) => { selectedOrderId.value = item.id }"
+      >
+        <template v-for="h in orderHeaders" :key="`header-${h.key}`" #[`header.${h.key}`]="{ column }">
+          <div class="truncated-cell" :title="column.title">
+            {{ column.title }}
+          </div>
+        </template>
+        <template #[`item.url`]="{ item }">
+          <div class="truncated-cell">
+            <a v-if="item.url" :href="item.url" target="_blank" rel="noopener noreferrer" class="product-link" :title="item.url">
+              {{ item.url }}
+            </a>
+            <span v-else>-</span>
+          </div>
+        </template>
+        <template v-for="h in orderHeaders.filter(h => h.key !== 'url')" :key="h.key" #[`item.${h.key}`]="{ item }">
+          <div class="truncated-cell" :title="item[h.key] || ''">
+            {{ item[h.key] }}
+          </div>
+        </template>
+      </v-data-table>
+      <div v-if="!orders?.length && !loading" class="text-center m-5">Список документов пуст</div>
+
+      <div v-if="orders?.length || feacnorders_search">
+        <v-text-field
+          v-model="authStore.feacnorders_search"
+          :append-inner-icon="mdiMagnify"
+          label="Поиск по документам"
+          variant="solo"
+          hide-details
+        />
+      </div>
+    </v-card>
+
+    <v-card class="mt-5">
+      <v-data-table
+        v-if="prefixItems?.length"
+        v-model:items-per-page="feacnprefixes_per_page"
+        items-per-page-text="Кодов на странице"
+        :items-per-page-options="itemsPerPageOptions"
+        page-text="{0}-{1} из {2}"
+        v-model:page="feacnprefixes_page"
+        :headers="prefixHeaders"
+        :items="prefixItems"
+        :search="authStore.feacnprefixes_search"
+        v-model:sort-by="feacnprefixes_sort_by"
+        :custom-filter="filterPrefixes"
+        density="compact"
+        class="elevation-1 interlaced-table single-line-table"
+      >
+        <template v-for="h in prefixHeaders" :key="`pheader-${h.key}`" #[`header.${h.key}`]="{ column }">
+          <div class="truncated-cell" :title="column.title">
+            {{ column.title }}
+          </div>
+        </template>
+        <template v-for="h in prefixHeaders" :key="h.key" #[`item.${h.key}`]="{ item }">
+          <div class="truncated-cell" :title="item[h.key] || ''">
+            {{ item[h.key] || '-' }}
+          </div>
+        </template>
+      </v-data-table>
+      <div v-if="!prefixItems?.length && !loading" class="text-center m-5">Список кодов пуст</div>
+
+      <div v-if="prefixItems?.length || feacnprefixes_search">
+        <v-text-field
+          v-model="authStore.feacnprefixes_search"
+          :append-inner-icon="mdiMagnify"
+          label="Поиск по кодам"
+          variant="solo"
+          hide-details
+        />
+      </div>
+    </v-card>
+
+    <div v-if="loading" class="text-center m-5">
+      <span class="spinner-border spinner-border-lg align-center"></span>
+    </div>
+    <div v-if="error" class="text-center m-5">
+      <div class="text-danger">Ошибка при загрузке информации: {{ error }}</div>
+    </div>
+    <div v-if="alert" class="alert alert-dismissable mt-3 mb-0" :class="alert.type">
+      <button @click="alertStore.clear()" class="btn btn-link close">×</button>
+      {{ alert.message }}
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.single-line-table :deep(.v-data-table__td) {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.8rem;
+  line-height: 1.0;
+  border-right: 1px solid rgba(var(--v-border-color), 0.25);
+}
+
+.single-line-table :deep(.v-data-table__th) {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+  font-size: 0.8rem;
+  line-height: 1.0;
+  font-weight: 600;
+  border-right: 1px solid rgba(var(--v-border-color), 0.12);
+}
+
+.single-line-table :deep(.v-data-table__td:last-child),
+.single-line-table :deep(.v-data-table__th:last-child) {
+  border-right: none;
+}
+
+.single-line-table :deep(.v-data-table__tr) {
+  height: 32px !important;
+}
+
+.single-line-table :deep(.v-data-table__thead .v-data-table__tr) {
+  height: 36px !important;
+}
+
+.single-line-table :deep(.v-data-table) {
+  table-layout: fixed;
+}
+
+.truncated-cell {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+  cursor: default;
+}
+
+.truncated-cell:hover {
+  cursor: help;
+}
+
+.product-link {
+  color: rgba(var(--v-theme-primary), 1);
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+  max-width: 100%;
+}
+
+.product-link:hover {
+  text-decoration: underline;
+  cursor: pointer;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -123,6 +123,11 @@ const router = createRouter({
       component: () => import('@/views/Countries_View.vue'),
     },
     {
+      path: '/feacn',
+      name: 'Коды ТН ВЭД',
+      component: () => import('@/views/FeacnCodes_View.vue'),
+    },
+    {
       path: '/registers',
       name: 'Реестры',
       component: () => import('@/views/Registers_View.vue'),

--- a/src/stores/auth.store.js
+++ b/src/stores/auth.store.js
@@ -70,6 +70,14 @@ export const useAuthStore = defineStore('auth', () => {
   const stopwords_search = ref('')
   const stopwords_sort_by = ref(['id'])
   const stopwords_page = ref(1)
+  const feacnorders_per_page = ref(10)
+  const feacnorders_search = ref('')
+  const feacnorders_sort_by = ref([])
+  const feacnorders_page = ref(1)
+  const feacnprefixes_per_page = ref(10)
+  const feacnprefixes_search = ref('')
+  const feacnprefixes_sort_by = ref([])
+  const feacnprefixes_page = ref(1)
   const returnUrl = ref(null)
   const re_jwt = ref(null)
   const re_tgt = ref(null)
@@ -180,6 +188,14 @@ export const useAuthStore = defineStore('auth', () => {
     stopwords_search,
     stopwords_sort_by,
     stopwords_page,
+    feacnorders_per_page,
+    feacnorders_search,
+    feacnorders_sort_by,
+    feacnorders_page,
+    feacnprefixes_per_page,
+    feacnprefixes_search,
+    feacnprefixes_sort_by,
+    feacnprefixes_page,
     returnUrl,
     re_jwt,
     re_tgt,

--- a/src/stores/feacn.codes.store.js
+++ b/src/stores/feacn.codes.store.js
@@ -1,0 +1,47 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/feacncodes`
+
+export const useFeacnCodesStore = defineStore('feacn.codes', () => {
+  const orders = ref([])
+  const prefixes = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function getOrders() {
+    loading.value = true
+    error.value = null
+    try {
+      orders.value = await fetchWrapper.get(`${baseUrl}/orders`)
+    } catch (err) {
+      error.value = err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getPrefixes(orderId) {
+    if (!orderId) {
+      prefixes.value = []
+      return
+    }
+    loading.value = true
+    error.value = null
+    try {
+      prefixes.value = await fetchWrapper.get(`${baseUrl}/orders/${orderId}/prefixes`)
+    } catch (err) {
+      error.value = err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function update() {
+    await fetchWrapper.post(`${baseUrl}/update`)
+  }
+
+  return { orders, prefixes, loading, error, getOrders, getPrefixes, update }
+})

--- a/src/views/FeacnCodes_View.vue
+++ b/src/views/FeacnCodes_View.vue
@@ -1,0 +1,7 @@
+<template>
+  <FeacnCodes_List />
+</template>
+
+<script setup>
+import FeacnCodes_List from '@/components/FeacnCodes_List.vue'
+</script>

--- a/tests/App.logout.spec.js
+++ b/tests/App.logout.spec.js
@@ -77,7 +77,8 @@ const router = createRouter({
     { path: '/orderstatuses', component: { template: '<div>Order Statuses</div>' } },
     { path: '/stopwords', component: { template: '<div>Stop Words</div>' } },
     { path: '/stopword/create', component: { template: '<div>Create Stop Word</div>' } },
-    { path: '/stopword/edit/:id', component: { template: '<div>Edit Stop Word</div>' } }
+    { path: '/stopword/edit/:id', component: { template: '<div>Edit Stop Word</div>' } },
+    { path: '/feacn', component: { template: '<div>Feacn</div>' } }
   ]
 })
 

--- a/tests/FeacnCodes_List.spec.js
+++ b/tests/FeacnCodes_List.spec.js
@@ -1,0 +1,119 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import FeacnCodesList from '@/components/FeacnCodes_List.vue'
+import { vuetifyStubs } from './test-utils.js'
+
+const mockOrders = ref([
+  { id: 1, title: 'Doc1', url: 'http://a' },
+  { id: 2, title: 'Doc2', url: 'http://b' }
+])
+const mockPrefixes = ref([])
+const mockLoading = ref(false)
+const mockError = ref(null)
+const perPage1 = ref(10)
+const search1 = ref('')
+const sortBy1 = ref([])
+const page1 = ref(1)
+const perPage2 = ref(10)
+const search2 = ref('')
+const sortBy2 = ref([])
+const page2 = ref(1)
+const mockIsAdmin = ref(false)
+const mockAlert = ref(null)
+
+const getOrders = vi.fn()
+const getPrefixes = vi.fn()
+const update = vi.fn()
+const success = vi.fn()
+const error = vi.fn()
+const clear = vi.fn()
+
+vi.mock('@/stores/feacn.codes.store.js', () => ({
+  useFeacnCodesStore: () => ({
+    orders: mockOrders,
+    prefixes: mockPrefixes,
+    loading: mockLoading,
+    error: mockError,
+    getOrders,
+    getPrefixes,
+    update
+  })
+}))
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => ({
+    alert: mockAlert,
+    success,
+    error,
+    clear
+  })
+}))
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: () => ({
+    feacnorders_per_page: perPage1,
+    feacnorders_search: search1,
+    feacnorders_sort_by: sortBy1,
+    feacnorders_page: page1,
+    feacnprefixes_per_page: perPage2,
+    feacnprefixes_search: search2,
+    feacnprefixes_sort_by: sortBy2,
+    feacnprefixes_page: page2,
+    isAdmin: mockIsAdmin
+  })
+}))
+
+vi.mock('@/helpers/items.per.page.js', () => ({
+  itemsPerPageOptions: [{ value: 10, title: '10' }]
+}))
+
+describe('FeacnCodes_List.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockOrders.value = [
+      { id: 1, title: 'Doc1', url: 'http://a' },
+      { id: 2, title: 'Doc2', url: 'http://b' }
+    ]
+    mockLoading.value = false
+    mockError.value = null
+    mockPrefixes.value = []
+    search1.value = ''
+    mockIsAdmin.value = false
+  })
+
+  it('calls getOrders on mount', () => {
+    mount(FeacnCodesList, { global: { stubs: vuetifyStubs } })
+    expect(getOrders).toHaveBeenCalled()
+  })
+
+  it('updateCodes calls store and alerts on success', async () => {
+    update.mockResolvedValue()
+    const wrapper = mount(FeacnCodesList, { global: { stubs: vuetifyStubs } })
+    await wrapper.vm.updateCodes()
+    expect(update).toHaveBeenCalled()
+    expect(getOrders).toHaveBeenCalledTimes(2)
+    expect(success).toHaveBeenCalledWith('Информация о кодах ТН ВЭД обновлена')
+  })
+
+  it('shows empty message when no orders', () => {
+    mockOrders.value = []
+    const wrapper = mount(FeacnCodesList, { global: { stubs: vuetifyStubs } })
+    expect(wrapper.text()).toContain('Список документов пуст')
+  })
+
+  it('renders admin update button when user is admin', () => {
+    mockIsAdmin.value = true
+    const wrapper = mount(FeacnCodesList, { global: { stubs: vuetifyStubs } })
+    expect(wrapper.text()).toContain('Обновить информацию о кодах')
+  })
+
+  it('shows spinner and error message', () => {
+    mockLoading.value = true
+    mockError.value = 'bad'
+    const wrapper = mount(FeacnCodesList, { global: { stubs: vuetifyStubs } })
+    expect(wrapper.html()).toContain('spinner-border')
+    expect(wrapper.html()).toContain('Ошибка при загрузке информации')
+  })
+})

--- a/tests/FeacnCodes_View.spec.js
+++ b/tests/FeacnCodes_View.spec.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import FeacnCodes_View from '@/views/FeacnCodes_View.vue'
+import FeacnCodes_List from '@/components/FeacnCodes_List.vue'
+
+const vuetify = createVuetify()
+
+vi.mock('@/components/FeacnCodes_List.vue', () => ({
+  default: {
+    name: 'FeacnCodes_List',
+    template: '<div data-test="feacn-codes-list">FeacnCodes_List Component</div>'
+  }
+}))
+
+describe('FeacnCodes_View', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(FeacnCodes_View, {
+      global: {
+        plugins: [vuetify]
+      }
+    })
+  })
+
+  it('should render FeacnCodes_List component', () => {
+    const comp = wrapper.findComponent(FeacnCodes_List)
+    expect(comp.exists()).toBe(true)
+  })
+
+  it('should have correct component structure', () => {
+    expect(wrapper.find('[data-test="feacn-codes-list"]').exists()).toBe(true)
+  })
+
+  it('should be a simple wrapper component', () => {
+    expect(wrapper.html()).toContain('FeacnCodes_List Component')
+  })
+})

--- a/tests/feacn.codes.store.spec.js
+++ b/tests/feacn.codes.store.spec.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: { get: vi.fn(), post: vi.fn() }
+}))
+
+vi.mock('@/helpers/config.js', () => ({
+  apiUrl: 'http://localhost:8080/api'
+}))
+
+describe('feacn.codes store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('fetches orders from API', async () => {
+    const mockOrders = [{ id: 1, title: 'doc', url: 'u' }]
+    fetchWrapper.get.mockResolvedValue(mockOrders)
+
+    const store = useFeacnCodesStore()
+    await store.getOrders()
+
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders`)
+    expect(store.orders).toEqual(mockOrders)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('fetches prefixes for order', async () => {
+    const mockPrefixes = [{ id: 1, code: '1', exceptions: [] }]
+    fetchWrapper.get.mockResolvedValue(mockPrefixes)
+
+    const store = useFeacnCodesStore()
+    await store.getPrefixes(1)
+
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/1/prefixes`)
+    expect(store.prefixes).toEqual(mockPrefixes)
+  })
+
+  it('calls update endpoint', async () => {
+    fetchWrapper.post.mockResolvedValue({})
+
+    const store = useFeacnCodesStore()
+    await store.update()
+
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/update`)
+  })
+})


### PR DESCRIPTION
## Summary
- implement `feacn.codes.store` with API calls to `FeacnCodesController`
- add `FeacnCodes_List` component and `FeacnCodes_View` wrapper
- integrate FEACN codes route and navigation link
- store table settings for FEACN codes in `auth.store`
- update test router stubs and add unit tests for new store, list and view

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a5b0478a88321b5afec98c30830fb