### PR TITLE
Implement match type option disabling logic

### DIFF
--- a/src/components/StopWord_Settings.vue
+++ b/src/components/StopWord_Settings.vue
@@ -73,6 +73,16 @@ const { errors, handleSubmit, resetForm, setFieldValue } = useForm({
 const { value: word } = useField('word')
 const { value: matchTypeId } = useField('matchTypeId')
 
+const words = computed(() => (word.value.match(/[\p{L}\d-]+/gu) || []))
+const isSingleWordInput = computed(() => words.value.length <= 1)
+
+function isOptionDisabled(value) {
+  if (isSingleWordInput.value) {
+    return value >= 21 && value <= 30
+  }
+  return (value >= 11 && value <= 20) || value > 30
+}
+
 matchTypesStore.ensureLoaded()
 
 // Ensure initial value is properly set for create mode
@@ -143,7 +153,8 @@ function cancel() {
 defineExpose({
   onSubmit,
   cancel,
-  onWordInput
+  onWordInput,
+  isOptionDisabled
 })
 </script>
 
@@ -181,7 +192,12 @@ defineExpose({
           :class="{ 'is-invalid': errors.matchTypeId }"
           v-model="matchTypeId"
         >
-          <option v-for="mt in matchTypesStore.matchTypes" :key="mt.id" :value="mt.id">
+          <option
+            v-for="mt in matchTypesStore.matchTypes"
+            :key="mt.id"
+            :value="mt.id"
+            :disabled="isOptionDisabled(mt.id)"
+          >
             {{ mt.name }}
           </option>
         </select>

--- a/tests/StopWord_Settings.spec.js
+++ b/tests/StopWord_Settings.spec.js
@@ -33,7 +33,12 @@ vi.mock('@/stores/stop.words.store.js', () => ({
 
 vi.mock('@/stores/stop.word.matchtypes.store.js', () => ({
   useStopWordMatchTypesStore: () => ({
-    matchTypes: ref([{ id: 1, name: 'Exact' }, { id: 41, name: 'Morphology' }]),
+    matchTypes: ref([
+      { id: 1, name: 'Exact' },
+      { id: 15, name: 'Type15' },
+      { id: 25, name: 'Type25' },
+      { id: 41, name: 'Morphology' }
+    ]),
     ensureLoaded: vi.fn()
   })
 }))
@@ -156,6 +161,34 @@ describe('StopWord_Settings.vue', () => {
       await wrapper.vm.$nextTick()
 
       expect(wrapper.vm.matchTypeId).toBe(41)
+    })
+
+    it('disables options 21-30 for single word', async () => {
+      const wrapper = mountComponent()
+      await resolveAll()
+
+      const wordInput = wrapper.find('input[name="word"]')
+      await wordInput.setValue('одиночное')
+      await wordInput.trigger('input')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.vm.isOptionDisabled(25)).toBe(true)
+      expect(wrapper.vm.isOptionDisabled(15)).toBe(false)
+      expect(wrapper.vm.isOptionDisabled(41)).toBe(false)
+    })
+
+    it('disables options 11-20 and >30 for multi-word', async () => {
+      const wrapper = mountComponent()
+      await resolveAll()
+
+      const wordInput = wrapper.find('input[name="word"]')
+      await wordInput.setValue('два слова')
+      await wordInput.trigger('input')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.vm.isOptionDisabled(15)).toBe(true)
+      expect(wrapper.vm.isOptionDisabled(25)).toBe(false)
+      expect(wrapper.vm.isOptionDisabled(41)).toBe(true)
     })
   })
 


### PR DESCRIPTION
## Summary
- enable/disable stop word match type options based on how many words are entered
- expose helper and update unit tests to cover new logic

## Testing
- `npx vitest run -t "disables options"`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688a72cef0a083219e283b611010ea80