### PR TITLE
Add register XML generation support

### DIFF
--- a/src/components/Registers_List.vue
+++ b/src/components/Registers_List.vue
@@ -27,7 +27,6 @@
 import { watch, ref, onMounted, onUnmounted, reactive, computed } from 'vue'
 import { OZON_COMPANY_ID, WBR_COMPANY_ID } from '@/helpers/company.constants.js'
 import { useRegistersStore } from '@/stores/registers.store.js'
-import { useParcelsStore } from '@/stores/parcels.store.js'
 import { useParcelStatusesStore } from '@/stores/parcel.statuses.store.js'
 import { useCompaniesStore } from '@/stores/companies.store.js'
 import { useCountriesStore } from '@/stores/countries.store.js'
@@ -56,8 +55,6 @@ const progressPercent = computed(() => {
 
 const registersStore = useRegistersStore()
 const { items, loading, error, totalCount } = storeToRefs(registersStore)
-
-const parcelsStore = useParcelsStore()
 
 const parcelStatusesStore = useParcelStatusesStore()
 
@@ -245,7 +242,7 @@ function editRegister(item) {
 }
 
 function exportAllXml(item) {
-  parcelsStore.generateAll(item.id)
+  registersStore.generate(item.id, item.invoiceNumber)
 }
 
 async function downloadRegister(item) {

--- a/src/stores/parcels.store.js
+++ b/src/stores/parcels.store.js
@@ -99,10 +99,6 @@ export const useParcelsStore = defineStore('parcels', () => {
     }
   }
 
-  async function generateAll(registerId) {
-    // Generate XML for all parcels in a register - stub implementation
-    console.log('stub generate all parcels XML', registerId)
-  }
 
   async function validate(id) {
       await fetchWrapper.post(`${baseUrl}/${id}/validate`)
@@ -126,7 +122,6 @@ export const useParcelsStore = defineStore('parcels', () => {
     getById,
     update,
     generate,
-    generateAll,
     validate,
     approve
   }

--- a/src/stores/registers.store.js
+++ b/src/stores/registers.store.js
@@ -131,6 +131,29 @@ export const useRegistersStore = defineStore('registers', () => {
     }
   }
 
+  async function generate(id, invoiceNumber) {
+    loading.value = true
+    error.value = null
+    try {
+      let filename
+      if (invoiceNumber !== null && invoiceNumber !== undefined) {
+        filename = `IndPost_${invoiceNumber}.xml`
+      } else {
+        filename = `IndPost_${id}.xml`
+      }
+      return await fetchWrapper.downloadFile(
+        `${baseUrl}/${id}/generate`,
+        filename
+      )
+    } catch (err) {
+      console.error('Error downloading file:', err)
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
   async function download(id, filename) {
     if (!filename) {
       filename = `register_${id}.xlsx`
@@ -193,6 +216,7 @@ export const useRegistersStore = defineStore('registers', () => {
     validate,
     getValidationProgress,
     cancelValidation,
+    generate,
     download,
     nextParcel,
     remove

--- a/tests/Registers_List.spec.js
+++ b/tests/Registers_List.spec.js
@@ -21,7 +21,7 @@ const getCountriesAll = vi.fn()
 const countriesEnsureLoadedFn = vi.fn()
 const getTransportationTypesAll = vi.fn()
 const getCustomsProceduresAll = vi.fn()
-const generateAllFn = vi.fn()
+const generateFn = vi.fn()
 const alertSuccessFn = vi.fn()
 const alertErrorFn = vi.fn()
 const validateFn = vi.fn()
@@ -74,15 +74,12 @@ vi.mock('@/stores/registers.store.js', () => ({
     getValidationProgress: getValidationProgressFn,
     cancelValidation: cancelValidationFn,
     remove: removeFn,
+    generate: generateFn,
     items: mockItems,
     loading: ref(false),
     error: ref(null),
     totalCount: ref(0)
   })
-}))
-
-vi.mock('@/stores/parcels.store.js', () => ({
-  useParcelsStore: () => ({ generateAll: generateAllFn })
 }))
 
 vi.mock('@/stores/parcel.statuses.store.js', () => ({
@@ -426,10 +423,10 @@ describe('Registers_List.vue', () => {
       expect(router.push).toHaveBeenCalledWith('/registers/123/parcels')
     })
 
-    it('calls generateAll when exportAllXml is called', () => {
-      const item = { id: 456 }
+    it('calls generate when exportAllXml is called', () => {
+      const item = { id: 456, invoiceNumber: 'INV' }
       wrapper.vm.exportAllXml(item)
-      expect(generateAllFn).toHaveBeenCalledWith(456)
+      expect(generateFn).toHaveBeenCalledWith(456, 'INV')
     })
   })
 

--- a/tests/parcels.store.spec.js
+++ b/tests/parcels.store.spec.js
@@ -190,15 +190,6 @@ describe('parcels store', () => {
       expect(console.error).toHaveBeenCalled()
     })
 
-    it('generateAll calls with correct registerId', async () => {
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-
-      const store = useParcelsStore()
-      await store.generateAll(456)
-
-      expect(consoleSpy).toHaveBeenCalledWith('stub generate all parcels XML', 456)
-      consoleSpy.mockRestore()
-    })
   })
 
   describe('validate method', () => {

--- a/tests/registers.store.spec.js
+++ b/tests/registers.store.spec.js
@@ -579,6 +579,37 @@ describe('registers store', () => {
     })
   })
 
+  describe('generate method', () => {
+    it('calls downloadFile with default filename by id when invoiceNumber missing', async () => {
+      const store = useRegistersStore()
+      fetchWrapper.downloadFile.mockResolvedValue(true)
+      const result = await store.generate(5)
+      expect(fetchWrapper.downloadFile).toHaveBeenCalledWith(
+        `${apiUrl}/registers/5/generate`,
+        'IndPost_5.xml'
+      )
+      expect(result).toBe(true)
+    })
+
+    it('calls downloadFile with invoiceNumber when provided', async () => {
+      const store = useRegistersStore()
+      fetchWrapper.downloadFile.mockResolvedValue(true)
+      await store.generate(5, 'INV')
+      expect(fetchWrapper.downloadFile).toHaveBeenCalledWith(
+        `${apiUrl}/registers/5/generate`,
+        'IndPost_INV.xml'
+      )
+    })
+
+    it('propagates error when download fails', async () => {
+      const store = useRegistersStore()
+      const error = new Error('fail')
+      fetchWrapper.downloadFile.mockRejectedValue(error)
+      await expect(store.generate(5)).rejects.toThrow('fail')
+      expect(store.error).toBe(error)
+    })
+  })
+
   describe('nextParcel method', () => {
     it('requests next parcel with correct id', async () => {
       const parcel = { id: 2 }


### PR DESCRIPTION
## Summary
- implement `generate` method in `registers.store.js`
- remove unused parcel XML generation stub
- update registers list to use register generation
- adjust related unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a85f5b1fc8321b7752a4b374f8536