### PR TITLE
Update WBR components and helpers

### DIFF
--- a/src/components/WbrOrder_EditDialog.vue
+++ b/src/components/WbrOrder_EditDialog.vue
@@ -9,8 +9,8 @@ import { useStopWordsStore } from '@/stores/stop.words.store.js'
 import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
 import { storeToRefs } from 'pinia'
 import { ref, watch } from 'vue'
-import { registerColumnTitles, registerColumnTooltips, HasIssues } from '@/helpers/register.mapping.js'
-import { getCheckStatusInfo } from '@/helpers/orders.check.helper.js'
+import { wbrRegisterColumnTitles, wbrRegisterColumnTooltips } from '@/helpers/wbr.register.mapping.js'
+import { HasIssues, getCheckStatusInfo } from '@/helpers/orders.check.helper.js'
 
 const props = defineProps({
   registerId: { type: Number, required: true },
@@ -35,7 +35,7 @@ watch(() => item.value?.statusId, (newStatusId) => {
   currentStatusId.value = newStatusId
 }, { immediate: true })
 
-// Field name mapping from camelCase to PascalCase for registerColumnTitles lookup
+// Field name mapping from camelCase to PascalCase for wbrRegisterColumnTitles lookup
 const fieldNameMapping = {
   statusId: 'Status',
   checkStatusId: 'CheckStatusId',
@@ -90,8 +90,8 @@ const getFieldLabel = (fieldName) => {
   const mappingKey = fieldNameMapping[fieldName]
   if (!mappingKey) return fieldName
 
-  const title = registerColumnTitles[mappingKey]
-  const tooltip = registerColumnTooltips[mappingKey]
+  const title = wbrRegisterColumnTitles[mappingKey]
+  const tooltip = wbrRegisterColumnTooltips[mappingKey]
 
   // If there's tooltip text, combine title with tooltip for a more descriptive label
   if (tooltip) {
@@ -104,7 +104,7 @@ const getFieldLabel = (fieldName) => {
 // Function to get tooltip for a field (if available)
 const getFieldTooltip = (fieldName) => {
   const mappingKey = fieldNameMapping[fieldName]
-  return mappingKey ? registerColumnTooltips[mappingKey] : null
+  return mappingKey ? wbrRegisterColumnTooltips[mappingKey] : null
 }
 
 statusStore.ensureStatusesLoaded()
@@ -377,7 +377,7 @@ async function validateOrder() {
   align-items: center;
 }
 
-/* Status cell styling similar to Orders_List */
+/* Status cell styling similar to WbrOrders_List */
 .status-cell {
   font-weight: 500;
   border-radius: 4px;

--- a/src/components/WbrOrders_List.vue
+++ b/src/components/WbrOrders_List.vue
@@ -11,8 +11,8 @@ import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
 import { storeToRefs } from 'pinia'
 import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
 import { apiUrl } from '@/helpers/config.js'
-import { registerColumnTitles, registerColumnTooltips, HasIssues } from '@/helpers/register.mapping.js'
-import { getCheckStatusInfo } from '@/helpers/orders.check.helper.js'
+import { wbrRegisterColumnTitles, wbrRegisterColumnTooltips } from '@/helpers/wbr.register.mapping.js'
+import { HasIssues, getCheckStatusInfo } from '@/helpers/orders.check.helper.js'
 
 const props = defineProps({
   registerId: { type: Number, required: true }
@@ -96,28 +96,28 @@ const headers = computed(() => {
     { title: '', key: 'actions3', sortable: false, align: 'center', width: '10px' },
     
     // Order Identification & Status - Key identifiers and current state
-    { title: registerColumnTitles.Status, key: 'statusId', align: 'start', width: '120px' },
-    { title: registerColumnTitles.CheckStatusId, key: 'checkStatusId', align: 'start', width: '120px' },
-    // { title: registerColumnTitles.OrderNumber, sortable: false, key: 'orderNumber', align: 'start', width: '120px' },
-    { title: registerColumnTitles.TnVed, key: 'tnVed', align: 'start', width: '120px' },
+    { title: wbrRegisterColumnTitles.Status, key: 'statusId', align: 'start', width: '120px' },
+    { title: wbrRegisterColumnTitles.CheckStatusId, key: 'checkStatusId', align: 'start', width: '120px' },
+    // { title: wbrRegisterColumnTitles.OrderNumber, sortable: false, key: 'orderNumber', align: 'start', width: '120px' },
+    { title: wbrRegisterColumnTitles.TnVed, key: 'tnVed', align: 'start', width: '120px' },
     
     // Product Identification & Details - What the order contains
-    { title: registerColumnTitles.Shk, sortable: false, key: 'shk', align: 'start', width: '120px' },
-    { title: registerColumnTitles.ProductName, sortable: false, key: 'productName', align: 'start', width: '200px' },
-    { title: registerColumnTitles.ProductLink, sortable: false, key: 'productLink', align: 'start', width: '150px' },
+    { title: wbrRegisterColumnTitles.Shk, sortable: false, key: 'shk', align: 'start', width: '120px' },
+    { title: wbrRegisterColumnTitles.ProductName, sortable: false, key: 'productName', align: 'start', width: '200px' },
+    { title: wbrRegisterColumnTitles.ProductLink, sortable: false, key: 'productLink', align: 'start', width: '150px' },
     
     // Physical Properties - Tangible characteristics
-    { title: registerColumnTitles.Country, sortable: false, key: 'country', align: 'start', width: '100px' },
-    { title: registerColumnTitles.WeightKg, sortable: false, key: 'weightKg', align: 'start', width: '100px' },
-    { title: registerColumnTitles.Quantity, sortable: false, key: 'quantity', align: 'start', width: '80px' },
+    { title: wbrRegisterColumnTitles.Country, sortable: false, key: 'country', align: 'start', width: '100px' },
+    { title: wbrRegisterColumnTitles.WeightKg, sortable: false, key: 'weightKg', align: 'start', width: '100px' },
+    { title: wbrRegisterColumnTitles.Quantity, sortable: false, key: 'quantity', align: 'start', width: '80px' },
     
     // Financial Information - Pricing and currency
-    { title: registerColumnTitles.UnitPrice, sortable: false, key: 'unitPrice', align: 'start', width: '100px' },
-    { title: registerColumnTitles.Currency, sortable: false, key: 'currency', align: 'start', width: '80px' },
+    { title: wbrRegisterColumnTitles.UnitPrice, sortable: false, key: 'unitPrice', align: 'start', width: '100px' },
+    { title: wbrRegisterColumnTitles.Currency, sortable: false, key: 'currency', align: 'start', width: '80px' },
     
     // Recipient Information - Who receives the order
-    { title: registerColumnTitles.RecipientName, sortable: false, key: 'recipientName', align: 'start', width: '200px' },
-    { title: registerColumnTitles.PassportNumber, sortable: false, key: 'passportNumber', align: 'start', width: '120px' }
+    { title: wbrRegisterColumnTitles.RecipientName, sortable: false, key: 'recipientName', align: 'start', width: '200px' },
+    { title: wbrRegisterColumnTitles.PassportNumber, sortable: false, key: 'passportNumber', align: 'start', width: '120px' }
   ]
 })
 
@@ -143,8 +143,8 @@ async function validateOrder(item) {
 function getColumnTooltip(key) {
   // Convert camelCase key to PascalCase to match the mapping keys
   const pascalKey = key.charAt(0).toUpperCase() + key.slice(1)
-  const tooltip = registerColumnTooltips[pascalKey]
-  const title = registerColumnTitles[pascalKey]
+  const tooltip = wbrRegisterColumnTooltips[pascalKey]
+  const title = wbrRegisterColumnTitles[pascalKey]
 
   if (tooltip && title) {
     return `${title} (${tooltip})`

--- a/src/helpers/orders.check.helper.js
+++ b/src/helpers/orders.check.helper.js
@@ -98,3 +98,12 @@ export function getCheckStatusInfo(item, feacnOrdersCollection, stopWordsCollect
   
   return null
 }
+
+/**
+ * Determine if a check status id indicates issues
+ * @param {number} checkStatusId - The check status identifier
+ * @returns {boolean} True if the id is > 100 and <= 200
+ */
+export function HasIssues(checkStatusId) {
+  return checkStatusId > 100 && checkStatusId <= 200
+}

--- a/src/helpers/wbr.register.mapping.js
+++ b/src/helpers/wbr.register.mapping.js
@@ -1,4 +1,4 @@
-export const registerColumnTitles = {
+export const wbrRegisterColumnTitles = {
   RowNumber: 'п/п',
   OrderNumber: 'Номер заказа',
   InvoiceDate: 'Дата инвойса',
@@ -48,7 +48,7 @@ export const registerColumnTitles = {
   CheckStatusId: 'Проверка'
 }
 
-export const registerColumnTooltips = {
+export const wbrRegisterColumnTooltips = {
   FabricType: 'для обуви "ОБУВЬ", для одежды "трикотаж", "текстиль"',
   Composition: 'для обуви материал верха',
   Unit: 'шт., пара',
@@ -58,13 +58,4 @@ export const registerColumnTooltips = {
   RecipientInn: 'индивидуальный номер налогоплательщика получателя',
   RecipientAddress: 'полный адрес получателя для доставки',
   SupplierInn: 'индивидуальный номер налогоплательщика поставщика'
-}
-
-/**
- * Determine if a check status id indicates issues
- * @param {number} checkStatusId - The check status identifier
- * @returns {boolean} True if the id is > 100 and <= 200
- */
-export function HasIssues(checkStatusId) {
-  return checkStatusId > 100 && checkStatusId <= 200
 }

--- a/src/views/Order_EditView.vue
+++ b/src/views/Order_EditView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import OrderEditDialog from '@/components/Order_EditDialog.vue'
+import OrderEditDialog from '@/components/WbrOrder_EditDialog.vue'
 
 const props = defineProps({
   registerId: { type: Number, required: true },

--- a/src/views/Orders_View.vue
+++ b/src/views/Orders_View.vue
@@ -1,5 +1,5 @@
 <script setup>
-import OrdersList from '@/components/Orders_List.vue'
+import OrdersList from '@/components/WbrOrders_List.vue'
 const props = defineProps({ id: { type: Number, required: true } })
 </script>
 

--- a/tests/WbrOrder_EditDialog.spec.js
+++ b/tests/WbrOrder_EditDialog.spec.js
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { nextTick, ref } from 'vue'
 import { defaultGlobalStubs, createMockStore } from './test-utils.js'
-import OrderEditDialog from '@/components/Order_EditDialog.vue'
+import OrderEditDialog from '@/components/WbrOrder_EditDialog.vue'
 
 // Mock router - create the mock function directly in the factory
 vi.mock('@/router', () => ({
@@ -123,7 +123,7 @@ vi.mock('@/stores/feacn.codes.store.js', () => ({
   useFeacnCodesStore: vi.fn(() => mockFeacnCodesStore)
 }))
 
-describe('Order_EditDialog', () => {
+describe('WbrOrder_EditDialog', () => {
   let wrapper
 
   beforeEach(async () => {

--- a/tests/WbrOrders_List.spec.js
+++ b/tests/WbrOrders_List.spec.js
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { ref } from 'vue'
 import { createPinia } from 'pinia'
-import OrdersList from '@/components/Orders_List.vue'
+import OrdersList from '@/components/WbrOrders_List.vue'
 import { vuetifyStubs, createMockStore } from './test-utils.js'
 
 
@@ -142,7 +142,7 @@ vi.mock('@/helpers/config.js', () => ({
 // Mock Vuetify components and other dependencies
 const globalStubs = vuetifyStubs
 
-describe('Orders_List', () => {
+describe('WbrOrders_List', () => {
   let pinia
 
   beforeEach(() => {

--- a/tests/wbr.register.mapping.spec.js
+++ b/tests/wbr.register.mapping.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { HasIssues } from '@/helpers/register.mapping.js'
+import { HasIssues } from '@/helpers/orders.check.helper.js'
 
-describe('register.mapping.js', () => {
+describe('orders.check.helper.js HasIssues', () => {
 
   describe('HasIssues', () => {
     it('returns true when checkStatusId is between 101 and 200', () => {


### PR DESCRIPTION
## Summary
- move `HasIssues` helper into `orders.check.helper.js`
- rename helper file to `wbr.register.mapping.js`
- rename component files to `WbrOrders_List.vue` and `WbrOrder_EditDialog.vue`
- update imports and variable names
- adjust unit tests for new filenames

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687de993e0708321bc7352f8c99a11f9