### PR TITLE
Add approval and FEACN order toggle API calls

### DIFF
--- a/src/stores/feacn.codes.store.js
+++ b/src/stores/feacn.codes.store.js
@@ -62,6 +62,32 @@ export const useFeacnCodesStore = defineStore('feacn.codes', () => {
     }
   }
 
+  async function enable(orderId) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.post(`${baseUrl}/orders/${orderId}/enable`)
+      await getOrders()
+    } catch (err) {
+      error.value = err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function disable(orderId) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.post(`${baseUrl}/orders/${orderId}/disable`)
+      await getOrders()
+    } catch (err) {
+      error.value = err
+    } finally {
+      loading.value = false
+    }
+  }
+
   return { 
     orders, 
     prefixes, 
@@ -69,8 +95,10 @@ export const useFeacnCodesStore = defineStore('feacn.codes', () => {
     error, 
     isInitialized, 
     getOrders, 
-    getPrefixes, 
-    update, 
-    ensureOrdersLoaded 
+    getPrefixes,
+    update,
+    enable,
+    disable,
+    ensureOrdersLoaded
   }
 })

--- a/src/stores/parcels.store.js
+++ b/src/stores/parcels.store.js
@@ -94,6 +94,11 @@ export const useParcelsStore = defineStore('parcels', () => {
       return true
   }
 
+  async function approve(id) {
+      await fetchWrapper.post(`${baseUrl}/${id}/approve`)
+      return true
+  }
+
   return {
     items,
     item,
@@ -107,6 +112,7 @@ export const useParcelsStore = defineStore('parcels', () => {
     update,
     generate,
     generateAll,
-    validate
+    validate,
+    approve
   }
 })

--- a/tests/feacn.codes.store.spec.js
+++ b/tests/feacn.codes.store.spec.js
@@ -50,4 +50,24 @@ describe('feacn.codes store', () => {
 
     expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/update`)
   })
+
+  it('calls enable endpoint', async () => {
+    fetchWrapper.post.mockResolvedValue({})
+    fetchWrapper.get.mockResolvedValue([])
+
+    const store = useFeacnCodesStore()
+    await store.enable(3)
+
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/3/enable`)
+  })
+
+  it('calls disable endpoint', async () => {
+    fetchWrapper.post.mockResolvedValue({})
+    fetchWrapper.get.mockResolvedValue([])
+
+    const store = useFeacnCodesStore()
+    await store.disable(4)
+
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/4/disable`)
+  })
 })

--- a/tests/parcels.store.spec.js
+++ b/tests/parcels.store.spec.js
@@ -207,4 +207,26 @@ describe('parcels store', () => {
       expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/orders/789/validate`)
     })
   })
+
+  describe('approve method', () => {
+    it('calls approve endpoint with correct id', async () => {
+      fetchWrapper.post.mockResolvedValue(undefined)
+
+      const store = useParcelsStore()
+      const result = await store.approve(123)
+
+      expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/orders/123/approve`)
+      expect(result).toBe(true)
+    })
+
+    it('throws error when approve fails', async () => {
+      const error = new Error('Approval failed')
+      fetchWrapper.post.mockRejectedValue(error)
+
+      const store = useParcelsStore()
+
+      await expect(store.approve(123)).rejects.toThrow('Approval failed')
+      expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/orders/123/approve`)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- add `approve` call to parcels store
- add `enable`/`disable` calls to FEACN codes store
- extend unit tests for new store actions

## Testing
- `npx -y vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68862f7d5d3c8321aaab0b5272255a38