### PR TITLE
feat: add register load view

### DIFF
--- a/src/components/Registers_List.vue
+++ b/src/components/Registers_List.vue
@@ -197,17 +197,15 @@ async function fileSelected(files) {
     return
   }
 
-  try {
-    await registersStore.upload(file, selectedCustomerId.value)
-    alertStore.success('Реестр успешно загружен')
-    loadRegisters()
-  } catch (err) {
-    alertStore.error(err.message || String(err))
-  } finally {
-    // Clear the file input so the same file can be selected again
-    if (fileInput.value) {
-      fileInput.value.value = null
-    }
+  registersStore.item = {
+    fileName: file.name,
+    companyId: selectedCustomerId.value
+  }
+  registersStore.uploadFile = file
+  router.push('/register/load')
+
+  if (fileInput.value) {
+    fileInput.value.value = null
   }
 }
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -160,6 +160,12 @@ const router = createRouter({
       meta: { requiresLogist: true, hideSidebar: true }
     },
     {
+      path: '/register/load',
+      name: 'Загрузка реестра',
+      component: () => import('@/views/Register_LoadView.vue'),
+      meta: { requiresLogist: true, hideSidebar: true }
+    },
+    {
       path: '/user/edit/:id',
       name: 'Настройки',
       component: () => import('@/views/User_EditView.vue'),

--- a/src/stores/registers.store.js
+++ b/src/stores/registers.store.js
@@ -9,6 +9,7 @@ const baseUrl = `${apiUrl}/registers`
 export const useRegistersStore = defineStore('registers', () => {
   const items = ref([])
   const item = ref({})
+  const uploadFile = ref(null)
   const loading = ref(false)
   const error = ref(null)
   const totalCount = ref(0)
@@ -250,6 +251,7 @@ export const useRegistersStore = defineStore('registers', () => {
     generate,
     download,
     nextParcel,
-    remove
+    remove,
+    uploadFile
   }
 })

--- a/src/views/Register_LoadView.vue
+++ b/src/views/Register_LoadView.vue
@@ -25,14 +25,10 @@
 
 <script setup>
 import RegisterEditDialog from '@/components/Register_EditDialog.vue'
-
-const props = defineProps({
-  id: { type: Number, required: true }
-})
 </script>
 
 <template>
   <Suspense>
-    <RegisterEditDialog :id="props.id" :create="false" />
+    <RegisterEditDialog :create="true" />
   </Suspense>
 </template>


### PR DESCRIPTION
## Summary
- support register loading via dedicated view and dialog
- customize register edit dialog for create mode and upload handling
- trigger load view before uploading register file

## Testing
- `npx vitest run tests/Register_EditDialog.spec.js tests/Registers_List.spec.js`

------
https://chatgpt.com/codex/tasks/task_e_688fb1aac4d4832183034c4b14d3b8e0