### PR TITLE
Remove duplicate lifecycle tests

### DIFF
--- a/tests/Company_Settings.spec.js
+++ b/tests/Company_Settings.spec.js
@@ -565,35 +565,7 @@ describe('Company_Settings.vue', () => {
     })
   })
 
-  describe('Component Lifecycle', () => {
-    it('initializes correctly in create mode', async () => {
-      const wrapper = mount(AsyncWrapper, {
-        props: { mode: 'create' },
-        global: {
-          stubs: defaultGlobalStubs
-        }
-      })
 
-      await resolveAll()
-      
-      expect(wrapper.find('h1').text()).toBe('Регистрация компании')
-      expect(wrapper.find('button[type="submit"]').text()).toContain('Создать')
-    })
-
-    it('initializes correctly in edit mode', async () => {
-      const wrapper = mount(AsyncWrapper, {
-        props: { mode: 'edit', companyId: 1 },
-        global: {
-          stubs: defaultGlobalStubs
-        }
-      })
-
-      await resolveAll()
-      
-      expect(wrapper.find('h1').text()).toBe('Изменить информацию о компании')
-      expect(wrapper.find('button[type="submit"]').text()).toContain('Сохранить')
-    })
-  })
 
   describe('Error Handling', () => {
     it('handles network errors gracefully during creation', async () => {

--- a/tests/ParcelStatus_Settings.spec.js
+++ b/tests/ParcelStatus_Settings.spec.js
@@ -397,35 +397,7 @@ describe('ParcelStatus_Settings.vue', () => {
     })
   })
 
-  describe('Component Lifecycle', () => {
-    it('initializes correctly in create mode', async () => {
-      const wrapper = mount(AsyncWrapper, {
-        props: { mode: 'create' },
-        global: {
-          stubs: defaultGlobalStubs
-        }
-      })
 
-      await resolveAll()
-
-      expect(wrapper.find('h1').text()).toBe('Создание статуса посылки')
-      expect(wrapper.find('button[type="submit"]').text()).toContain('Создать')
-    })
-
-    it('initializes correctly in edit mode', async () => {
-      const wrapper = mount(AsyncWrapper, {
-        props: { mode: 'edit', parcelStatusId: 1 },
-        global: {
-          stubs: defaultGlobalStubs
-        }
-      })
-
-      await resolveAll()
-
-      expect(wrapper.find('h1').text()).toBe('Редактирование статуса посылки')
-      expect(wrapper.find('button[type="submit"]').text()).toContain('Сохранить')
-    })
-  })
 
   describe('Error Handling', () => {
     it('handles network errors gracefully during creation', async () => {


### PR DESCRIPTION
## Summary
- drop redundant `Component Lifecycle` blocks in company/parcel status tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6883de4e93dc8321a3f6ddd08261fcab