### PR TITLE
Switch to match type radio buttons

### DIFF
--- a/src/components/StopWord_Settings.vue
+++ b/src/components/StopWord_Settings.vue
@@ -184,23 +184,25 @@ defineExpose({
       </div>
 
       <div class="form-group">
-        <label for="matchTypeId" class="label">Тип соответствия:</label>
-        <select
-          id="matchTypeId"
-          name="matchTypeId"
-          class="form-control input"
-          :class="{ 'is-invalid': errors.matchTypeId }"
-          v-model="matchTypeId"
-        >
-          <option
+        <label class="label">Тип соответствия:</label>
+        <div class="radio-group" :class="{ 'is-invalid': errors.matchTypeId }">
+          <label
             v-for="mt in matchTypesStore.matchTypes"
             :key="mt.id"
-            :value="mt.id"
-            :disabled="isOptionDisabled(mt.id)"
+            class="radio-styled"
           >
+            <input
+              type="radio"
+              :id="`matchType-${mt.id}`"
+              name="matchTypeId"
+              :value="mt.id"
+              v-model="matchTypeId"
+              :disabled="isOptionDisabled(mt.id)"
+            />
+            <span class="radio-mark"></span>
             {{ mt.name }}
-          </option>
-        </select>
+          </label>
+        </div>
         <div v-if="errors.matchTypeId" class="invalid-feedback">{{ errors.matchTypeId }}</div>
       </div>
 

--- a/tests/StopWord_Settings.spec.js
+++ b/tests/StopWord_Settings.spec.js
@@ -93,7 +93,7 @@ describe('StopWord_Settings.vue', () => {
 
       expect(wrapper.find('h1').text()).toBe('Регистрация стоп-слова или фразы')
       expect(wrapper.find('input[name="word"]').exists()).toBe(true)
-      expect(wrapper.find('select[name="matchTypeId"]').exists()).toBe(true)
+      expect(wrapper.findAll('input[type="radio"][name="matchTypeId"]').length).toBeGreaterThan(0)
       expect(wrapper.find('button[type="submit"]').text()).toContain('Сохранить')
     })
 
@@ -123,12 +123,12 @@ describe('StopWord_Settings.vue', () => {
       expect(wordInput.attributes('placeholder')).toBe('Стоп-слово или фраза')
     })
 
-    it('renders matchTypeId select', async () => {
+    it('renders matchTypeId radios', async () => {
       const wrapper = mountComponent()
       await resolveAll()
 
-      const select = wrapper.find('select[name="matchTypeId"]')
-      expect(select.exists()).toBe(true)
+      const radios = wrapper.findAll('input[type="radio"][name="matchTypeId"]')
+      expect(radios.length).toBeGreaterThan(0)
     })
 
     it('renders form labels correctly', async () => {


### PR DESCRIPTION
## Summary
- use radio buttons in StopWord settings to choose match type
- update match type tests to reflect new radio inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a7a1149f4832183d643c123ae92b9