### PR TITLE
Render parcels list based on company

### DIFF
--- a/src/helpers/company.constants.js
+++ b/src/helpers/company.constants.js
@@ -1,0 +1,2 @@
+export const OZON_COMPANY_ID = 1
+export const WBR_COMPANY_ID = 2

--- a/src/views/Parcels_View.vue
+++ b/src/views/Parcels_View.vue
@@ -1,10 +1,33 @@
 <script setup>
-import ParcelsList from '@/components/WbrParcels_List.vue'
+import { ref, onMounted, computed } from 'vue'
+import OzonParcelsList from '@/components/OzonParcels_List.vue'
+import WbrParcelsList from '@/components/WbrParcels_List.vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+import { OZON_COMPANY_ID, WBR_COMPANY_ID } from '@/helpers/company.constants.js'
+
 const props = defineProps({ id: { type: Number, required: true } })
+
+const companyId = ref(null)
+
+onMounted(async () => {
+  try {
+    const res = await fetchWrapper.get(`${apiUrl}/registers/${props.id}`)
+    companyId.value = res.companyId
+  } catch {
+    companyId.value = null
+  }
+})
+
+const listComponent = computed(() => {
+  if (companyId.value === OZON_COMPANY_ID) return OzonParcelsList
+  if (companyId.value === WBR_COMPANY_ID) return WbrParcelsList
+  return null
+})
 </script>
 
 <template>
   <Suspense>
-    <ParcelsList :register-id="props.id" />
+    <component v-if="listComponent" :is="listComponent" :register-id="props.id" />
   </Suspense>
 </template>

--- a/tests/Parcels_View.spec.js
+++ b/tests/Parcels_View.spec.js
@@ -1,0 +1,44 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ParcelsView from '@/views/Parcels_View.vue'
+import { resolveAll } from './helpers/test-utils'
+import { OZON_COMPANY_ID, WBR_COMPANY_ID } from '@/helpers/company.constants.js'
+
+vi.mock('@/components/WbrParcels_List.vue', () => ({
+  default: { template: '<div data-test="wbr-list">WBR</div>' }
+}))
+
+vi.mock('@/components/OzonParcels_List.vue', () => ({
+  default: { template: '<div data-test="ozon-list">OZON</div>' }
+}))
+
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: { get: vi.fn() }
+}))
+
+vi.mock('@/helpers/config.js', () => ({ apiUrl: 'http://api' }))
+
+const { fetchWrapper } = await import('@/helpers/fetch.wrapper.js')
+
+describe('Parcels_View', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders WbrParcels_List when register companyId is WBR', async () => {
+    fetchWrapper.get.mockResolvedValue({ companyId: WBR_COMPANY_ID })
+    const wrapper = mount(ParcelsView, { props: { id: 1 } })
+    await resolveAll()
+    expect(wrapper.find('[data-test="wbr-list"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="ozon-list"]').exists()).toBe(false)
+  })
+
+  it('renders OzonParcels_List when register companyId is OZON', async () => {
+    fetchWrapper.get.mockResolvedValue({ companyId: OZON_COMPANY_ID })
+    const wrapper = mount(ParcelsView, { props: { id: 2 } })
+    await resolveAll()
+    expect(wrapper.find('[data-test="ozon-list"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="wbr-list"]').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add `company.constants` to store company IDs
- load register company in `Parcels_View` and dynamically choose parcel list
- test `Parcels_View` component rendering

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687f856ecdec832197f29cbb3ef121de