### PR TITLE
feat: toggle parcel description

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -964,6 +964,16 @@ a,
   margin-bottom: 0rem;
 }
 
+.product-name-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.product-name-row .form-group-1 {
+  flex: 1;
+}
+
 .form-group {
   display: flex;
   flex-direction: row;

--- a/src/components/WbrParcel_EditDialog.vue
+++ b/src/components/WbrParcel_EditDialog.vue
@@ -72,6 +72,8 @@ watch(() => item.value?.statusId, (newStatusId) => {
 
 const productLinkWithProtocol = computed(() => ensureHttps(item.value?.productLink))
 
+const isDescriptionVisible = ref(false)
+
 statusStore.ensureStatusesLoaded()
 parcelCheckStatusStore.ensureStatusesLoaded()
 await stopWordsStore.getAll()
@@ -213,18 +215,24 @@ async function generateXml(values) {
 
       <!-- Product Name and description Section -->
       <div class="form-section">
-        <div class="form-row-1">
+        <div class="form-row-1 product-name-row">
+          <ActionButton
+            :item="item"
+            :icon="isDescriptionVisible ? 'fa-solid fa-arrow-up' : 'fa-solid fa-arrow-down'"
+            :tooltip-text="isDescriptionVisible ? 'Скрыть описание' : 'Показать описание'"
+            @click="isDescriptionVisible = !isDescriptionVisible"
+          />
           <WbrFormField name="productName" :errors="errors" />
         </div>
-        <div class="form-row-0">
+        <div class="form-row-0" v-show="isDescriptionVisible">
           <div class="form-group-0">
             <label for="description" class="label-0">Описание:</label>
-            <Field 
+            <Field
               as="textarea"
-              name="description" 
-              id="description" 
+              name="description"
+              id="description"
               rows="5"
-              class="form-control input-0" 
+              class="form-control input-0"
               :class="{ 'is-invalid': errors && errors.description }"
             />
           </div>

--- a/tests/WbrParcel_EditDialog.spec.js
+++ b/tests/WbrParcel_EditDialog.spec.js
@@ -4,6 +4,7 @@ import { mount } from '@vue/test-utils'
 import { nextTick, ref } from 'vue'
 import { defaultGlobalStubs, createMockStore } from './test-utils.js'
 import ParcelEditDialog from '@/components/WbrParcel_EditDialog.vue'
+import ActionButton from '@/components/ActionButton.vue'
 
 // Mock router - create the mock function directly in the factory
 vi.mock('@/router', () => ({
@@ -235,6 +236,27 @@ describe('WbrParcel_EditDialog', () => {
       expect(field.exists()).toBe(true)
       expect(field.attributes('type')).toBe('number')
     })
+  })
+
+  it('toggles description visibility with action button', async () => {
+    const parcelComponent = wrapper.findComponent(ParcelEditDialog)
+    expect(parcelComponent.vm.isDescriptionVisible).toBe(false)
+
+    let toggleBtn = wrapper
+      .findAllComponents(ActionButton)
+      .find(btn => btn.props('tooltipText')?.includes('описание'))
+    expect(toggleBtn).toBeTruthy()
+    expect(toggleBtn.props('icon')).toBe('fa-solid fa-arrow-down')
+
+    await toggleBtn.vm.$emit('click')
+    await nextTick()
+
+    expect(parcelComponent.vm.isDescriptionVisible).toBe(true)
+
+    toggleBtn = wrapper
+      .findAllComponents(ActionButton)
+      .find(btn => btn.props('tooltipText')?.includes('описание'))
+    expect(toggleBtn.props('icon')).toBe('fa-solid fa-arrow-up')
   })
 
   it('renders all required buttons', () => {


### PR DESCRIPTION
## Summary
- add expand/collapse button for parcel description
- style product name row to include toggle control
- cover description toggle with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890e2899e8c832196d2662e4524ed36