### PR TITLE
Remove matchtype helpers from stop words store

### DIFF
--- a/src/components/StopWord_Settings.vue
+++ b/src/components/StopWord_Settings.vue
@@ -31,6 +31,7 @@ import { toTypedSchema } from '@vee-validate/yup'
 import * as Yup from 'yup'
 import router from '@/router'
 import { useStopWordsStore } from '@/stores/stop.words.store.js'
+import { useStopWordMatchTypesStore } from '@/stores/stop.word.matchtypes.store.js'
 import { useAlertStore } from '@/stores/alert.store.js'
 
 const props = defineProps({
@@ -41,6 +42,7 @@ const props = defineProps({
 })
 
 const stopWordsStore = useStopWordsStore()
+const matchTypesStore = useStopWordMatchTypesStore()
 const alertStore = useAlertStore()
 
 const { alert } = storeToRefs(alertStore)
@@ -71,7 +73,7 @@ const { errors, handleSubmit, resetForm, setFieldValue } = useForm({
 const { value: word } = useField('word')
 const { value: matchTypeId } = useField('matchTypeId')
 
-stopWordsStore.ensureMatchTypesLoaded()
+matchTypesStore.ensureLoaded()
 
 // Ensure initial value is properly set for create mode
 onMounted(async () => {
@@ -179,7 +181,7 @@ defineExpose({
           :class="{ 'is-invalid': errors.matchTypeId }"
           v-model="matchTypeId"
         >
-          <option v-for="mt in stopWordsStore.matchTypes" :key="mt.id" :value="mt.id">
+          <option v-for="mt in matchTypesStore.matchTypes" :key="mt.id" :value="mt.id">
             {{ mt.name }}
           </option>
         </select>

--- a/src/components/StopWords_List.vue
+++ b/src/components/StopWords_List.vue
@@ -28,6 +28,7 @@ import { onMounted } from 'vue'
 import { storeToRefs } from 'pinia'
 import router from '@/router'
 import { useStopWordsStore } from '@/stores/stop.words.store.js'
+import { useStopWordMatchTypesStore } from '@/stores/stop.word.matchtypes.store.js'
 import { useAuthStore } from '@/stores/auth.store.js'
 import { useAlertStore } from '@/stores/alert.store.js'
 import { useConfirm } from 'vuetify-use-dialog'
@@ -35,6 +36,7 @@ import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
 import { mdiMagnify } from '@mdi/js'
 
 const stopWordsStore = useStopWordsStore()
+const matchTypesStore = useStopWordMatchTypesStore()
 const authStore = useAuthStore()
 const alertStore = useAlertStore()
 const confirm = useConfirm()
@@ -67,7 +69,7 @@ const headers = [
 ]
 
 function getMatchTypeText(id) {
-  return stopWordsStore.getMatchTypeName(id)
+  return matchTypesStore.getName(id)
 }
 
 function openEditDialog(item) {
@@ -109,7 +111,7 @@ async function deleteStopWord(stopWord) {
 
 // Initialize data
 onMounted(async () => {
-  stopWordsStore.ensureMatchTypesLoaded()
+  matchTypesStore.ensureLoaded()
   await stopWordsStore.getAll()
 })
 

--- a/src/stores/stop.words.store.js
+++ b/src/stores/stop.words.store.js
@@ -29,17 +29,11 @@ import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
 import { apiUrl } from '@/helpers/config.js'
 
 const baseUrl = `${apiUrl}/stopwords`
-const matchTypesUrl = `${baseUrl}/matchtypes`
-
 export const useStopWordsStore = defineStore('stopWords', () => {
   const stopWords = ref([])
   const stopWord = ref({ loading: true })
   const loading = ref(false)
   const error = ref(null)
-
-  const matchTypes = ref([])
-  const matchTypeMap = ref(new Map())
-  let matchTypesLoaded = false
 
   async function getAll() {
     loading.value = true
@@ -54,31 +48,6 @@ export const useStopWordsStore = defineStore('stopWords', () => {
     }
   }
 
-  async function getMatchTypes() {
-    loading.value = true
-    try {
-      const res = await fetchWrapper.get(matchTypesUrl)
-      matchTypes.value = res || []
-      matchTypeMap.value = new Map(matchTypes.value.map(mt => [mt.id, mt]))
-    } catch (err) {
-      error.value = err
-      throw err
-    } finally {
-      loading.value = false
-    }
-  }
-
-  function ensureMatchTypesLoaded() {
-    if (!matchTypesLoaded && matchTypes.value.length === 0) {
-      matchTypesLoaded = true
-      getMatchTypes()
-    }
-  }
-
-  function getMatchTypeName(id) {
-    const mt = matchTypeMap.value.get(id)
-    return mt ? mt.name : `Тип ${id}`
-  }
 
   async function getById(id, refresh = false) {
     if (refresh) {
@@ -144,15 +113,10 @@ export const useStopWordsStore = defineStore('stopWords', () => {
     stopWord,
     loading,
     error,
-    matchTypes,
-    matchTypeMap,
     getAll,
     getById,
     create,
     update,
-    remove,
-    getMatchTypes,
-    ensureMatchTypesLoaded,
-    getMatchTypeName
+    remove
   }
 })

--- a/tests/StopWord_Settings.spec.js
+++ b/tests/StopWord_Settings.spec.js
@@ -27,10 +27,14 @@ vi.mock('@/stores/stop.words.store.js', () => ({
   useStopWordsStore: () => ({
     getById,
     create,
-    update,
-    ensureMatchTypesLoaded: vi.fn(),
-    getMatchTypeName: vi.fn(() => 'Exact'),
-    matchTypes: ref([{ id: 1, name: 'Exact' }, { id: 41, name: 'Morphology' }])
+    update
+  })
+}))
+
+vi.mock('@/stores/stop.word.matchtypes.store.js', () => ({
+  useStopWordMatchTypesStore: () => ({
+    matchTypes: ref([{ id: 1, name: 'Exact' }, { id: 41, name: 'Morphology' }]),
+    ensureLoaded: vi.fn()
   })
 }))
 

--- a/tests/StopWords_List.spec.js
+++ b/tests/StopWords_List.spec.js
@@ -69,12 +69,15 @@ vi.mock('@/stores/stop.words.store.js', () => ({
     getById: getStopWordById,
     create: createStopWord,
     update: updateStopWord,
-    remove: removeStopWord,
-    matchTypeMap: new Map(),
-    ensureMatchTypesLoaded: vi.fn(),
-    getMatchTypeName(id) {
-      return this.matchTypeMap.get(id)?.name || `Тип ${id}`
-    }
+    remove: removeStopWord
+  })
+}))
+
+vi.mock('@/stores/stop.word.matchtypes.store.js', () => ({
+  useStopWordMatchTypesStore: () => ({
+    matchTypes: ref([{ id: 1, name: 'Exact' }, { id: 41, name: 'Morphology' }]),
+    ensureLoaded: vi.fn(),
+    getName: vi.fn(id => (id === 1 ? 'Exact' : id === 41 ? 'Morphology' : `Тип ${id}`))
   })
 }))
 
@@ -355,14 +358,13 @@ describe('StopWords_List.vue', () => {
 
   describe('Match Type Display', () => {
     it('returns correct text for known id', () => {
-      wrapper.vm.stopWordsStore.matchTypeMap.set(1, { id: 1, name: 'Exact' })
       const result = wrapper.vm.getMatchTypeText(1)
       expect(result).toBe('Exact')
     })
 
     it('returns fallback text for unknown id', () => {
       const result = wrapper.vm.getMatchTypeText(99)
-      expect(result).toBe('Тип 99')
+      expect(result).toBe(`Тип 99`)
     })
   })
 

--- a/tests/stop.words.store.spec.js
+++ b/tests/stop.words.store.spec.js
@@ -53,9 +53,6 @@ describe('stop.words.store.js', () => {
       expect(typeof store.create).toBe('function')
       expect(typeof store.update).toBe('function')
       expect(typeof store.remove).toBe('function')
-      expect(typeof store.getMatchTypes).toBe('function')
-      expect(typeof store.ensureMatchTypesLoaded).toBe('function')
-      expect(typeof store.getMatchTypeName).toBe('function')
     })
   })
 
@@ -281,24 +278,6 @@ describe('stop.words.store.js', () => {
     })
   })
 
-  describe('match types', () => {
-    it('ensureMatchTypesLoaded loads only once', async () => {
-      fetchWrapper.get.mockResolvedValue([])
-      store.ensureMatchTypesLoaded()
-      store.ensureMatchTypesLoaded()
-      await Promise.resolve()
-      expect(fetchWrapper.get).toHaveBeenCalledTimes(1)
-      expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:3000/api/stopwords/matchtypes')
-    })
-
-    it('getMatchTypeName returns name or fallback', async () => {
-      const types = [{ id: 1, name: 'Exact' }]
-      fetchWrapper.get.mockResolvedValueOnce(types)
-      await store.getMatchTypes()
-      expect(store.getMatchTypeName(1)).toBe('Exact')
-      expect(store.getMatchTypeName(99)).toBe('Тип 99')
-    })
-  })
 
   describe('Store State Management', () => {
     it('maintains reactive state', async () => {


### PR DESCRIPTION
## Summary
- drop match-type helpers from `stop.words.store`
- switch components to use `stop.word.matchtypes.store`
- update related tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688a6e9f09b083218511dc090eae49e4