### PR TITLE
feat: add register cell actions

### DIFF
--- a/src/components/Registers_List.vue
+++ b/src/components/Registers_List.vue
@@ -398,35 +398,203 @@ const headers = [
         density="compact"
         class="elevation-1 interlaced-table"
       >
+        <template #[`item.dealNumber`]="{ item }">
+          <v-tooltip>
+            <template #activator="{ props }">
+              <span
+                class="open-parcels-link clickable-cell"
+                v-bind="props"
+                @click="openParcels(item)"
+              >
+                {{ item.dealNumber }}
+              </span>
+            </template>
+            <template #default>
+              <span>
+                <font-awesome-icon icon="fa-solid fa-list" class="mr-1" />Открыть список посылок
+              </span>
+            </template>
+          </v-tooltip>
+        </template>
         <template #[`item.senderId`]="{ item }">
-          {{ getCustomerName(item.senderId) }}
+          <v-tooltip>
+            <template #activator="{ props }">
+              <span
+                class="edit-register-link clickable-cell"
+                v-bind="props"
+                @click="editRegister(item)"
+              >
+                {{ getCustomerName(item.senderId) }}
+              </span>
+            </template>
+            <template #default>
+              <span>
+                <font-awesome-icon icon="fa-solid fa-pen" class="mr-1" />Редактировать реестр
+              </span>
+            </template>
+          </v-tooltip>
         </template>
         <template #[`item.recipientId`]="{ item }">
-          {{ getCustomerName(item.recipientId) }}
+          <v-tooltip>
+            <template #activator="{ props }">
+              <span
+                class="edit-register-link clickable-cell"
+                v-bind="props"
+                @click="editRegister(item)"
+              >
+                {{ getCustomerName(item.recipientId) }}
+              </span>
+            </template>
+            <template #default>
+              <span>
+                <font-awesome-icon icon="fa-solid fa-pen" class="mr-1" />Редактировать реестр
+              </span>
+            </template>
+          </v-tooltip>
         </template>
         <template #[`item.destCountryCode`]="{ item }">
-          {{ countriesStore.getCountryShortName(item.destCountryCode) }}
+          <v-tooltip>
+            <template #activator="{ props }">
+              <span
+                class="edit-register-link clickable-cell"
+                v-bind="props"
+                @click="editRegister(item)"
+              >
+                {{ countriesStore.getCountryShortName(item.destCountryCode) }}
+              </span>
+            </template>
+            <template #default>
+              <span>
+                <font-awesome-icon icon="fa-solid fa-pen" class="mr-1" />Редактировать реестр
+              </span>
+            </template>
+          </v-tooltip>
         </template>
         <template #[`item.origCountryCode`]="{ item }">
-          {{ countriesStore.getCountryShortName(item.origCountryCode) }}
+          <v-tooltip>
+            <template #activator="{ props }">
+              <span
+                class="edit-register-link clickable-cell"
+                v-bind="props"
+                @click="editRegister(item)"
+              >
+                {{ countriesStore.getCountryShortName(item.origCountryCode) }}
+              </span>
+            </template>
+            <template #default>
+              <span>
+                <font-awesome-icon icon="fa-solid fa-pen" class="mr-1" />Редактировать реестр
+              </span>
+            </template>
+          </v-tooltip>
         </template>
         <template #[`item.date`]="{ item }">
-          {{ formatDate(item.date) }}
-        </template>
-        <template #[`item.invoiceDate`]="{ item }">
-          {{ formatDate(item.invoiceDate) }}
+          <v-tooltip>
+            <template #activator="{ props }">
+              <span
+                class="edit-register-link clickable-cell"
+                v-bind="props"
+                @click="editRegister(item)"
+              >
+                {{ formatDate(item.date) }}
+              </span>
+            </template>
+            <template #default>
+              <span>
+                <font-awesome-icon icon="fa-solid fa-pen" class="mr-1" />Редактировать реестр
+              </span>
+            </template>
+          </v-tooltip>
         </template>
         <template #[`item.invoiceNumber`]="{ item }">
-          {{ item.invoiceNumber }}
+          <v-tooltip>
+            <template #activator="{ props }">
+              <span
+                class="open-parcels-link clickable-cell"
+                v-bind="props"
+                @click="openParcels(item)"
+              >
+                {{ item.invoiceNumber }}
+              </span>
+            </template>
+            <template #default>
+              <span>
+                <font-awesome-icon icon="fa-solid fa-list" class="mr-1" />Открыть список посылок
+              </span>
+            </template>
+          </v-tooltip>
+        </template>
+        <template #[`item.invoiceDate`]="{ item }">
+          <v-tooltip>
+            <template #activator="{ props }">
+              <span
+                class="edit-register-link clickable-cell"
+                v-bind="props"
+                @click="editRegister(item)"
+              >
+                {{ formatDate(item.invoiceDate) }}
+              </span>
+            </template>
+            <template #default>
+              <span>
+                <font-awesome-icon icon="fa-solid fa-pen" class="mr-1" />Редактировать реестр
+              </span>
+            </template>
+          </v-tooltip>
         </template>
         <template #[`item.transportationTypeId`]="{ item }">
-          {{ transportationTypesStore.getName(item.transportationTypeId) }}
+          <v-tooltip>
+            <template #activator="{ props }">
+              <span
+                class="edit-register-link clickable-cell"
+                v-bind="props"
+                @click="editRegister(item)"
+              >
+                {{ transportationTypesStore.getName(item.transportationTypeId) }}
+              </span>
+            </template>
+            <template #default>
+              <span>
+                <font-awesome-icon icon="fa-solid fa-pen" class="mr-1" />Редактировать реестр
+              </span>
+            </template>
+          </v-tooltip>
         </template>
         <template #[`item.customsProcedureId`]="{ item }">
-          {{ customsProceduresStore.getName(item.customsProcedureId) }}
+          <v-tooltip>
+            <template #activator="{ props }">
+              <span
+                class="edit-register-link clickable-cell"
+                v-bind="props"
+                @click="editRegister(item)"
+              >
+                {{ customsProceduresStore.getName(item.customsProcedureId) }}
+              </span>
+            </template>
+            <template #default>
+              <span>
+                <font-awesome-icon icon="fa-solid fa-pen" class="mr-1" />Редактировать реестр
+              </span>
+            </template>
+          </v-tooltip>
         </template>
         <template #[`item.ordersTotal`]="{ item }">
-          {{ item.ordersTotal }}
+          <v-tooltip>
+            <template #activator="{ props }">
+              <span
+                class="edit-register-link clickable-cell"
+                v-bind="props"
+                @click="editRegister(item)"
+              >
+                {{ item.ordersTotal }}
+              </span>
+            </template>
+            <template #default>
+              <span>
+                <font-awesome-icon icon="fa-solid fa-pen" class="mr-1" />Редактировать реестр
+              </span>
+            </template>
+          </v-tooltip>
         </template>
         <template #[`item.actions1`]="{ item }">
           <v-tooltip text="Открыть список посылок">
@@ -647,6 +815,10 @@ const headers = [
 .anti-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.clickable-cell {
+  cursor: pointer;
 }
 
 .upload-links {

--- a/tests/Registers_List.spec.js
+++ b/tests/Registers_List.spec.js
@@ -117,7 +117,7 @@ vi.mock('@/stores/transportation.types.store.js', () => ({
     types: mockTransportationTypes,
     getAll: getTransportationTypesAll,
     ensureLoaded: vi.fn(),
-    getTitle: vi.fn(id => `Type ${id}`)
+    getName: vi.fn(id => `Type ${id}`)
   })
 }))
 
@@ -126,7 +126,7 @@ vi.mock('@/stores/customs.procedures.store.js', () => ({
     procedures: mockCustomsProcedures,
     getAll: getCustomsProceduresAll,
     ensureLoaded: vi.fn(),
-    getTitle: vi.fn(id => `Proc ${id}`)
+    getName: vi.fn(id => `Proc ${id}`)
   })
 }))
 
