### PR TITLE
Update stop words store for new controller changes

### DIFF
--- a/src/helpers/fetch.wrapper.js
+++ b/src/helpers/fetch.wrapper.js
@@ -67,17 +67,21 @@ function request(method) {
             // If server returned an error response, try to parse it
             const errorText = await response.text();
             let errorMessage;
+            let errorObj;
             try {
                 // Try to parse as JSON
-                const errorObj = JSON.parse(errorText);
+                errorObj = JSON.parse(errorText);
                 errorMessage = errorObj.msg || `Ошибка ${response.status}`;
             } catch {
                 // If not valid JSON, use text as is
                 errorMessage = errorText || `Ошибка ${response.status}`;
             }
-            
+
+            const error = new Error(errorMessage);
+            error.status = response.status;
+            if (errorObj) error.data = errorObj;
             // Re-throw the error for further handling if needed
-            throw new Error(errorMessage);
+            throw error;
         }
         
         return handleResponse(response);
@@ -111,13 +115,17 @@ function requestFile(method) {
         if (!response.ok) {
             const errorText = await response.text();
             let errorMessage;
+            let errorObj;
             try {
-                const errorObj = JSON.parse(errorText);
+                errorObj = JSON.parse(errorText);
                 errorMessage = errorObj.msg || `Ошибка ${response.status}`;
             } catch {
                 errorMessage = errorText || `Ошибка ${response.status}`;
             }
-            throw new Error(errorMessage);
+            const error = new Error(errorMessage);
+            error.status = response.status;
+            if (errorObj) error.data = errorObj;
+            throw error;
         }
 
         return handleResponse(response);
@@ -164,17 +172,21 @@ function requestBlob(method) {
             // If server returned an error response, try to parse it
             const errorText = await response.text();
             let errorMessage;
+            let errorObj;
             try {
                 // Try to parse as JSON
-                const errorObj = JSON.parse(errorText);
+                errorObj = JSON.parse(errorText);
                 errorMessage = errorObj.msg || `Ошибка ${response.status}`;
             } catch {
                 // If not valid JSON, use text as is
                 errorMessage = errorText || `Ошибка ${response.status}`;
             }
-            
+
+            const error = new Error(errorMessage);
+            error.status = response.status;
+            if (errorObj) error.data = errorObj;
             // Re-throw the error for further handling if needed
-            throw new Error(errorMessage);
+            throw error;
         }
         
         return response;

--- a/src/stores/stop.words.store.js
+++ b/src/stores/stop.words.store.js
@@ -69,9 +69,10 @@ export const useStopWordsStore = defineStore('stopWords', () => {
   async function create(data) {
     loading.value = true
     try {
-      await fetchWrapper.post(baseUrl, data)
+      const response = await fetchWrapper.post(baseUrl, data)
       // Refresh the list after creation
       await getAll()
+      return response
     } catch (err) {
       error.value = err
       throw err
@@ -83,9 +84,10 @@ export const useStopWordsStore = defineStore('stopWords', () => {
   async function update(id, data) {
     loading.value = true
     try {
-      await fetchWrapper.put(`${baseUrl}/${id}`, data)
+      const response = await fetchWrapper.put(`${baseUrl}/${id}`, data)
       // Refresh the list after update
       await getAll()
+      return response
     } catch (err) {
       error.value = err
       throw err

--- a/tests/StopWord_Settings.spec.js
+++ b/tests/StopWord_Settings.spec.js
@@ -258,8 +258,33 @@ describe('StopWord_Settings.vue', () => {
 
       // Check if error is displayed (the API error should be set in the errors object)
       const errorElements = wrapper.findAll('.alert-danger')
-      const hasErrorMessage = errorElements.some(el => 
+      const hasErrorMessage = errorElements.some(el =>
         el.text().includes('409')
+      )
+      expect(hasErrorMessage).toBe(true)
+    })
+
+    it('handles morphology error on create', async () => {
+      const err = new Error('Morphology unsupported')
+      err.status = 418
+      err.data = { word: 'abc', level: 1 }
+      create.mockRejectedValueOnce(err)
+      const wrapper = mountComponent()
+      await resolveAll()
+
+      const component = wrapper.vm
+      component.word = 'abc'
+      component.matchTypeId = 41
+
+      try {
+        await component.onSubmit()
+      } catch {}
+
+      await wrapper.vm.$nextTick()
+
+      const errorElements = wrapper.findAll('.alert-danger')
+      const hasErrorMessage = errorElements.some(el =>
+        el.text().includes('Morphology unsupported')
       )
       expect(hasErrorMessage).toBe(true)
     })


### PR DESCRIPTION
## Summary
- propagate HTTP status and payload in `fetch.wrapper`
- return API responses from `stop.words.store` create and update
- adjust store tests for return values and new 418 status
- ensure StopWord Settings handles morphology errors

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688ab3c987348321b1ccecedae754d3f