### PR TITLE
Add match types retrieval to stop words store

### DIFF
--- a/src/stores/stop.words.store.js
+++ b/src/stores/stop.words.store.js
@@ -34,6 +34,7 @@ export const useStopWordsStore = defineStore('stopWords', () => {
   const stopWords = ref([])
   const stopWord = ref({ loading: true })
   const loading = ref(false)
+  const matchTypes = ref([])
 
   async function getAll() {
     loading.value = true
@@ -96,6 +97,17 @@ export const useStopWordsStore = defineStore('stopWords', () => {
     }
   }
 
+  async function matchtypes() {
+    try {
+      const response = await fetchWrapper.get(`${baseUrl}/matchtypes`)
+      matchTypes.value = response || []
+      return matchTypes.value
+    } catch (error) {
+      console.error('Failed to fetch stop word match types:', error)
+      throw error
+    }
+  }
+
   return {
     stopWords,
     stopWord,
@@ -104,6 +116,8 @@ export const useStopWordsStore = defineStore('stopWords', () => {
     getById,
     create,
     update,
-    remove
+    remove,
+    matchtypes,
+    matchTypes
   }
 })

--- a/tests/stop.words.store.spec.js
+++ b/tests/stop.words.store.spec.js
@@ -42,6 +42,7 @@ describe('stop.words.store.js', () => {
       expect(store.stopWords).toEqual([])
       expect(store.stopWord).toEqual({ loading: true })
       expect(store.loading).toBe(false)
+      expect(store.matchTypes).toEqual([])
     })
 
     it('has all required methods', () => {
@@ -50,6 +51,7 @@ describe('stop.words.store.js', () => {
       expect(typeof store.create).toBe('function')
       expect(typeof store.update).toBe('function')
       expect(typeof store.remove).toBe('function')
+      expect(typeof store.matchtypes).toBe('function')
     })
   })
 
@@ -294,6 +296,30 @@ describe('stop.words.store.js', () => {
 
       await expect(store.remove(1)).rejects.toThrow('Delete failed')
       expect(fetchWrapper.get).not.toHaveBeenCalled()
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('matchtypes', () => {
+    it('fetches match types successfully', async () => {
+      const types = [ { id: 1, name: 'Exact' } ]
+      fetchWrapper.get.mockResolvedValue(types)
+
+      const result = await store.matchtypes()
+
+      expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:3000/api/stopwords/matchtypes')
+      expect(store.matchTypes).toEqual(types)
+      expect(result).toEqual(types)
+    })
+
+    it('handles fetch error', async () => {
+      const error = new Error('fail')
+      fetchWrapper.get.mockRejectedValue(error)
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      await expect(store.matchtypes()).rejects.toThrow('fail')
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch stop word match types:', error)
 
       consoleSpy.mockRestore()
     })


### PR DESCRIPTION
## Summary
- add `matchtypes` API call in stop.words.store and store results
- test new matchtypes behaviour

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688a34ee044483218000bee01f0a9c57