@@ -434,6 +434,52 @@ describe('Registers_List.vue', () => {
       const item = { id: 456, invoiceNumber: 'INV' }
       wrapper.vm.exportAllXml(item)
       expect(generateFn).toHaveBeenCalledWith(456, 'INV')
+    })
+  })
+
+  describe('table cell interactions', () => {
+    it('opens parcels when dealNumber cell is clicked', async () => {
+      mockItems.value = [
+        {
+          id: 1,
+          dealNumber: 'D-1',
+          invoiceNumber: 'INV-1'
+        }
+      ]
+
+      const wrapper = mount(RegistersList, {
+        global: {
+          stubs: vuetifyStubs
+        }
+      })
+
+      const router = (await import('@/router')).default
+      await wrapper.vm.$nextTick()
+      const cell = wrapper.find('.open-parcels-link')
+      await cell.trigger('click')
+      expect(router.push).toHaveBeenCalledWith('/registers/1/parcels')
+    })
+
+    it('edits register when sender cell is clicked', async () => {
+      mockItems.value = [
+        {
+          id: 2,
+          senderId: 10
+        }
+      ]
+      mockCompanies.value = [{ id: 10, name: 'Sender' }]
+
+      const wrapper = mount(RegistersList, {
+        global: {
+          stubs: vuetifyStubs
+        }
+      })
+
+      const router = (await import('@/router')).default
+      await wrapper.vm.$nextTick()
+      const cell = wrapper.find('.edit-register-link')
+      await cell.trigger('click')
+      expect(router.push).toHaveBeenCalledWith('/register/edit/2')
     })
   })
 

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -24,12 +24,34 @@ export const vuetifyStubs = {
     emits: ['input', 'update:modelValue']
   },
   'v-data-table': {
-    template: '<div class="v-data-table-stub" data-testid="v-data-table"><slot></slot></div>',
+    template: `
+      <div class="v-data-table-stub" data-testid="v-data-table">
+        <div v-for="(item, i) in items" :key="i" class="v-data-table-row">
+          <div v-for="header in headers" :key="header.key" class="v-data-table-cell">
+            <slot :name="'item.' + header.key" :item="item">
+              {{ item[header.key] }}
+            </slot>
+          </div>
+        </div>
+        <slot></slot>
+      </div>
+    `,
     props: ['items', 'headers', 'loading', 'itemsLength', 'itemsPerPage', 'page', 'sortBy', 'itemsPerPageOptions', 'search', 'customFilter', 'density', 'style'],
     inheritAttrs: false
   },
   'v-data-table-server': {
-    template: '<div class="v-data-table-stub" data-testid="v-data-table"><slot></slot></div>',
+    template: `
+      <div class="v-data-table-stub" data-testid="v-data-table">
+        <div v-for="(item, i) in items" :key="i" class="v-data-table-row">
+          <div v-for="header in headers" :key="header.key" class="v-data-table-cell">
+            <slot :name="'item.' + header.key" :item="item">
+              {{ item[header.key] }}
+            </slot>
+          </div>
+        </div>
+        <slot></slot>
+      </div>
+    `,
     props: ['items', 'headers', 'loading', 'itemsLength', 'itemsPerPage', 'page', 'sortBy', 'itemsPerPageOptions', 'style'],
     inheritAttrs: false
   },
@@ -56,7 +78,7 @@ export const vuetifyStubs = {
     inheritAttrs: false
   },
   'v-tooltip': {
-    template: '<div class="v-tooltip-stub" data-testid="v-tooltip"><slot></slot></div>',
+    template: '<div class="v-tooltip-stub" data-testid="v-tooltip"><slot name="activator"></slot><slot></slot></div>',
     props: ['text', 'location', 'activator', 'style'],
     inheritAttrs: false
   },


### PR DESCRIPTION
## Summary
- make deal and invoice columns open parcel list
- click other register fields to edit register
- support new interactions in tests

## Testing
- `npm test run --silent`


------
https://chatgpt.com/codex/tasks/task_e_6890c3d9355c8321ba6fe327fc0a7779