### PR TITLE
Extend Registers list with new columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "logibooks-ui",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logibooks-ui",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.4.0",
         "@fortawesome/fontawesome-svg-core": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "logibooks-ui",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest --run",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix",
     "format": "prettier --write src/",
     "coverage": "vitest run --coverage"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run --run",
+    "test": "vitest",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix",
     "format": "prettier --write src/",
     "coverage": "vitest run --coverage"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest --run",
+    "test": "vitest run --run",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix",
     "format": "prettier --write src/",
     "coverage": "vitest run --coverage"

--- a/src/components/Companies_List.vue
+++ b/src/components/Companies_List.vue
@@ -135,10 +135,8 @@ async function deleteCompany(company) {
 // Initialize data
 onMounted(async () => {
   await companiesStore.getAll()
-  // Only fetch countries if not already loaded
-  if (countries.value.length === 0) {
-    await countriesStore.getAll()
-  }
+  // Fetch countries using ensureLoaded pattern
+  countriesStore.ensureLoaded()
 })
 
 // Expose functions for testing

--- a/src/components/Companies_List.vue
+++ b/src/components/Companies_List.vue
@@ -42,16 +42,10 @@ const alertStore = useAlertStore()
 const confirm = useConfirm()
 
 const { companies, loading } = storeToRefs(companiesStore)
-const { countries } = storeToRefs(countriesStore)
+countriesStore.ensureLoaded()
 const { alert } = storeToRefs(alertStore)
 
 // Remove local search and itemsPerPage refs - use auth store instead
-
-// Get country name by ISO numeric code
-function getCountryName(isoNumeric) {
-  const country = countries.value.find(c => c.isoNumeric === isoNumeric)
-  return country ? country.nameRuOfficial : isoNumeric ? `Код: ${isoNumeric}` : ''
-}
 
 // Custom filter function for v-data-table
 function filterCompanies(value, query, item) {
@@ -74,7 +68,7 @@ function filterCompanies(value, query, item) {
     return true
   }
 
-  const countryName = getCountryName(i.countryIsoNumeric)
+  const countryName = countriesStore.getCountryShortName(i.countryIsoNumeric)
   if (countryName?.toLocaleUpperCase().indexOf(q) !== -1) {
     return true
   }
@@ -136,7 +130,6 @@ async function deleteCompany(company) {
 onMounted(async () => {
   await companiesStore.getAll()
   // Fetch countries using ensureLoaded pattern
-  countriesStore.ensureLoaded()
 })
 
 // Expose functions for testing
@@ -191,7 +184,7 @@ defineExpose({
         </template>
 
         <template v-slot:[`item.countryIsoNumeric`]="{ item }">
-          {{ getCountryName(item.countryIsoNumeric) }}
+          {{ countriesStore.getCountryShortName(item.countryIsoNumeric) }}
         </template>
 
         <template v-slot:[`item.actions1`]="{ item }">

--- a/src/components/Company_Settings.vue
+++ b/src/components/Company_Settings.vue
@@ -24,7 +24,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed } from 'vue'
 import router from '@/router'
 import { storeToRefs } from 'pinia'
 import { Form, Field } from 'vee-validate'
@@ -46,7 +46,7 @@ const props = defineProps({
 
 const companiesStore = useCompaniesStore()
 const countriesStore = useCountriesStore()
-
+countriesStore.ensureLoaded()
 const { countries } = storeToRefs(countriesStore)
 
 // Check if we're in create mode
@@ -117,11 +117,6 @@ function onSubmit(values, { setErrors }) {
   }
 }
 
-// Initialize data
-onMounted(async () => {
-  // Fetch countries using ensureLoaded pattern
-  countriesStore.ensureLoaded()
-})
 </script>
 
 <template>

--- a/src/components/Company_Settings.vue
+++ b/src/components/Company_Settings.vue
@@ -119,10 +119,8 @@ function onSubmit(values, { setErrors }) {
 
 // Initialize data
 onMounted(async () => {
-  // Fetch countries if not already loaded
-  if (countries.value.length === 0) {
-    await countriesStore.getAll()
-  }
+  // Fetch countries using ensureLoaded pattern
+  countriesStore.ensureLoaded()
 })
 </script>
 

--- a/src/components/OzonParcel_EditDialog.vue
+++ b/src/components/OzonParcel_EditDialog.vue
@@ -68,9 +68,7 @@ watch(() => item.value?.statusId, (newStatusId) => {
 statusStore.ensureStatusesLoaded()
 parcelCheckStatusStore.ensureStatusesLoaded()
 await stopWordsStore.getAll()
-if (countries.value.length === 0) {
-  await countriesStore.getAll()
-}
+countriesStore.ensureLoaded()
 await parcelsStore.getById(props.id)
 
 const schema = Yup.object().shape({

--- a/src/components/OzonParcel_EditDialog.vue
+++ b/src/components/OzonParcel_EditDialog.vue
@@ -52,6 +52,10 @@ const stopWordsStore = useStopWordsStore()
 const feacnCodesStore = useFeacnCodesStore()
 const countriesStore = useCountriesStore()
 
+countriesStore.ensureLoaded()
+statusStore.ensureStatusesLoaded()
+parcelCheckStatusStore.ensureStatusesLoaded()
+
 const { item } = storeToRefs(parcelsStore)
 const { stopWords } = storeToRefs(stopWordsStore)
 const { orders: feacnOrders } = storeToRefs(feacnCodesStore)
@@ -65,10 +69,7 @@ watch(() => item.value?.statusId, (newStatusId) => {
   currentStatusId.value = newStatusId
 }, { immediate: true })
 
-statusStore.ensureStatusesLoaded()
-parcelCheckStatusStore.ensureStatusesLoaded()
 await stopWordsStore.getAll()
-countriesStore.ensureLoaded()
 await parcelsStore.getById(props.id)
 
 const schema = Yup.object().shape({

--- a/src/components/OzonParcels_List.vue
+++ b/src/components/OzonParcels_List.vue
@@ -52,12 +52,12 @@ const parcelCheckStatusStore = useParcelCheckStatusStore()
 const stopWordsStore = useStopWordsStore()
 const feacnCodesStore = useFeacnCodesStore()
 const countriesStore = useCountriesStore()
+countriesStore.ensureLoaded()
 const authStore = useAuthStore()
 
 const { items, loading, error, totalCount } = storeToRefs(parcelsStore)
 const { stopWords } = storeToRefs(stopWordsStore)
 const { orders: feacnOrders } = storeToRefs(feacnCodesStore)
-const { countries } = storeToRefs(countriesStore)
 const {
   parcels_per_page,
   parcels_sort_by,
@@ -107,9 +107,6 @@ onMounted(async () => {
   parcelCheckStatusStore.ensureStatusesLoaded()
   // Load all stop words once to reduce network traffic
   await stopWordsStore.getAll()
-  if (countries.value.length === 0) {
-    await countriesStore.getAll()
-  }
   // Ensure feacn orders are loaded (loaded globally at startup, but ensure here as fallback)
   await feacnCodesStore.ensureOrdersLoaded()
   await fetchRegister()

--- a/src/components/Registers_List.vue
+++ b/src/components/Registers_List.vue
@@ -66,9 +66,13 @@ const companiesStore = useCompaniesStore()
 const { companies } = storeToRefs(companiesStore)
 
 const countriesStore = useCountriesStore()
-const transportationTypesStore = useTransportationTypesStore()
-const customsProceduresStore = useCustomsProceduresStore()
 const { countries } = storeToRefs(countriesStore)
+
+const transportationTypesStore = useTransportationTypesStore()
+transportationTypesStore.ensureLoaded()
+
+const customsProceduresStore = useCustomsProceduresStore()
+customsProceduresStore.ensureLoaded()
 
 const alertStore = useAlertStore()
 const confirm = useConfirm()
@@ -157,15 +161,7 @@ function getCustomerName(customerId) {
 }
 
 function getCountryName(code) {
-  return countriesStore.getCountryShortName(code)
-}
-
-function getTransportationTypeTitle(id) {
-  return transportationTypesStore.getTitle(id)
-}
-
-function getCustomsProcedureTitle(id) {
-  return customsProceduresStore.getTitle(id)
+  return countriesStore.getCountryShortName(code) || 'Неизвестно'
 }
 
 // Load companies and order statuses on component mount
@@ -175,8 +171,6 @@ onMounted(async () => {
   if (countries.value.length === 0) {
     await countriesStore.getAll()
   }
-  transportationTypesStore.ensureLoaded()
-  customsProceduresStore.ensureLoaded()
 })
 
 onUnmounted(() => {
@@ -315,24 +309,24 @@ function cancelValidation() {
 }
 
 const headers = [
-  { title: '', key: 'actions1', sortable: false, align: 'center', width: '10px' },
-  { title: '', key: 'actions2', sortable: false, align: 'center', width: '10px' },
-  { title: '', key: 'actions3', sortable: false, align: 'center', width: '10px' },
-  { title: '', key: 'actions4', sortable: false, align: 'center', width: '10px' },
-  { title: '', key: 'actions5', sortable: false, align: 'center', width: '10px' },
-  { title: 'Файл реестра', key: 'fileName', align: 'start' },
+  { title: '', key: 'actions1', sortable: false, align: 'center', width: '5px' },
+  { title: '', key: 'actions2', sortable: false, align: 'center', width: '5x' },
+  { title: '', key: 'actions3', sortable: false, align: 'center', width: '5px' },
+  { title: '', key: 'actions4', sortable: false, align: 'center', width: '5px' },
+  { title: '', key: 'actions5', sortable: false, align: 'center', width: '5px' },
+  { title: 'Файл', key: 'fileName', align: 'start' },
   { title: 'Клиент', key: 'companyId', align: 'start' },
-  { title: 'Страна назначения', key: 'destCountryCode', align: 'start' },
+  { title: 'Страна', key: 'destCountryCode', align: 'start' },
   { title: 'Дата инвойса', key: 'invoiceDate', align: 'start' },
   { title: 'Номер инвойса', key: 'invoiceNumber', align: 'start' },
-  { title: 'Тип транспорта', key: 'transportationTypeId', align: 'start' },
-  { title: 'Таможенная процедура', key: 'customsProcedureId', align: 'start' },
+  { title: 'Транспорт', key: 'transportationTypeId', align: 'start' },
+  { title: 'Процедура', key: 'customsProcedureId', align: 'start' },
   { title: 'Заказы', key: 'ordersTotal', align: 'end' }
 ]
 </script>
 
 <template>
-  <div class="settings table-2">
+  <div class="settings table-3">
     <h1 class="primary-heading">Реестры</h1>
     <hr class="hr" />
 
@@ -388,10 +382,10 @@ const headers = [
           {{ item.invoiceNumber }}
         </template>
         <template #[`item.transportationTypeId`]="{ item }">
-          {{ getTransportationTypeTitle(item.transportationTypeId) }}
+          {{ transportationTypesStore.getName(item.transportationTypeId) }}
         </template>
         <template #[`item.customsProcedureId`]="{ item }">
-          {{ getCustomsProcedureTitle(item.customsProcedureId) }}
+          {{ customsProceduresStore.getName(item.customsProcedureId) }}
         </template>
         <template #[`item.ordersTotal`]="{ item }">
           {{ item.ordersTotal }}

--- a/src/components/Registers_List.vue
+++ b/src/components/Registers_List.vue
@@ -75,6 +75,7 @@ const customsProceduresStore = useCustomsProceduresStore()
 customsProceduresStore.ensureLoaded()
 
 const alertStore = useAlertStore()
+const { alert } = storeToRefs(alertStore)
 const confirm = useConfirm()
 
 const authStore = useAuthStore()
@@ -183,10 +184,13 @@ async function wbrFileSelected(files) {
   if (!file) return
   try {
     await registersStore.upload(file, WBR_COMPANY_ID)
-    alertStore.success('Реестр успешно загружен')
     loadRegisters()
   } catch (err) {
     alertStore.error(err.message || String(err))
+  } finally {
+    if (wbrFileInput.value) {
+      wbrFileInput.value.value = null
+    }
   }
 }
 
@@ -199,6 +203,10 @@ async function ozonFileSelected(files) {
     loadRegisters()
   } catch (err) {
     alertStore.error(err.message || String(err))
+  } finally {
+    if (ozonFileInput.value) {
+      ozonFileInput.value.value = null
+    }
   }
 }
 
@@ -501,6 +509,10 @@ const headers = [
     </div>
     <div v-if="error" class="text-center m-5">
       <div class="text-danger">Ошибка при загрузке списка реестров: {{ error }}</div>
+    </div>
+   <div v-if="alert" class="alert alert-dismissable mt-3 mb-0" :class="alert.type">
+      <button @click="alertStore.clear()" class="btn btn-link close">×</button>
+      {{ alert.message }}
     </div>
 
     <v-dialog v-model="validationState.show" width="300">

--- a/src/components/Registers_List.vue
+++ b/src/components/Registers_List.vue
@@ -30,6 +30,9 @@ import { useRegistersStore } from '@/stores/registers.store.js'
 import { useParcelsStore } from '@/stores/parcels.store.js'
 import { useParcelStatusesStore } from '@/stores/parcel.statuses.store.js'
 import { useCompaniesStore } from '@/stores/companies.store.js'
+import { useCountriesStore } from '@/stores/countries.store.js'
+import { useTransportationTypesStore } from '@/stores/transportation.types.store.js'
+import { useCustomsProceduresStore } from '@/stores/customs.procedures.store.js'
 import { useAuthStore } from '@/stores/auth.store.js'
 import { useAlertStore } from '@/stores/alert.store.js'
 import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
@@ -61,6 +64,11 @@ const parcelStatusesStore = useParcelStatusesStore()
 
 const companiesStore = useCompaniesStore()
 const { companies } = storeToRefs(companiesStore)
+
+const countriesStore = useCountriesStore()
+const transportationTypesStore = useTransportationTypesStore()
+const customsProceduresStore = useCustomsProceduresStore()
+const { countries } = storeToRefs(countriesStore)
 
 const alertStore = useAlertStore()
 const confirm = useConfirm()
@@ -148,10 +156,27 @@ function getCustomerName(customerId) {
   return company.shortName || company.name || 'Неизвестно'
 }
 
+function getCountryName(code) {
+  return countriesStore.getCountryShortName(code)
+}
+
+function getTransportationTypeTitle(id) {
+  return transportationTypesStore.getTitle(id)
+}
+
+function getCustomsProcedureTitle(id) {
+  return customsProceduresStore.getTitle(id)
+}
+
 // Load companies and order statuses on component mount
 onMounted(async () => {
   await companiesStore.getAll()
   await parcelStatusesStore.getAll()
+  if (countries.value.length === 0) {
+    await countriesStore.getAll()
+  }
+  transportationTypesStore.ensureLoaded()
+  customsProceduresStore.ensureLoaded()
 })
 
 onUnmounted(() => {
@@ -297,6 +322,11 @@ const headers = [
   { title: '', key: 'actions5', sortable: false, align: 'center', width: '10px' },
   { title: 'Файл реестра', key: 'fileName', align: 'start' },
   { title: 'Клиент', key: 'companyId', align: 'start' },
+  { title: 'Страна назначения', key: 'destCountryCode', align: 'start' },
+  { title: 'Дата инвойса', key: 'invoiceDate', align: 'start' },
+  { title: 'Номер инвойса', key: 'invoiceNumber', align: 'start' },
+  { title: 'Тип транспорта', key: 'transportationTypeId', align: 'start' },
+  { title: 'Таможенная процедура', key: 'customsProcedureId', align: 'start' },
   { title: 'Заказы', key: 'ordersTotal', align: 'end' }
 ]
 </script>
@@ -347,6 +377,21 @@ const headers = [
       >
         <template #[`item.companyId`]="{ item }">
           {{ getCustomerName(item.companyId) }}
+        </template>
+        <template #[`item.destCountryCode`]="{ item }">
+          {{ getCountryName(item.destCountryCode) }}
+        </template>
+        <template #[`item.invoiceDate`]="{ item }">
+          {{ item.invoiceDate }}
+        </template>
+        <template #[`item.invoiceNumber`]="{ item }">
+          {{ item.invoiceNumber }}
+        </template>
+        <template #[`item.transportationTypeId`]="{ item }">
+          {{ getTransportationTypeTitle(item.transportationTypeId) }}
+        </template>
+        <template #[`item.customsProcedureId`]="{ item }">
+          {{ getCustomsProcedureTitle(item.customsProcedureId) }}
         </template>
         <template #[`item.ordersTotal`]="{ item }">
           {{ item.ordersTotal }}

--- a/src/components/Registers_List.vue
+++ b/src/components/Registers_List.vue
@@ -160,10 +160,6 @@ function getCustomerName(customerId) {
   return company.shortName || company.name || 'Неизвестно'
 }
 
-function getCountryName(code) {
-  return countriesStore.getCountryShortName(code) || 'Неизвестно'
-}
-
 // Load companies and order statuses on component mount
 onMounted(async () => {
   await companiesStore.getAll()
@@ -370,7 +366,7 @@ const headers = [
           {{ getCustomerName(item.companyId) }}
         </template>
         <template #[`item.destCountryCode`]="{ item }">
-          {{ getCountryName(item.destCountryCode) }}
+          {{ countriesStore.getCountryShortName(item.destCountryCode) }}
         </template>
         <template #[`item.invoiceDate`]="{ item }">
           {{ item.invoiceDate }}

--- a/src/components/Registers_List.vue
+++ b/src/components/Registers_List.vue
@@ -66,7 +66,7 @@ const companiesStore = useCompaniesStore()
 const { companies } = storeToRefs(companiesStore)
 
 const countriesStore = useCountriesStore()
-const { countries } = storeToRefs(countriesStore)
+countriesStore.ensureLoaded()
 
 const transportationTypesStore = useTransportationTypesStore()
 transportationTypesStore.ensureLoaded()
@@ -168,9 +168,6 @@ function getCountryName(code) {
 onMounted(async () => {
   await companiesStore.getAll()
   await parcelStatusesStore.getAll()
-  if (countries.value.length === 0) {
-    await countriesStore.getAll()
-  }
 })
 
 onUnmounted(() => {

--- a/src/components/WbrParcel_EditDialog.vue
+++ b/src/components/WbrParcel_EditDialog.vue
@@ -68,9 +68,7 @@ watch(() => item.value?.statusId, (newStatusId) => {
 statusStore.ensureStatusesLoaded()
 parcelCheckStatusStore.ensureStatusesLoaded()
 await stopWordsStore.getAll()
-if (countries.value.length === 0) {
-  await countriesStore.getAll()
-}
+countriesStore.ensureLoaded()
 await parcelsStore.getById(props.id)
 
 const schema = Yup.object().shape({

--- a/src/components/WbrParcels_List.vue
+++ b/src/components/WbrParcels_List.vue
@@ -51,13 +51,15 @@ const parcelStatusStore = useParcelStatusesStore()
 const parcelCheckStatusStore = useParcelCheckStatusStore()
 const stopWordsStore = useStopWordsStore()
 const feacnCodesStore = useFeacnCodesStore()
+
 const countriesStore = useCountriesStore()
+countriesStore.ensureLoaded()
+
 const authStore = useAuthStore()
 
 const { items, loading, error, totalCount } = storeToRefs(parcelsStore)
 const { stopWords } = storeToRefs(stopWordsStore)
 const { orders: feacnOrders } = storeToRefs(feacnCodesStore)
-const { countries } = storeToRefs(countriesStore)
 const {
   parcels_per_page,
   parcels_sort_by,
@@ -107,9 +109,6 @@ onMounted(async () => {
   parcelCheckStatusStore.ensureStatusesLoaded()
   // Load all stop words once to reduce network traffic
   await stopWordsStore.getAll()
-  if (countries.value.length === 0) {
-    await countriesStore.getAll()
-  }
   // Ensure feacn orders are loaded (loaded globally at startup, but ensure here as fallback)
   await feacnCodesStore.ensureOrdersLoaded()
   await fetchRegister()

--- a/src/helpers/fetch.wrapper.js
+++ b/src/helpers/fetch.wrapper.js
@@ -47,7 +47,10 @@ function request(method) {
         
         let response;
         try {
-            response = await fetch(url, requestOptions);
+           if (enableLog) {
+            console.log(url, requestOptions.body)
+           }
+           response = await fetch(url, requestOptions);
         } catch (error) {
             // Customize your error message here
             if (error.name === 'TypeError' && error.message === 'Failed to fetch') {
@@ -91,7 +94,10 @@ function requestFile(method) {
 
         let response;
         try {
-            response = await fetch(url, requestOptions);
+          if (enableLog) {
+            console.log(url, requestOptions.body)
+          }
+          response = await fetch(url, requestOptions);
         } catch (error) {
             if (error.name === 'TypeError' && error.message === 'Failed to fetch') {
                 throw new Error('Не удалось соединиться с сервером. Пожалуйста, проверьте подключение к сети.');

--- a/src/helpers/fetch.wrapper.js
+++ b/src/helpers/fetch.wrapper.js
@@ -48,7 +48,7 @@ function request(method) {
         let response;
         try {
            if (enableLog) {
-            console.log(url, requestOptions.body)
+            console.log(url, requestOptions)
            }
            response = await fetch(url, requestOptions);
         } catch (error) {
@@ -95,7 +95,7 @@ function requestFile(method) {
         let response;
         try {
           if (enableLog) {
-            console.log(url, requestOptions.body)
+            console.log(url, requestOptions)
           }
           response = await fetch(url, requestOptions);
         } catch (error) {

--- a/src/init.app.js
+++ b/src/init.app.js
@@ -63,6 +63,8 @@ import router from '@/router'
 
 import { useAuthStore } from '@/stores/auth.store.js'
 import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
+import { useTransportationTypesStore } from '@/stores/transportation.types.store.js'
+import { useCustomsProceduresStore } from '@/stores/customs.procedures.store.js'
 
 export function initializeApp() {
   // Create custom Russian translations with missing keys
@@ -123,11 +125,15 @@ export function initializeApp() {
 
   // Initialize global data after Pinia is set up
   const feacnCodesStore = useFeacnCodesStore()
-  
+  const transportationTypesStore = useTransportationTypesStore()
+  const customsProceduresStore = useCustomsProceduresStore()
+
   // Load feacnOrders globally at app startup
   feacnCodesStore.ensureOrdersLoaded().catch(error => {
     console.warn('Failed to load feacn orders at startup:', error)
   })
+  transportationTypesStore.ensureLoaded()
+  customsProceduresStore.ensureLoaded()
 
   const queryString = window.location.search
   const urlParams = new URLSearchParams(queryString)

--- a/src/stores/countries.store.js
+++ b/src/stores/countries.store.js
@@ -40,5 +40,12 @@ export const useCountriesStore = defineStore('countries', () => {
     return country ? country.isoAlpha2 : code
   }
 
-  return { countries, loading, error, getAll, update, getCountryAlpha2 }
+  function getCountryShortName(code) {
+    const num = Number(code)
+    const country = countries.value.find(c => c.isoNumeric === num)
+    if (!country) return code
+    return country.nameRuShort || country.nameRuOfficial || code
+  }
+
+  return { countries, loading, error, getAll, update, getCountryAlpha2, getCountryShortName }
 })

--- a/src/stores/countries.store.js
+++ b/src/stores/countries.store.js
@@ -10,6 +10,8 @@ export const useCountriesStore = defineStore('countries', () => {
   const loading = ref(false)
   const error = ref(null)
 
+  let initialized = false
+
   async function getAll() {
     loading.value = true
     error.value = null
@@ -25,6 +27,7 @@ export const useCountriesStore = defineStore('countries', () => {
   async function update() {
     loading.value = true
     error.value = null
+    initialized = false
     try {
       await fetchWrapper.post(`${baseUrl}/update`)
     } catch (err) {
@@ -47,5 +50,21 @@ export const useCountriesStore = defineStore('countries', () => {
     return country.nameRuShort || country.nameRuOfficial || code
   }
 
-  return { countries, loading, error, getAll, update, getCountryAlpha2, getCountryShortName }
+  function ensureLoaded() {
+    if (!initialized && !loading.value) {
+      initialized = true
+      getAll()
+    }
+  }
+
+  return { 
+    countries, 
+    loading, 
+    error, 
+    getAll, 
+    update, 
+    getCountryAlpha2, 
+    getCountryShortName,
+    ensureLoaded,
+  }
 })

--- a/src/stores/customs.procedures.store.js
+++ b/src/stores/customs.procedures.store.js
@@ -1,0 +1,43 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/customsprocedures`
+
+export const useCustomsProceduresStore = defineStore('customsProcedures', () => {
+  const procedures = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+
+  const procedureMap = ref(new Map())
+  let initialized = false
+
+  async function getAll() {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await fetchWrapper.get(baseUrl)
+      procedures.value = res || []
+      procedureMap.value = new Map(procedures.value.map(p => [p.id, p]))
+    } catch (err) {
+      error.value = err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function ensureLoaded() {
+    if (!initialized && procedures.value.length === 0 && !loading.value) {
+      initialized = true
+      getAll()
+    }
+  }
+
+  function getTitle(id) {
+    const proc = procedureMap.value.get(id)
+    return proc ? proc.title : `Процедура ${id}`
+  }
+
+  return { procedures, loading, error, getAll, ensureLoaded, getTitle, procedureMap }
+})

--- a/src/stores/customs.procedures.store.js
+++ b/src/stores/customs.procedures.store.js
@@ -34,10 +34,10 @@ export const useCustomsProceduresStore = defineStore('customsProcedures', () => 
     }
   }
 
-  function getTitle(id) {
+  function getName(id) {
     const proc = procedureMap.value.get(id)
-    return proc ? proc.title : `Процедура ${id}`
+    return proc ? proc.name : `Процедура ${id}`
   }
 
-  return { procedures, loading, error, getAll, ensureLoaded, getTitle, procedureMap }
+  return { procedures, loading, error, getAll, ensureLoaded, getName }
 })

--- a/src/stores/transportation.types.store.js
+++ b/src/stores/transportation.types.store.js
@@ -1,0 +1,43 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/transportationtypes`
+
+export const useTransportationTypesStore = defineStore('transportationTypes', () => {
+  const types = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+
+  const typeMap = ref(new Map())
+  let initialized = false
+
+  async function getAll() {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await fetchWrapper.get(baseUrl)
+      types.value = res || []
+      typeMap.value = new Map(types.value.map(t => [t.id, t]))
+    } catch (err) {
+      error.value = err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function ensureLoaded() {
+    if (!initialized && types.value.length === 0 && !loading.value) {
+      initialized = true
+      getAll()
+    }
+  }
+
+  function getTitle(id) {
+    const type = typeMap.value.get(id)
+    return type ? type.title : `Тип ${id}`
+  }
+
+  return { types, loading, error, getAll, ensureLoaded, getTitle, typeMap }
+})

--- a/src/stores/transportation.types.store.js
+++ b/src/stores/transportation.types.store.js
@@ -39,5 +39,5 @@ export const useTransportationTypesStore = defineStore('transportationTypes', ()
     return type ? type.title : `Тип ${id}`
   }
 
-  return { types, loading, error, getAll, ensureLoaded, getTitle, typeMap }
+  return { types, loading, error, getAll, ensureLoaded, getTitle }
 })

--- a/src/stores/transportation.types.store.js
+++ b/src/stores/transportation.types.store.js
@@ -26,7 +26,6 @@ export const useTransportationTypesStore = defineStore('transportationTypes', ()
       loading.value = false
     }
   }
-
   function ensureLoaded() {
     if (!initialized && types.value.length === 0 && !loading.value) {
       initialized = true
@@ -34,10 +33,10 @@ export const useTransportationTypesStore = defineStore('transportationTypes', ()
     }
   }
 
-  function getTitle(id) {
+  function getName(id) {
     const type = typeMap.value.get(id)
-    return type ? type.title : `Тип ${id}`
+    return type ? type.name : `Тип ${id}`
   }
 
-  return { types, loading, error, getAll, ensureLoaded, getTitle }
+  return { types, loading, error, getAll, ensureLoaded, getName }
 })

--- a/tests/Companies_List.spec.js
+++ b/tests/Companies_List.spec.js
@@ -47,6 +47,7 @@ const mockCountries = ref([
 // Centralized mock functions
 const getAllCompanies = vi.hoisted(() => vi.fn())
 const getAllCountries = vi.hoisted(() => vi.fn())
+const countriesEnsureLoaded = vi.hoisted(() => vi.fn())
 const createCompany = vi.hoisted(() => vi.fn())
 const updateCompany = vi.hoisted(() => vi.fn())
 const deleteCompanyFn = vi.hoisted(() => vi.fn())
@@ -89,7 +90,8 @@ vi.mock('@/stores/countries.store.js', () => ({
   useCountriesStore: () => ({
     countries: mockCountries,
     loading: false,
-    getAll: getAllCountries
+    getAll: getAllCountries,
+    ensureLoaded: countriesEnsureLoaded
   })
 }))
 
@@ -160,7 +162,7 @@ describe('Companies_List.vue', () => {
     await wrapper.vm.$nextTick()
 
     expect(getAllCompanies).toHaveBeenCalled()
-    expect(getAllCountries).toHaveBeenCalled()
+    expect(countriesEnsureLoaded).toHaveBeenCalled()
     expect(wrapper.exists()).toBe(true)
 
     // Reset mock data for other tests
@@ -170,15 +172,9 @@ describe('Companies_List.vue', () => {
     ]
   })
 
-  it('does not fetch countries if already loaded', async () => {
+  it('calls ensureLoaded for countries on mount', async () => {
     // Clear previous calls
-    getAllCountries.mockClear()
-
-    // Start with populated countries
-    mockCountries.value = [
-      { id: 1, isoNumeric: 643, nameRuOfficial: 'Россия' },
-      { id: 2, isoNumeric: 840, nameRuOfficial: 'США' }
-    ]
+    countriesEnsureLoaded.mockClear()
 
     const wrapper = mount(CompaniesList, {
       global: {
@@ -190,7 +186,7 @@ describe('Companies_List.vue', () => {
     await wrapper.vm.$nextTick()
 
     expect(getAllCompanies).toHaveBeenCalled()
-    expect(getAllCountries).not.toHaveBeenCalled()
+    expect(countriesEnsureLoaded).toHaveBeenCalled()
     expect(wrapper.exists()).toBe(true)
   })
 

--- a/tests/Companies_List.spec.js
+++ b/tests/Companies_List.spec.js
@@ -91,7 +91,13 @@ vi.mock('@/stores/countries.store.js', () => ({
     countries: mockCountries,
     loading: false,
     getAll: getAllCountries,
-    ensureLoaded: countriesEnsureLoaded
+    ensureLoaded: countriesEnsureLoaded,
+    getCountryShortName: vi.fn((code) => {
+      const num = Number(code)
+      const country = mockCountries.value.find(c => c.isoNumeric === num)
+      if (!country) return code
+      return country.nameRuShort || country.nameRuOfficial || code
+    })
   })
 }))
 
@@ -267,14 +273,16 @@ describe('Companies_List.vue', () => {
       }
     })
 
+    const countriesStore = wrapper.vm.countriesStore
+
     // Test with existing country
-    expect(wrapper.vm.getCountryName(643)).toBe('Россия')
+    expect(countriesStore.getCountryShortName(643)).toBe('Россия')
 
     // Test with non-existent country (should return code)
-    expect(wrapper.vm.getCountryName(999)).toBe('Код: 999')
+    expect(countriesStore.getCountryShortName(999)).toBe(999)
 
     // Test with null value
-    expect(wrapper.vm.getCountryName(null)).toBe('')
+    expect(countriesStore.getCountryShortName(null)).toBe(null)
   })
 
   it('navigates to create page when add link is clicked', async () => {

--- a/tests/Company_Settings.spec.js
+++ b/tests/Company_Settings.spec.js
@@ -34,7 +34,8 @@ const mockCompaniesStore = createMockStore({
 
 const mockCountriesStore = createMockStore({
   countries: mockCountries,
-  getAll: vi.fn().mockResolvedValue()
+  getAll: vi.fn().mockResolvedValue(),
+  ensureLoaded: vi.fn()
 })
 
 const mockAlertStore = createMockStore({
@@ -268,10 +269,7 @@ describe('Company_Settings.vue', () => {
   })
 
   describe('Store Integration', () => {
-    it('fetches countries on mount when empty', async () => {
-      // Set countries to empty to trigger fetch
-      mockCountriesStore.countries = []
-      
+    it('calls ensureLoaded on mount', async () => {
       mount(AsyncWrapper, {
         props: { mode: 'create' },
         global: {
@@ -281,22 +279,7 @@ describe('Company_Settings.vue', () => {
 
       await resolveAll()
       
-      expect(mockCountriesStore.getAll).toHaveBeenCalled()
-    })
-
-    it('does not fetch countries when already loaded', async () => {
-      mockCountriesStore.countries = mockCountries
-      
-      mount(AsyncWrapper, {
-        props: { mode: 'create' },
-        global: {
-          stubs: defaultGlobalStubs
-        }
-      })
-
-      await resolveAll()
-      
-      expect(mockCountriesStore.getAll).not.toHaveBeenCalled()
+      expect(mockCountriesStore.ensureLoaded).toHaveBeenCalled()
     })
 
     it('handles store loading states', async () => {

--- a/tests/OzonParcel_EditDialog.spec.js
+++ b/tests/OzonParcel_EditDialog.spec.js
@@ -108,7 +108,8 @@ const mockFeacnCodesStore = createMockStore({
 })
 const mockCountriesStore = createMockStore({
   countries: ref([]),
-  getAll: vi.fn()
+  getAll: vi.fn(),
+  ensureLoaded: vi.fn()
 })
 
 // Mock stores

--- a/tests/OzonParcels_List.spec.js
+++ b/tests/OzonParcels_List.spec.js
@@ -126,7 +126,8 @@ vi.mock('@/stores/feacn.codes.store.js', () => ({
 vi.mock('@/stores/countries.store.js', () => ({
   useCountriesStore: () => createMockStore({
     countries: mockCountries,
-    getAll: vi.fn()
+    getAll: vi.fn(),
+    ensureLoaded: vi.fn()
   })
 }))
 

--- a/tests/Registers_List.spec.js
+++ b/tests/Registers_List.spec.js
@@ -233,17 +233,6 @@ describe('Registers_List.vue', () => {
     })
   })
 
-  describe('getCountryName function', () => {
-    it('delegates to countriesStore.getCountryShortName', () => {
-      const wrapper = mount(RegistersList, {
-        global: { stubs: vuetifyStubs }
-      })
-
-      const result = wrapper.vm.getCountryName(643)
-      expect(result).toBe('Country 643')
-    })
-  })
-
   describe('component integration', () => {
     it('displays customer names correctly when items and companies are present', async () => {
       // Set up mock companies

--- a/tests/Registers_List.spec.js
+++ b/tests/Registers_List.spec.js
@@ -241,14 +241,6 @@ describe('Registers_List.vue', () => {
     })
   })
 
-  describe('transportation/customs helpers', () => {
-    it('returns titles from stores', () => {
-      const wrapper = mount(RegistersList, { global: { stubs: vuetifyStubs } })
-      expect(wrapper.vm.getTransportationTypeTitle(1)).toBe('Type 1')
-      expect(wrapper.vm.getCustomsProcedureTitle(2)).toBe('Proc 2')
-    })
-  })
-
   describe('component integration', () => {
     it('displays customer names correctly when items and companies are present', async () => {
       // Set up mock companies

--- a/tests/Registers_List.spec.js
+++ b/tests/Registers_List.spec.js
@@ -444,138 +444,151 @@ describe('Registers_List.vue', () => {
       })
     })
 
-    describe('WBR upload functionality', () => {
-      it('opens WBR file dialog when openWbrFileDialog is called', () => {
-        const mockClick = vi.fn()
-        wrapper.vm.wbrFileInput = { click: mockClick }
+    describe('Upload functionality', () => {
+      beforeEach(() => {
+        // Set up mock companies data for upload customers
+        mockCompanies.value = [
+          { id: OZON_COMPANY_ID, name: 'ООО "Интернет решения"', shortName: 'Озон' },
+          { id: WBR_COMPANY_ID, name: 'ООО "РВБ"', shortName: 'РВБ' },
+          { id: 3, name: 'Other Company', shortName: 'Other' }
+        ]
+      })
 
-        wrapper.vm.openWbrFileDialog()
+      it('opens file dialog when customer is selected', () => {
+        const mockClick = vi.fn()
+        wrapper.vm.fileInput = { click: mockClick }
+        wrapper.vm.selectedCustomerId = OZON_COMPANY_ID
+
+        wrapper.vm.openFileDialog()
         expect(mockClick).toHaveBeenCalled()
       })
 
-      it('handles WBR file selection with array input', async () => {
+      it('shows error when trying to open file dialog without selected customer', () => {
+        wrapper.vm.selectedCustomerId = null
+        wrapper.vm.openFileDialog()
+        
+        expect(alertErrorFn).toHaveBeenCalledWith('Пожалуйста, выберите клиента')
+      })
+
+      it('handles file selection with array input for OZON', async () => {
         const file = new File(['data'], 'test.xlsx')
         uploadFn.mockResolvedValueOnce({ success: true })
+        wrapper.vm.selectedCustomerId = OZON_COMPANY_ID
 
-        await wrapper.vm.wbrFileSelected([file])
-
-        expect(uploadFn).toHaveBeenCalledWith(file, WBR_COMPANY_ID)
-        expect(alertSuccessFn).toHaveBeenCalledWith('Реестр успешно загружен')
-        expect(getAll).toHaveBeenCalled()
-      })
-
-      it('handles WBR file selection with single file input', async () => {
-        const file = new File(['data'], 'test.xlsx')
-        uploadFn.mockResolvedValueOnce({ success: true })
-
-        await wrapper.vm.wbrFileSelected(file)
-
-        expect(uploadFn).toHaveBeenCalledWith(file, WBR_COMPANY_ID)
-        expect(alertSuccessFn).toHaveBeenCalledWith('Реестр успешно загружен')
-      })
-
-      it('handles WBR file upload error', async () => {
-        const file = new File(['data'], 'test.xlsx')
-        const errorMessage = 'Upload failed'
-        uploadFn.mockRejectedValueOnce(new Error(errorMessage))
-
-        await wrapper.vm.wbrFileSelected(file)
-
-        expect(uploadFn).toHaveBeenCalledWith(file, WBR_COMPANY_ID)
-        expect(alertErrorFn).toHaveBeenCalledWith(errorMessage)
-      })
-
-      it('handles WBR file upload error without message', async () => {
-        const file = new File(['data'], 'test.xlsx')
-        const errorObj = { code: 500 }
-        uploadFn.mockRejectedValueOnce(errorObj)
-
-        await wrapper.vm.wbrFileSelected(file)
-
-        expect(uploadFn).toHaveBeenCalledWith(file, WBR_COMPANY_ID)
-        expect(alertErrorFn).toHaveBeenCalledWith('[object Object]')
-      })
-
-      it('handles empty WBR file selection', async () => {
-        await wrapper.vm.wbrFileSelected(null)
-        expect(uploadFn).not.toHaveBeenCalled()
-
-        await wrapper.vm.wbrFileSelected([])
-        expect(uploadFn).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('OZON upload functionality', () => {
-      it('opens OZON file dialog when openOzonFileDialog is called', () => {
-        const mockClick = vi.fn()
-        wrapper.vm.ozonFileInput = { click: mockClick }
-
-        wrapper.vm.openOzonFileDialog()
-        expect(mockClick).toHaveBeenCalled()
-      })
-
-      it('handles OZON file selection with array input', async () => {
-        const file = new File(['data'], 'test.xlsx')
-        uploadFn.mockResolvedValueOnce({ success: true })
-
-        await wrapper.vm.ozonFileSelected([file])
+        await wrapper.vm.fileSelected([file])
 
         expect(uploadFn).toHaveBeenCalledWith(file, OZON_COMPANY_ID)
         expect(alertSuccessFn).toHaveBeenCalledWith('Реестр успешно загружен')
         expect(getAll).toHaveBeenCalled()
       })
 
-      it('handles OZON file selection with single file input', async () => {
+      it('handles file selection with single file input for WBR', async () => {
         const file = new File(['data'], 'test.xlsx')
         uploadFn.mockResolvedValueOnce({ success: true })
+        wrapper.vm.selectedCustomerId = WBR_COMPANY_ID
 
-        await wrapper.vm.ozonFileSelected(file)
+        await wrapper.vm.fileSelected(file)
 
-        expect(uploadFn).toHaveBeenCalledWith(file, OZON_COMPANY_ID)
+        expect(uploadFn).toHaveBeenCalledWith(file, WBR_COMPANY_ID)
         expect(alertSuccessFn).toHaveBeenCalledWith('Реестр успешно загружен')
       })
 
-      it('handles OZON file upload error', async () => {
+      it('handles file upload error', async () => {
         const file = new File(['data'], 'test.xlsx')
         const errorMessage = 'Upload failed'
         uploadFn.mockRejectedValueOnce(new Error(errorMessage))
+        wrapper.vm.selectedCustomerId = OZON_COMPANY_ID
 
-        await wrapper.vm.ozonFileSelected(file)
+        await wrapper.vm.fileSelected(file)
 
         expect(uploadFn).toHaveBeenCalledWith(file, OZON_COMPANY_ID)
         expect(alertErrorFn).toHaveBeenCalledWith(errorMessage)
       })
 
-      it('handles OZON file upload error without message', async () => {
+      it('handles file upload error without message', async () => {
         const file = new File(['data'], 'test.xlsx')
         const errorObj = { code: 500 }
         uploadFn.mockRejectedValueOnce(errorObj)
+        wrapper.vm.selectedCustomerId = WBR_COMPANY_ID
 
-        await wrapper.vm.ozonFileSelected(file)
+        await wrapper.vm.fileSelected(file)
 
-        expect(uploadFn).toHaveBeenCalledWith(file, OZON_COMPANY_ID)
+        expect(uploadFn).toHaveBeenCalledWith(file, WBR_COMPANY_ID)
         expect(alertErrorFn).toHaveBeenCalledWith('[object Object]')
       })
 
-      it('handles empty OZON file selection', async () => {
-        await wrapper.vm.ozonFileSelected(null)
+      it('handles empty file selection', async () => {
+        wrapper.vm.selectedCustomerId = OZON_COMPANY_ID
+        
+        await wrapper.vm.fileSelected(null)
         expect(uploadFn).not.toHaveBeenCalled()
 
-        await wrapper.vm.ozonFileSelected([])
+        await wrapper.vm.fileSelected([])
         expect(uploadFn).not.toHaveBeenCalled()
+      })
+
+      it('shows error when trying to upload without selected customer', async () => {
+        const file = new File(['data'], 'test.xlsx')
+        wrapper.vm.selectedCustomerId = null
+
+        await wrapper.vm.fileSelected(file)
+        
+        expect(alertErrorFn).toHaveBeenCalledWith('Не выбран клиент для загрузки реестра')
+        expect(uploadFn).not.toHaveBeenCalled()
+      })
+
+      it('clears file input after upload', async () => {
+        const file = new File(['data'], 'test.xlsx')
+        const mockFileInput = { value: null }
+        wrapper.vm.fileInput = mockFileInput
+        wrapper.vm.selectedCustomerId = OZON_COMPANY_ID
+        uploadFn.mockResolvedValueOnce({ success: true })
+
+        await wrapper.vm.fileSelected(file)
+
+        expect(mockFileInput.value).toBeNull()
+      })
+
+      it('clears file input even when upload fails', async () => {
+        const file = new File(['data'], 'test.xlsx')
+        const mockFileInput = { value: null }
+        wrapper.vm.fileInput = mockFileInput
+        wrapper.vm.selectedCustomerId = OZON_COMPANY_ID
+        uploadFn.mockRejectedValueOnce(new Error('Upload failed'))
+
+        await wrapper.vm.fileSelected(file)
+
+        expect(mockFileInput.value).toBeNull()
       })
     })
 
-    describe('legacy compatibility', () => {
-      it('handles legacy fileSelected method (for backwards compatibility)', async () => {
-        const file = new File(['data'], 'test.xlsx')
-        uploadFn.mockResolvedValueOnce({ success: true })
+    describe('uploadCustomers computed property', () => {
+      it('returns filtered customers for upload', () => {
+        mockCompanies.value = [
+          { id: OZON_COMPANY_ID, name: 'ООО "Интернет решения"', shortName: 'Озон' },
+          { id: WBR_COMPANY_ID, name: 'ООО "РВБ"', shortName: 'РВБ' },
+          { id: 3, name: 'Other Company', shortName: 'Other' }
+        ]
 
-        // Test that the old method name still works if it exists
-        if (wrapper.vm.fileSelected) {
-          await wrapper.vm.fileSelected([file])
-          expect(uploadFn).toHaveBeenCalledWith(file)
-        }
+        const uploadCustomers = wrapper.vm.uploadCustomers
+
+        expect(uploadCustomers).toHaveLength(2)
+        expect(uploadCustomers).toEqual([
+          { id: OZON_COMPANY_ID, name: 'Озон' },
+          { id: WBR_COMPANY_ID, name: 'РВБ' }
+        ])
+      })
+
+      it('returns empty array when no companies loaded', () => {
+        mockCompanies.value = []
+        const uploadCustomers = wrapper.vm.uploadCustomers
+        expect(uploadCustomers).toEqual([])
+      })
+
+      it('returns empty array when companies is null', () => {
+        mockCompanies.value = null
+        const uploadCustomers = wrapper.vm.uploadCustomers
+        expect(uploadCustomers).toEqual([])
       })
     })
   })

--- a/tests/Registers_List.spec.js
+++ b/tests/Registers_List.spec.js
@@ -18,6 +18,7 @@ const setOrderStatusesFn = vi.fn()
 const getCompaniesAll = vi.fn()
 const getOrderStatusesAll = vi.fn()
 const getCountriesAll = vi.fn()
+const countriesEnsureLoadedFn = vi.fn()
 const getTransportationTypesAll = vi.fn()
 const getCustomsProceduresAll = vi.fn()
 const generateAllFn = vi.fn()
@@ -102,6 +103,7 @@ vi.mock('@/stores/countries.store.js', () => ({
   useCountriesStore: () => ({
     countries: mockCountries,
     getAll: getCountriesAll,
+    ensureLoaded: countriesEnsureLoadedFn,
     getCountryShortName: vi.fn(code => `Country ${code}`)
   })
 }))
@@ -173,6 +175,7 @@ describe('Registers_List.vue', () => {
       expect(getOrderStatusesAll).toHaveBeenCalled()
     })
     expect(getAll).toHaveBeenCalled()
+    expect(countriesEnsureLoadedFn).toHaveBeenCalled()
   })
 
   describe('getCustomerName function', () => {

--- a/tests/Registers_List.spec.js
+++ b/tests/Registers_List.spec.js
@@ -9,11 +9,17 @@ import { vuetifyStubs } from './test-utils.js'
 const mockItems = ref([])
 const mockCompanies = ref([])
 const mockOrderStatuses = ref([])
+const mockCountries = ref([])
+const mockTransportationTypes = ref([])
+const mockCustomsProcedures = ref([])
 const getAll = vi.fn()
 const uploadFn = vi.fn()
 const setOrderStatusesFn = vi.fn()
 const getCompaniesAll = vi.fn()
 const getOrderStatusesAll = vi.fn()
+const getCountriesAll = vi.fn()
+const getTransportationTypesAll = vi.fn()
+const getCustomsProceduresAll = vi.fn()
 const generateAllFn = vi.fn()
 const alertSuccessFn = vi.fn()
 const alertErrorFn = vi.fn()
@@ -41,6 +47,9 @@ vi.mock('pinia', async () => {
       } else if (store.getAll && store.parcelStatuses) {
         // parcel statuses store
         return { parcelStatuses: mockOrderStatuses }
+      } else if (store.getAll && store.countries) {
+        // countries store
+        return { countries: mockCountries }
       } else {
         // auth store or other stores - return safe defaults
         return {
@@ -86,6 +95,32 @@ vi.mock('@/stores/companies.store.js', () => ({
   useCompaniesStore: () => ({
     getAll: getCompaniesAll,
     companies: mockCompanies
+  })
+}))
+
+vi.mock('@/stores/countries.store.js', () => ({
+  useCountriesStore: () => ({
+    countries: mockCountries,
+    getAll: getCountriesAll,
+    getCountryShortName: vi.fn(code => `Country ${code}`)
+  })
+}))
+
+vi.mock('@/stores/transportation.types.store.js', () => ({
+  useTransportationTypesStore: () => ({
+    types: mockTransportationTypes,
+    getAll: getTransportationTypesAll,
+    ensureLoaded: vi.fn(),
+    getTitle: vi.fn(id => `Type ${id}`)
+  })
+}))
+
+vi.mock('@/stores/customs.procedures.store.js', () => ({
+  useCustomsProceduresStore: () => ({
+    procedures: mockCustomsProcedures,
+    getAll: getCustomsProceduresAll,
+    ensureLoaded: vi.fn(),
+    getTitle: vi.fn(id => `Proc ${id}`)
   })
 }))
 
@@ -192,6 +227,25 @@ describe('Registers_List.vue', () => {
       mockCompanies.value = []
       const customerName = wrapper.vm.getCustomerName(1)
       expect(customerName).toBe('Неизвестно')
+    })
+  })
+
+  describe('getCountryName function', () => {
+    it('delegates to countriesStore.getCountryShortName', () => {
+      const wrapper = mount(RegistersList, {
+        global: { stubs: vuetifyStubs }
+      })
+
+      const result = wrapper.vm.getCountryName(643)
+      expect(result).toBe('Country 643')
+    })
+  })
+
+  describe('transportation/customs helpers', () => {
+    it('returns titles from stores', () => {
+      const wrapper = mount(RegistersList, { global: { stubs: vuetifyStubs } })
+      expect(wrapper.vm.getTransportationTypeTitle(1)).toBe('Type 1')
+      expect(wrapper.vm.getCustomsProcedureTitle(2)).toBe('Proc 2')
     })
   })
 

--- a/tests/WbrParcel_EditDialog.spec.js
+++ b/tests/WbrParcel_EditDialog.spec.js
@@ -106,7 +106,8 @@ const mockFeacnCodesStore = createMockStore({
 })
 const mockCountriesStore = createMockStore({
   countries: ref([]),
-  getAll: vi.fn()
+  getAll: vi.fn(),
+  ensureLoaded: vi.fn()
 })
 
 // Mock stores

--- a/tests/WbrParcels_List.spec.js
+++ b/tests/WbrParcels_List.spec.js
@@ -126,7 +126,8 @@ vi.mock('@/stores/feacn.codes.store.js', () => ({
 vi.mock('@/stores/countries.store.js', () => ({
   useCountriesStore: () => createMockStore({
     countries: mockCountries,
-    getAll: vi.fn()
+    getAll: vi.fn(),
+    ensureLoaded: vi.fn()
   })
 }))
 

--- a/tests/countries.store.spec.js
+++ b/tests/countries.store.spec.js
@@ -102,4 +102,141 @@ describe('countries store', () => {
       expect(store.getCountryShortName(123)).toBe(123)
     })
   })
+
+  describe('ensureLoaded', () => {
+    it('calls getAll on first invocation when not initialized and not loading', async () => {
+      const mockCountries = [{ isoNumeric: 643, isoAlpha2: 'RU', nameRuShort: 'Россия' }]
+      fetchWrapper.get.mockResolvedValueOnce(mockCountries)
+
+      const store = useCountriesStore()
+      
+      // Initially no API call should have been made
+      expect(fetchWrapper.get).not.toHaveBeenCalled()
+      
+      // Call ensureLoaded
+      store.ensureLoaded()
+      
+      // Should trigger getAll which calls the API
+      await vi.waitFor(() => {
+        expect(fetchWrapper.get).toHaveBeenCalledOnce()
+        expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/countries/compact`)
+      })
+    })
+
+    it('does not call getAll on second invocation (already initialized)', async () => {
+      const mockCountries = [{ isoNumeric: 643, isoAlpha2: 'RU', nameRuShort: 'Россия' }]
+      fetchWrapper.get.mockResolvedValue(mockCountries)
+
+      const store = useCountriesStore()
+      
+      // First call should initialize
+      store.ensureLoaded()
+      
+      await vi.waitFor(() => {
+        expect(fetchWrapper.get).toHaveBeenCalledOnce()
+      })
+      
+      // Second call should not call API again
+      store.ensureLoaded()
+      
+      // Should still only have been called once
+      expect(fetchWrapper.get).toHaveBeenCalledOnce()
+    })
+
+    it('does not call getAll when already loading', async () => {
+      const store = useCountriesStore()
+      
+      // Set loading state to true to simulate ongoing request
+      store.loading = true
+      
+      store.ensureLoaded()
+      
+      // Should not make any API calls when loading is true
+      expect(fetchWrapper.get).not.toHaveBeenCalled()
+    })
+
+    it('can be called multiple times safely', async () => {
+      const mockCountries = [{ isoNumeric: 643, isoAlpha2: 'RU', nameRuShort: 'Россия' }]
+      fetchWrapper.get.mockResolvedValueOnce(mockCountries)
+      
+      const store = useCountriesStore()
+      
+      // Call multiple times in quick succession
+      store.ensureLoaded()
+      store.ensureLoaded()
+      store.ensureLoaded()
+      
+      // Should only trigger one API call
+      await vi.waitFor(() => {
+        expect(fetchWrapper.get).toHaveBeenCalledOnce()
+      })
+      
+      // Even after loading completes, additional calls should not trigger more API calls
+      await vi.waitFor(() => {
+        expect(store.countries).toEqual(mockCountries)
+      })
+      
+      store.ensureLoaded()
+      store.ensureLoaded()
+      
+      expect(fetchWrapper.get).toHaveBeenCalledOnce()
+    })
+
+    it('works correctly in integration with component lifecycle', async () => {
+      const store = useCountriesStore()
+      const mockCountries = [
+        { isoNumeric: 643, isoAlpha2: 'RU', nameRuShort: 'Россия' },
+        { isoNumeric: 840, isoAlpha2: 'US', nameRuShort: 'США' }
+      ]
+      
+      fetchWrapper.get.mockResolvedValueOnce(mockCountries)
+      
+      // Simulate component mounting and calling ensureLoaded
+      store.ensureLoaded()
+      
+      // Wait for async getAll to complete
+      await vi.waitFor(() => {
+        expect(store.countries).toEqual(mockCountries)
+      })
+      
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+      
+      // Subsequent calls should not trigger additional API calls
+      const initialCallCount = fetchWrapper.get.mock.calls.length
+      store.ensureLoaded()
+      store.ensureLoaded()
+      
+      expect(fetchWrapper.get).toHaveBeenCalledTimes(initialCallCount)
+    })
+
+    it('handles errors gracefully but does not retry automatically', async () => {
+      const store = useCountriesStore()
+      
+      // First call fails
+      fetchWrapper.get.mockRejectedValueOnce(new Error('Network error'))
+      
+      store.ensureLoaded()
+      
+      // Wait for the error to be set
+      await vi.waitFor(() => {
+        expect(store.error).toBeTruthy()
+      })
+      
+      // Reset the mock for a successful call
+      fetchWrapper.get.mockResolvedValueOnce([{ isoNumeric: 643, isoAlpha2: 'RU' }])
+      
+      // ensureLoaded should NOT retry automatically since initialized flag is set
+      // This is the expected behavior - once initialized, it won't retry
+      store.ensureLoaded()
+      
+      // Should still only have been called once (the failed call)
+      expect(fetchWrapper.get).toHaveBeenCalledOnce()
+      
+      // To retry, we need to call getAll() directly
+      await store.getAll()
+      expect(fetchWrapper.get).toHaveBeenCalledTimes(2)
+      expect(store.error).toBeNull()
+    })
+  })
 })

--- a/tests/countries.store.spec.js
+++ b/tests/countries.store.spec.js
@@ -80,7 +80,26 @@ describe('countries store', () => {
         { isoNumeric: 643, isoAlpha2: 'RU', nameEnOfficial: 'Russia', nameRuOfficial: 'Россия' }
       ]
 
-      expect(store.getCountryAlpha2('643')).toBe('RU')
+    expect(store.getCountryAlpha2('643')).toBe('RU')
+  })
+  })
+
+  describe('getCountryShortName', () => {
+    it('returns short or official name for valid code', () => {
+      const store = useCountriesStore()
+      store.countries = [
+        { isoNumeric: 643, isoAlpha2: 'RU', nameRuOfficial: 'Россия', nameRuShort: 'Россия' },
+        { isoNumeric: 840, isoAlpha2: 'US', nameRuOfficial: 'США', nameRuShort: 'США' }
+      ]
+
+      expect(store.getCountryShortName(643)).toBe('Россия')
+      expect(store.getCountryShortName('840')).toBe('США')
+    })
+
+    it('returns original code for unknown code', () => {
+      const store = useCountriesStore()
+      store.countries = []
+      expect(store.getCountryShortName(123)).toBe(123)
     })
   })
 })

--- a/tests/customs.procedures.store.spec.js
+++ b/tests/customs.procedures.store.spec.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCustomsProceduresStore } from '@/stores/customs.procedures.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: { get: vi.fn() }
+}))
+
+vi.mock('@/helpers/config.js', () => ({
+  apiUrl: 'http://localhost:8080/api'
+}))
+
+describe('customs procedures store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('initializes with defaults', () => {
+    const store = useCustomsProceduresStore()
+    expect(store.procedures).toEqual([])
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('fetches procedures successfully', async () => {
+    const data = [ { id: 1, title: 'Экспорт' } ]
+    fetchWrapper.get.mockResolvedValue(data)
+
+    const store = useCustomsProceduresStore()
+    await store.getAll()
+
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/customsprocedures`)
+    expect(store.procedures).toEqual(data)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('handles fetch error', async () => {
+    const err = new Error('err')
+    fetchWrapper.get.mockRejectedValue(err)
+    const store = useCustomsProceduresStore()
+    await store.getAll()
+    expect(store.error).toBe(err)
+    expect(store.loading).toBe(false)
+  })
+
+  it('ensureLoaded loads only once', async () => {
+    const data = [ { id: 1, title: 'Процедура' } ]
+    fetchWrapper.get.mockResolvedValue(data)
+    const store = useCustomsProceduresStore()
+    store.ensureLoaded()
+    store.ensureLoaded()
+    await Promise.resolve()
+    expect(fetchWrapper.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('getTitle returns title or fallback', async () => {
+    const store = useCustomsProceduresStore()
+    fetchWrapper.get.mockResolvedValueOnce([{ id: 3, title: 'Импорт' }])
+    await store.getAll()
+    expect(store.getTitle(3)).toBe('Импорт')
+    expect(store.getTitle(7)).toBe('Процедура 7')
+  })
+})

--- a/tests/customs.procedures.store.spec.js
+++ b/tests/customs.procedures.store.spec.js
@@ -57,11 +57,11 @@ describe('customs procedures store', () => {
     expect(fetchWrapper.get).toHaveBeenCalledTimes(1)
   })
 
-  it('getTitle returns title or fallback', async () => {
+  it('getName returns name or fallback', async () => {
     const store = useCustomsProceduresStore()
-    fetchWrapper.get.mockResolvedValueOnce([{ id: 3, title: 'Импорт' }])
+    fetchWrapper.get.mockResolvedValueOnce([{ id: 3, name: 'Импорт' }])
     await store.getAll()
-    expect(store.getTitle(3)).toBe('Импорт')
-    expect(store.getTitle(7)).toBe('Процедура 7')
+    expect(store.getName(3)).toBe('Импорт')
+    expect(store.getName(7)).toBe('Процедура 7')
   })
 })

--- a/tests/transportation.types.store.spec.js
+++ b/tests/transportation.types.store.spec.js
@@ -61,12 +61,12 @@ describe('transportation types store', () => {
     expect(fetchWrapper.get).toHaveBeenCalledTimes(1)
   })
 
-  it('getTitle returns title or fallback', async () => {
+  it('getName returns name or fallback', async () => {
     const store = useTransportationTypesStore()
-    fetchWrapper.get.mockResolvedValueOnce([{ id: 2, title: 'Авиа' }])
+    fetchWrapper.get.mockResolvedValueOnce([{ id: 2, name: 'Авиа' }])
     await store.getAll()
 
-    expect(store.getTitle(2)).toBe('Авиа')
-    expect(store.getTitle(5)).toBe('Тип 5')
+    expect(store.getName(2)).toBe('Авиа')
+    expect(store.getName(5)).toBe('Тип 5')
   })
 })

--- a/tests/transportation.types.store.spec.js
+++ b/tests/transportation.types.store.spec.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useTransportationTypesStore } from '@/stores/transportation.types.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: { get: vi.fn() }
+}))
+
+vi.mock('@/helpers/config.js', () => ({
+  apiUrl: 'http://localhost:8080/api'
+}))
+
+describe('transportation types store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('initializes with defaults', () => {
+    const store = useTransportationTypesStore()
+    expect(store.types).toEqual([])
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('fetches types successfully', async () => {
+    const data = [ { id: 1, title: 'Авто' } ]
+    fetchWrapper.get.mockResolvedValue(data)
+
+    const store = useTransportationTypesStore()
+    await store.getAll()
+
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/transportationtypes`)
+    expect(store.types).toEqual(data)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('handles fetch error', async () => {
+    const err = new Error('fail')
+    fetchWrapper.get.mockRejectedValue(err)
+
+    const store = useTransportationTypesStore()
+    await store.getAll()
+
+    expect(store.error).toBe(err)
+    expect(store.loading).toBe(false)
+  })
+
+  it('ensureLoaded loads only once', async () => {
+    const data = [ { id: 1, title: 'Авто' } ]
+    fetchWrapper.get.mockResolvedValue(data)
+    const store = useTransportationTypesStore()
+
+    store.ensureLoaded()
+    store.ensureLoaded()
+    await Promise.resolve()
+
+    expect(fetchWrapper.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('getTitle returns title or fallback', async () => {
+    const store = useTransportationTypesStore()
+    fetchWrapper.get.mockResolvedValueOnce([{ id: 2, title: 'Авиа' }])
+    await store.getAll()
+
+    expect(store.getTitle(2)).toBe('Авиа')
+    expect(store.getTitle(5)).toBe('Тип 5')
+  })
+})


### PR DESCRIPTION
## Summary
- show destination country and invoice details in register list
- translate destination country using stored country list
- load transportation types and customs procedures on app startup and display names
- expose new helpers in countries store
- add stores and tests for transportation types and customs procedures
- update component and tests to cover new helpers

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6884aedfe158832195862e84c1ae900d