### PR TITLE
Add navigation for next issue and improve export

### DIFF
--- a/src/components/OzonParcel_EditDialog.vue
+++ b/src/components/OzonParcel_EditDialog.vue
@@ -35,7 +35,6 @@ import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
 import { useCountriesStore } from '@/stores/countries.store.js'
 import { storeToRefs } from 'pinia'
 import { ref, watch } from 'vue'
-import { useAuthStore } from '@/stores/auth.store.js'
 import { findNextIssueParcel } from '@/helpers/parcel.navigation.js'
 import { ozonRegisterColumnTitles, ozonRegisterColumnTooltips } from '@/helpers/ozon.register.mapping.js'
 import { HasIssues, getCheckStatusInfo, getCheckStatusClass } from '@/helpers/orders.check.helper.js'
@@ -53,7 +52,6 @@ const parcelCheckStatusStore = useParcelCheckStatusStore()
 const stopWordsStore = useStopWordsStore()
 const feacnCodesStore = useFeacnCodesStore()
 const countriesStore = useCountriesStore()
-const authStore = useAuthStore()
 
 const goNext = ref(false)
 

--- a/src/components/OzonParcels_List.vue
+++ b/src/components/OzonParcels_List.vue
@@ -153,7 +153,7 @@ function editParcel(item) {
 }
 
 function exportParcelXml(item) {
-  parcelsStore.generate(item.id)
+  parcelsStore.exportXml(item.id)
 }
 
 async function validateParcel(item) {

--- a/src/components/WbrParcel_EditDialog.vue
+++ b/src/components/WbrParcel_EditDialog.vue
@@ -35,7 +35,6 @@ import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
 import { useCountriesStore } from '@/stores/countries.store.js'
 import { storeToRefs } from 'pinia'
 import { ref, watch } from 'vue'
-import { useAuthStore } from '@/stores/auth.store.js'
 import { findNextIssueParcel } from '@/helpers/parcel.navigation.js'
 import { wbrRegisterColumnTitles, wbrRegisterColumnTooltips } from '@/helpers/wbr.register.mapping.js'
 import { HasIssues, getCheckStatusInfo, getCheckStatusClass } from '@/helpers/orders.check.helper.js'
@@ -53,7 +52,6 @@ const parcelCheckStatusStore = useParcelCheckStatusStore()
 const stopWordsStore = useStopWordsStore()
 const feacnCodesStore = useFeacnCodesStore()
 const countriesStore = useCountriesStore()
-const authStore = useAuthStore()
 
 const goNext = ref(false)
 

--- a/src/components/WbrParcel_EditDialog.vue
+++ b/src/components/WbrParcel_EditDialog.vue
@@ -34,7 +34,9 @@ import { useStopWordsStore } from '@/stores/stop.words.store.js'
 import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
 import { useCountriesStore } from '@/stores/countries.store.js'
 import { storeToRefs } from 'pinia'
-import { ref, watch, } from 'vue'
+import { ref, watch } from 'vue'
+import { useAuthStore } from '@/stores/auth.store.js'
+import { findNextIssueParcel } from '@/helpers/parcel.navigation.js'
 import { wbrRegisterColumnTitles, wbrRegisterColumnTooltips } from '@/helpers/wbr.register.mapping.js'
 import { HasIssues, getCheckStatusInfo, getCheckStatusClass } from '@/helpers/orders.check.helper.js'
 import { getFieldTooltip } from '@/helpers/parcel.tooltip.helpers.js'
@@ -51,6 +53,9 @@ const parcelCheckStatusStore = useParcelCheckStatusStore()
 const stopWordsStore = useStopWordsStore()
 const feacnCodesStore = useFeacnCodesStore()
 const countriesStore = useCountriesStore()
+const authStore = useAuthStore()
+
+const goNext = ref(false)
 
 const { item } = storeToRefs(parcelsStore)
 const { stopWords } = storeToRefs(stopWordsStore)
@@ -81,11 +86,23 @@ const schema = Yup.object().shape({
   unitPrice: Yup.number().nullable().min(0, 'Цена не может быть отрицательной')
 })
 
-function onSubmit(values, { setErrors }) {
-  return parcelsStore
-    .update(props.id, values)
-    .then(() => router.push(`/registers/${props.registerId}/parcels`))
-    .catch((error) => setErrors({ apiError: error.message || String(error) }))
+async function onSubmit(values, { setErrors }) {
+  try {
+    await parcelsStore.update(props.id, values)
+    if (goNext.value) {
+      const nextId = await findNextIssueParcel(parcelsStore, props.registerId, props.id)
+      goNext.value = false
+      if (nextId) {
+        router.push(`/registers/${props.registerId}/parcels/edit/${nextId}`)
+      } else {
+        router.push(`/registers/${props.registerId}/parcels`)
+      }
+    } else {
+      router.push(`/registers/${props.registerId}/parcels`)
+    }
+  } catch (error) {
+    setErrors({ apiError: error.message || String(error) })
+  }
 }
 
 
@@ -110,6 +127,10 @@ async function approveParcel() {
     console.error('Failed to approve parcel:', error)
     parcelsStore.error = error?.response?.data?.message || 'Ошибка при согласовании посылки'
   }
+}
+
+function saveAndNext() {
+  goNext.value = true
 }
 </script>
 
@@ -187,6 +208,10 @@ async function approveParcel() {
       <!-- Action buttons -->
 
       <div class="form-actions">
+        <button class="button primary" type="submit" :disabled="isSubmitting" @click="saveAndNext">
+          <span v-show="isSubmitting" class="spinner-border spinner-border-sm mr-1"></span>
+          Следующая проблема
+        </button>
         <button class="button primary" type="submit" :disabled="isSubmitting">
           <span v-show="isSubmitting" class="spinner-border spinner-border-sm mr-1"></span>
           Сохранить

--- a/src/components/WbrParcels_List.vue
+++ b/src/components/WbrParcels_List.vue
@@ -160,7 +160,7 @@ function editParcel(item) {
 }
 
 function exportParcelXml(item) {
-  parcelsStore.generate(item.id)
+  parcelsStore.exportXml(item.id)
 }
 
 async function validateParcel(item) {

--- a/src/helpers/parcel.navigation.js
+++ b/src/helpers/parcel.navigation.js
@@ -1,0 +1,53 @@
+import { useAuthStore } from '@/stores/auth.store.js'
+import { HasIssues } from '@/helpers/orders.check.helper.js'
+
+/**
+ * Find next parcel with issues based on persistent sort order
+ * @param {Object} parcelsStore - parcels pinia store
+ * @param {number} registerId - current register id
+ * @param {number} currentId - id of currently edited parcel
+ * @returns {Promise<number|null>} id of next parcel with issues or null if none
+ */
+export async function findNextIssueParcel(parcelsStore, registerId, currentId) {
+  const authStore = useAuthStore()
+
+  let page = authStore.parcels_page.value
+  const pageSize = authStore.parcels_per_page.value
+  const sortKey = authStore.parcels_sort_by.value?.[0]?.key || 'id'
+  const sortOrder = authStore.parcels_sort_by.value?.[0]?.order || 'asc'
+  const status = authStore.parcels_status.value
+  const tnVed = authStore.parcels_tnved.value
+
+  let foundCurrent = false
+  while (true) {
+    await parcelsStore.getAll(
+      registerId,
+      status ? Number(status) : null,
+      tnVed || null,
+      page,
+      pageSize,
+      sortKey,
+      sortOrder
+    )
+
+    const issueItems = parcelsStore.items.filter(p => HasIssues(p.checkStatusId))
+
+    if (!foundCurrent) {
+      const idx = issueItems.findIndex(p => p.id === currentId)
+      if (idx >= 0) {
+        foundCurrent = true
+        if (idx + 1 < issueItems.length) {
+          return issueItems[idx + 1].id
+        }
+      }
+    } else if (issueItems.length) {
+      return issueItems[0].id
+    }
+
+    if (!parcelsStore.hasNextPage) break
+    page += 1
+  }
+
+  return null
+}
+

--- a/src/stores/parcels.store.js
+++ b/src/stores/parcels.store.js
@@ -84,6 +84,11 @@ export const useParcelsStore = defineStore('parcels', () => {
     console.log('stub generate parcel XML', id)
   }
 
+  async function exportXml(id) {
+    // Export invoice XML for a specific parcel - stub implementation
+    console.log('stub export parcel XML', id)
+  }
+
   async function generateAll(registerId) {
     // Generate XML for all parcels in a register - stub implementation
     console.log('stub generate all parcels XML', registerId)
@@ -110,6 +115,7 @@ export const useParcelsStore = defineStore('parcels', () => {
     getAll,
     getById,
     update,
+    exportXml,
     generate,
     generateAll,
     validate,

--- a/tests/OzonParcel_EditDialog.spec.js
+++ b/tests/OzonParcel_EditDialog.spec.js
@@ -10,6 +10,12 @@ vi.mock('@/router', () => ({
   default: { push: vi.fn() }
 }))
 
+// Mock helper for finding next issue
+const nextIssueMock = vi.fn().mockResolvedValue(null)
+vi.mock('@/helpers/parcel.navigation.js', () => ({
+  findNextIssueParcel: () => nextIssueMock()
+}))
+
 // Mock Pinia's storeToRefs to return the mock values
 vi.mock('pinia', async () => {
   const actual = await vi.importActual('pinia')
@@ -210,9 +216,10 @@ describe('OzonParcel_EditDialog', () => {
 
   it('renders save and cancel buttons', () => {
     const buttons = wrapper.findAll('button')
-    expect(buttons.length).toBeGreaterThanOrEqual(2)
+    expect(buttons.length).toBeGreaterThanOrEqual(3)
 
     const buttonTexts = buttons.map(btn => btn.text())
+    expect(buttonTexts).toContain('Следующая проблема')
     expect(buttonTexts).toContain('Сохранить')
     expect(buttonTexts).toContain('Отменить')
   })
@@ -231,6 +238,17 @@ describe('OzonParcel_EditDialog', () => {
 
   it('loads stopwords on mount', () => {
     expect(mockStopWordsStore.getAll).toHaveBeenCalled()
+  })
+
+  it('calls helper and navigates when saveAndNext is used', async () => {
+    nextIssueMock.mockResolvedValue(5)
+    const buttons = wrapper.findAll('button')
+    await buttons[0].trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(nextIssueMock).toHaveBeenCalled()
+    const router = (await import('@/router')).default
+    expect(router.push).toHaveBeenCalledWith('/registers/1/parcels/edit/5')
   })
 
   describe('Status Cell Styling', () => {

--- a/tests/OzonParcels_List.spec.js
+++ b/tests/OzonParcels_List.spec.js
@@ -76,7 +76,8 @@ vi.mock('@/stores/parcels.store.js', () => ({
     hasNextPage: false,
     hasPreviousPage: false,
     getAll: vi.fn(),
-    validate: vi.fn()
+    validate: vi.fn(),
+    exportXml: vi.fn()
   })
 }))
 
@@ -286,6 +287,21 @@ describe('OzonParcels_List', () => {
 
     // The validate function should be called with the order id
     expect(wrapper.vm.parcelsStore.validate).toHaveBeenCalledWith(123)
+  })
+
+  it('exportParcelXml calls store exportXml method', async () => {
+    const wrapper = mount(ParcelsList, {
+      props: { registerId: 1 },
+      global: {
+        plugins: [pinia],
+        stubs: globalStubs
+      }
+    })
+
+    const testOrder = { id: 321 }
+    await wrapper.vm.exportParcelXml(testOrder)
+
+    expect(wrapper.vm.parcelsStore.exportXml).toHaveBeenCalledWith(321)
   })
 
   it('marks rows with issues using getRowProps', () => {

--- a/tests/WbrParcel_EditDialog.spec.js
+++ b/tests/WbrParcel_EditDialog.spec.js
@@ -10,6 +10,11 @@ vi.mock('@/router', () => ({
   default: { push: vi.fn() }
 }))
 
+const nextIssueMock = vi.fn().mockResolvedValue(null)
+vi.mock('@/helpers/parcel.navigation.js', () => ({
+  findNextIssueParcel: () => nextIssueMock()
+}))
+
 // Mock Pinia's storeToRefs to return the mock values
 vi.mock('pinia', async () => {
   const actual = await vi.importActual('pinia')
@@ -208,9 +213,10 @@ describe('WbrParcel_EditDialog', () => {
 
   it('renders save and cancel buttons', () => {
     const buttons = wrapper.findAll('button')
-    expect(buttons.length).toBeGreaterThanOrEqual(2)
+    expect(buttons.length).toBeGreaterThanOrEqual(3)
 
     const buttonTexts = buttons.map(btn => btn.text())
+    expect(buttonTexts).toContain('Следующая проблема')
     expect(buttonTexts).toContain('Сохранить')
     expect(buttonTexts).toContain('Отменить')
   })
@@ -229,6 +235,17 @@ describe('WbrParcel_EditDialog', () => {
 
   it('loads stopwords on mount', () => {
     expect(mockStopWordsStore.getAll).toHaveBeenCalled()
+  })
+
+  it('calls helper and navigates when saveAndNext is used', async () => {
+    nextIssueMock.mockResolvedValue(7)
+    const buttons = wrapper.findAll('button')
+    await buttons[0].trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(nextIssueMock).toHaveBeenCalled()
+    const router = (await import('@/router')).default
+    expect(router.push).toHaveBeenCalledWith('/registers/1/parcels/edit/7')
   })
 
   describe('Status Cell Styling', () => {

--- a/tests/WbrParcels_List.spec.js
+++ b/tests/WbrParcels_List.spec.js
@@ -76,7 +76,8 @@ vi.mock('@/stores/parcels.store.js', () => ({
     hasNextPage: false,
     hasPreviousPage: false,
     getAll: vi.fn(),
-    validate: vi.fn()
+    validate: vi.fn(),
+    exportXml: vi.fn()
   })
 }))
 
@@ -286,6 +287,21 @@ describe('WbrParcels_List', () => {
 
     // The validate function should be called with the order id
     expect(wrapper.vm.parcelsStore.validate).toHaveBeenCalledWith(123)
+  })
+
+  it('exportParcelXml calls store exportXml method', async () => {
+    const wrapper = mount(ParcelsList, {
+      props: { registerId: 1 },
+      global: {
+        plugins: [pinia],
+        stubs: globalStubs
+      }
+    })
+
+    const testOrder = { id: 321 }
+    await wrapper.vm.exportParcelXml(testOrder)
+
+    expect(wrapper.vm.parcelsStore.exportXml).toHaveBeenCalledWith(321)
   })
 
   it('marks rows with issues using getRowProps', () => {

--- a/tests/parcel.navigation.spec.js
+++ b/tests/parcel.navigation.spec.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { findNextIssueParcel } from '@/helpers/parcel.navigation.js'
+
+const mockAuthStore = {
+  parcels_page: ref(1),
+  parcels_per_page: ref(3),
+  parcels_sort_by: ref([{ key: 'id', order: 'asc' }]),
+  parcels_status: ref(null),
+  parcels_tnved: ref('')
+}
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: () => mockAuthStore
+}))
+
+describe('findNextIssueParcel', () => {
+  let mockStore
+
+  beforeEach(() => {
+    mockStore = {
+      items: [],
+      hasNextPage: false,
+      getAll: vi.fn(async (registerId, status, tnVed, page) => {
+        if (page === 1) {
+          mockStore.items = [
+            { id: 1, checkStatusId: 150 },
+            { id: 2, checkStatusId: 50 },
+            { id: 3, checkStatusId: 150 }
+          ]
+          mockStore.hasNextPage = true
+        } else if (page === 2) {
+          mockStore.items = [
+            { id: 4, checkStatusId: 150 }
+          ]
+          mockStore.hasNextPage = false
+        }
+      })
+    }
+  })
+
+  it('returns next issue id on the same page', async () => {
+    const result = await findNextIssueParcel(mockStore, 1, 1)
+    expect(result).toBe(3)
+  })
+
+  it('returns issue id from next page when current is last on page', async () => {
+    const result = await findNextIssueParcel(mockStore, 1, 3)
+    expect(result).toBe(4)
+  })
+
+  it('returns null when there is no next issue', async () => {
+    const result = await findNextIssueParcel(mockStore, 1, 4)
+    expect(result).toBeNull()
+  })
+})
+

--- a/tests/parcels.store.spec.js
+++ b/tests/parcels.store.spec.js
@@ -165,6 +165,16 @@ describe('parcels store', () => {
   })
 
   describe('generate methods', () => {
+    it('exportXml calls with correct id', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      const store = useParcelsStore()
+      await store.exportXml(321)
+
+      expect(consoleSpy).toHaveBeenCalledWith('stub export parcel XML', 321)
+      consoleSpy.mockRestore()
+    })
+
     it('generate calls with correct id', async () => {
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 


### PR DESCRIPTION
## Summary
- create `findNextIssueParcel` helper to jump to the next problematic parcel
- support new helper in Ozon and WBR parcel edit dialogs
- add `exportXml` method to parcels store and use it from parcel lists
- expose new "Следующая проблема" button in edit dialogs
- test new helper and updated components

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68863ea5734083218c0b14e126ee0e88