### PR TITLE
Add https prefix to product links

### DIFF
--- a/src/components/OzonParcel_EditDialog.vue
+++ b/src/components/OzonParcel_EditDialog.vue
@@ -34,12 +34,13 @@ import { useStopWordsStore } from '@/stores/stop.words.store.js'
 import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
 import { useCountriesStore } from '@/stores/countries.store.js'
 import { storeToRefs } from 'pinia'
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import { ozonRegisterColumnTitles, ozonRegisterColumnTooltips } from '@/helpers/ozon.register.mapping.js'
 import { HasIssues, getCheckStatusInfo, getCheckStatusClass } from '@/helpers/orders.check.helper.js'
 import { getFieldTooltip } from '@/helpers/parcel.tooltip.helpers.js'
 import { useRegistersStore } from '@/stores/registers.store.js'
 import OzonFormField from './OzonFormField.vue'
+import { ensureHttps } from '@/helpers/url.helpers.js'
 
 const props = defineProps({
   registerId: { type: Number, required: true },
@@ -70,6 +71,8 @@ const currentStatusId = ref(null)
 watch(() => item.value?.statusId, (newStatusId) => {
   currentStatusId.value = newStatusId
 }, { immediate: true })
+
+const productLinkWithProtocol = computed(() => ensureHttps(item.value?.productLink))
 
 await stopWordsStore.getAll()
 await parcelsStore.getById(props.id)
@@ -193,8 +196,15 @@ async function generateXml() {
           <OzonFormField name="productName" :errors="errors" />
           <div class="form-group">
             <label class="label">{{ ozonRegisterColumnTitles.productLink }}:</label>
-            <a v-if="item?.productLink" :href="item.productLink" target="_blank" rel="noopener noreferrer" class="product-link-inline" :title="item.productLink">
-              {{ item.productLink }}
+            <a
+              v-if="item?.productLink"
+              :href="productLinkWithProtocol"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="product-link-inline"
+              :title="productLinkWithProtocol"
+            >
+              {{ productLinkWithProtocol }}
             </a>
             <span v-else class="no-link">Ссылка отсутствует</span>
           </div>

--- a/src/components/OzonParcels_List.vue
+++ b/src/components/OzonParcels_List.vue
@@ -41,6 +41,7 @@ import { apiUrl } from '@/helpers/config.js'
 import { ozonRegisterColumnTitles, ozonRegisterColumnTooltips } from '@/helpers/ozon.register.mapping.js'
 import { HasIssues, getCheckStatusClass } from '@/helpers/orders.check.helper.js'
 import { getFieldTooltip, getCheckStatusTooltip } from '@/helpers/parcel.tooltip.helpers.js'
+import { ensureHttps } from '@/helpers/url.helpers.js'
 
 const props = defineProps({
   registerId: { type: Number, required: true }
@@ -293,13 +294,13 @@ function getGenericTemplateHeaders() {
           <div class="truncated-cell">
             <a
               v-if="item.productLink"
-              :href="item.productLink"
+              :href="ensureHttps(item.productLink)"
               target="_blank"
               rel="noopener noreferrer"
               class="product-link"
-              :title="item.productLink"
+              :title="ensureHttps(item.productLink)"
             >
-              {{ item.productLink }}
+              {{ ensureHttps(item.productLink) }}
             </a>
             <span v-else>-</span>
           </div>

--- a/src/components/WbrParcel_EditDialog.vue
+++ b/src/components/WbrParcel_EditDialog.vue
@@ -35,11 +35,12 @@ import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
 import { useCountriesStore } from '@/stores/countries.store.js'
 import { useRegistersStore } from '@/stores/registers.store.js'
 import { storeToRefs } from 'pinia'
-import { ref, watch, } from 'vue'
+import { ref, watch, computed } from 'vue'
 import { wbrRegisterColumnTitles, wbrRegisterColumnTooltips } from '@/helpers/wbr.register.mapping.js'
 import { HasIssues, getCheckStatusInfo, getCheckStatusClass } from '@/helpers/orders.check.helper.js'
 import { getFieldTooltip } from '@/helpers/parcel.tooltip.helpers.js'
 import WbrFormField from './WbrFormField.vue'
+import { ensureHttps } from '@/helpers/url.helpers.js'
 
 const props = defineProps({
   registerId: { type: Number, required: true },
@@ -66,6 +67,8 @@ const currentStatusId = ref(null)
 watch(() => item.value?.statusId, (newStatusId) => {
   currentStatusId.value = newStatusId
 }, { immediate: true })
+
+const productLinkWithProtocol = computed(() => ensureHttps(item.value?.productLink))
 
 statusStore.ensureStatusesLoaded()
 parcelCheckStatusStore.ensureStatusesLoaded()
@@ -197,8 +200,15 @@ async function generateXml() {
           <WbrFormField name="productName" :errors="errors" />
           <div class="form-group">
             <label class="label">{{ wbrRegisterColumnTitles.productLink }}:</label>
-            <a v-if="item?.productLink" :href="item.productLink" target="_blank" rel="noopener noreferrer" class="product-link-inline" :title="item.productLink">
-              {{ item.productLink }}
+            <a
+              v-if="item?.productLink"
+              :href="productLinkWithProtocol"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="product-link-inline"
+              :title="productLinkWithProtocol"
+            >
+              {{ productLinkWithProtocol }}
             </a>
             <span v-else class="no-link">Ссылка отсутствует</span>
           </div>

--- a/src/components/WbrParcels_List.vue
+++ b/src/components/WbrParcels_List.vue
@@ -41,6 +41,7 @@ import { apiUrl } from '@/helpers/config.js'
 import { wbrRegisterColumnTitles, wbrRegisterColumnTooltips } from '@/helpers/wbr.register.mapping.js'
 import { HasIssues, getCheckStatusClass } from '@/helpers/orders.check.helper.js'
 import { getFieldTooltip, getCheckStatusTooltip } from '@/helpers/parcel.tooltip.helpers.js'
+import { ensureHttps } from '@/helpers/url.helpers.js'
 
 const props = defineProps({
   registerId: { type: Number, required: true }
@@ -300,13 +301,13 @@ function getGenericTemplateHeaders() {
           <div class="truncated-cell">
             <a
               v-if="item.productLink"
-              :href="item.productLink"
+              :href="ensureHttps(item.productLink)"
               target="_blank"
               rel="noopener noreferrer"
               class="product-link"
-              :title="item.productLink"
+              :title="ensureHttps(item.productLink)"
             >
-              {{ item.productLink }}
+              {{ ensureHttps(item.productLink) }}
             </a>
             <span v-else>-</span>
           </div>

--- a/src/helpers/url.helpers.js
+++ b/src/helpers/url.helpers.js
@@ -1,0 +1,4 @@
+export function ensureHttps(url) {
+  if (!url) return url;
+  return /^(https?:)?\/\//i.test(url) ? url : `https://${url}`;
+}

--- a/tests/OzonParcel_EditDialog.spec.js
+++ b/tests/OzonParcel_EditDialog.spec.js
@@ -519,6 +519,15 @@ describe('OzonParcel_EditDialog', () => {
       expect(productLink.attributes('href')).toBe('https://example.com/product')
     })
 
+    it('adds https prefix when missing in product link', async () => {
+      mockItem.value.productLink = 'example.com/product'
+      await nextTick()
+
+      const productLink = wrapper.find('a.product-link-inline')
+      expect(productLink.exists()).toBe(true)
+      expect(productLink.attributes('href')).toBe('https://example.com/product')
+    })
+
     it('renders no link message when product link is not available', async () => {
       mockItem.value.productLink = null
       await nextTick()

--- a/tests/WbrParcel_EditDialog.spec.js
+++ b/tests/WbrParcel_EditDialog.spec.js
@@ -508,6 +508,15 @@ describe('WbrParcel_EditDialog', () => {
       expect(productLink.attributes('href')).toBe('https://example.com/product')
     })
 
+    it('adds https prefix when missing in product link', async () => {
+      mockItem.value.productLink = 'example.com/product'
+      await nextTick()
+
+      const productLink = wrapper.find('a.product-link-inline')
+      expect(productLink.exists()).toBe(true)
+      expect(productLink.attributes('href')).toBe('https://example.com/product')
+    })
+
     it('renders no link message when product link is not available', async () => {
       mockItem.value.productLink = null
       await nextTick()


### PR DESCRIPTION
## Summary
- ensure parcel links always have a protocol
- adjust parcel edit dialogs to use helper
- display corrected URLs in parcel lists
- update parcel dialog tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b15ef5f1c8321a9791e66a30f9739