### PR TITLE
Refactor matchtype store

### DIFF
--- a/src/stores/stop.word.matchtypes.store.js
+++ b/src/stores/stop.word.matchtypes.store.js
@@ -1,0 +1,52 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/stopwords`
+
+export const useStopWordMatchTypesStore = defineStore('stopWordMatchTypes', () => {
+  const matchTypes = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+
+  const matchTypeMap = ref(new Map())
+
+  async function fetchMatchTypes() {
+    loading.value = true
+    error.value = null
+    try {
+      const response = await fetchWrapper.get(`${baseUrl}/matchtypes`)
+      matchTypes.value = response || []
+      matchTypeMap.value = new Map(matchTypes.value.map(t => [t.id, t]))
+    } catch (err) {
+      error.value = err
+      console.error('Failed to fetch stop word match types:', err)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function getName(id) {
+    const type = matchTypeMap.value.get(id)
+    return type ? type.name : `Тип ${id}`
+  }
+
+  let initialized = false
+  function ensureLoaded() {
+    if (!initialized && matchTypes.value.length === 0 && !loading.value) {
+      initialized = true
+      fetchMatchTypes()
+    }
+  }
+
+  return {
+    matchTypes,
+    loading,
+    error,
+    matchTypeMap,
+    fetchMatchTypes,
+    getName,
+    ensureLoaded
+  }
+})

--- a/src/stores/stop.word.matchtypes.store.js
+++ b/src/stores/stop.word.matchtypes.store.js
@@ -32,10 +32,10 @@ export const useStopWordMatchTypesStore = defineStore('stopWordMatchTypes', () =
     return type ? type.name : `Тип ${id}`
   }
 
-  let initialized = false
+  const initialized = ref(false)
   function ensureLoaded() {
-    if (!initialized && matchTypes.value.length === 0 && !loading.value) {
-      initialized = true
+    if (!initialized.value && matchTypes.value.length === 0 && !loading.value) {
+      initialized.value = true
       fetchMatchTypes()
     }
   }

--- a/src/stores/stop.words.store.js
+++ b/src/stores/stop.words.store.js
@@ -34,7 +34,6 @@ export const useStopWordsStore = defineStore('stopWords', () => {
   const stopWords = ref([])
   const stopWord = ref({ loading: true })
   const loading = ref(false)
-  const matchTypes = ref([])
 
   async function getAll() {
     loading.value = true
@@ -97,16 +96,6 @@ export const useStopWordsStore = defineStore('stopWords', () => {
     }
   }
 
-  async function matchtypes() {
-    try {
-      const response = await fetchWrapper.get(`${baseUrl}/matchtypes`)
-      matchTypes.value = response || []
-      return matchTypes.value
-    } catch (error) {
-      console.error('Failed to fetch stop word match types:', error)
-      throw error
-    }
-  }
 
   return {
     stopWords,
@@ -116,8 +105,6 @@ export const useStopWordsStore = defineStore('stopWords', () => {
     getById,
     create,
     update,
-    remove,
-    matchtypes,
-    matchTypes
+    remove
   }
 })

--- a/tests/stop.word.matchtypes.store.spec.js
+++ b/tests/stop.word.matchtypes.store.spec.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useStopWordMatchTypesStore } from '@/stores/stop.word.matchtypes.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: { get: vi.fn() }
+}))
+
+vi.mock('@/helpers/config.js', () => ({
+  apiUrl: 'http://localhost:8080/api'
+}))
+
+describe('stop word matchtypes store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('initializes with defaults', () => {
+    const store = useStopWordMatchTypesStore()
+    expect(store.matchTypes).toEqual([])
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('fetches match types successfully', async () => {
+    const data = [{ id: 1, name: 'Exact' }]
+    fetchWrapper.get.mockResolvedValue(data)
+
+    const store = useStopWordMatchTypesStore()
+    await store.fetchMatchTypes()
+
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/stopwords/matchtypes`)
+    expect(store.matchTypes).toEqual(data)
+    expect(store.matchTypeMap.size).toBe(1)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('handles fetch error', async () => {
+    const err = new Error('fail')
+    fetchWrapper.get.mockRejectedValue(err)
+
+    const store = useStopWordMatchTypesStore()
+    await store.fetchMatchTypes()
+
+    expect(store.error).toBe(err)
+    expect(store.loading).toBe(false)
+  })
+
+  it('ensureLoaded loads only once', async () => {
+    const data = [{ id: 1, name: 'Exact' }]
+    fetchWrapper.get.mockResolvedValue(data)
+    const store = useStopWordMatchTypesStore()
+
+    store.ensureLoaded()
+    store.ensureLoaded()
+    await Promise.resolve()
+
+    expect(fetchWrapper.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('getName returns name or fallback', async () => {
+    const store = useStopWordMatchTypesStore()
+    fetchWrapper.get.mockResolvedValueOnce([{ id: 2, name: 'Partial' }])
+    await store.fetchMatchTypes()
+
+    expect(store.getName(2)).toBe('Partial')
+    expect(store.getName(5)).toBe('Тип 5')
+  })
+})

--- a/tests/stop.words.store.spec.js
+++ b/tests/stop.words.store.spec.js
@@ -42,7 +42,6 @@ describe('stop.words.store.js', () => {
       expect(store.stopWords).toEqual([])
       expect(store.stopWord).toEqual({ loading: true })
       expect(store.loading).toBe(false)
-      expect(store.matchTypes).toEqual([])
     })
 
     it('has all required methods', () => {
@@ -51,7 +50,6 @@ describe('stop.words.store.js', () => {
       expect(typeof store.create).toBe('function')
       expect(typeof store.update).toBe('function')
       expect(typeof store.remove).toBe('function')
-      expect(typeof store.matchtypes).toBe('function')
     })
   })
 
@@ -301,29 +299,6 @@ describe('stop.words.store.js', () => {
     })
   })
 
-  describe('matchtypes', () => {
-    it('fetches match types successfully', async () => {
-      const types = [ { id: 1, name: 'Exact' } ]
-      fetchWrapper.get.mockResolvedValue(types)
-
-      const result = await store.matchtypes()
-
-      expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:3000/api/stopwords/matchtypes')
-      expect(store.matchTypes).toEqual(types)
-      expect(result).toEqual(types)
-    })
-
-    it('handles fetch error', async () => {
-      const error = new Error('fail')
-      fetchWrapper.get.mockRejectedValue(error)
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-      await expect(store.matchtypes()).rejects.toThrow('fail')
-      expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch stop word match types:', error)
-
-      consoleSpy.mockRestore()
-    })
-  })
 
   describe('Store State Management', () => {
     it('maintains reactive state', async () => {


### PR DESCRIPTION
## Summary
- create new `stop.word.matchtypes.store.js`
- refactor `stop.words.store.js` to remove match type logic
- adjust tests for stop words store
- add tests for new stop word match type store

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a39d40a588321abbcdd388cd66c15