### PR TITLE
feat: add parcel views store

### DIFF
--- a/src/stores/parcel.views.store.js
+++ b/src/stores/parcel.views.store.js
@@ -1,0 +1,47 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/parcelviews`
+
+export const useParcelViewsStore = defineStore('parcelViews', () => {
+  const orderView = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function add(orderId) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.post(baseUrl, { id: orderId })
+    } catch (err) {
+      error.value = err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function back() {
+    loading.value = true
+    error.value = null
+    try {
+      const response = await fetchWrapper.put(baseUrl)
+      orderView.value = response || null
+      return orderView.value
+    } catch (err) {
+      error.value = err
+      return null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    orderView,
+    loading,
+    error,
+    add,
+    back
+  }
+})

--- a/tests/parcel.views.store.spec.js
+++ b/tests/parcel.views.store.spec.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useParcelViewsStore } from '@/stores/parcel.views.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: { post: vi.fn(), put: vi.fn() }
+}))
+
+vi.mock('@/helpers/config.js', () => ({
+  apiUrl: 'http://localhost:8080/api'
+}))
+
+describe('parcel.views store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('adds a parcel view', async () => {
+    fetchWrapper.post.mockResolvedValue({})
+
+    const store = useParcelViewsStore()
+    await store.add(123)
+
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/parcelviews`, { id: 123 })
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('handles error when adding a parcel view', async () => {
+    const testError = new Error('API error')
+    fetchWrapper.post.mockRejectedValue(testError)
+
+    const store = useParcelViewsStore()
+    await store.add(123)
+
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/parcelviews`, { id: 123 })
+    expect(store.loading).toBe(false)
+    expect(store.error).toBe(testError)
+  })
+
+  it('retrieves previous parcel view', async () => {
+    const mockView = { id: 1 }
+    fetchWrapper.put.mockResolvedValue(mockView)
+
+    const store = useParcelViewsStore()
+    const result = await store.back()
+
+    expect(fetchWrapper.put).toHaveBeenCalledWith(`${apiUrl}/parcelviews`)
+    expect(store.orderView).toEqual(mockView)
+    expect(result).toEqual(mockView)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('handles no content when backing', async () => {
+    fetchWrapper.put.mockResolvedValue(undefined)
+
+    const store = useParcelViewsStore()
+    const result = await store.back()
+
+    expect(fetchWrapper.put).toHaveBeenCalledWith(`${apiUrl}/parcelviews`)
+    expect(store.orderView).toBeNull()
+    expect(result).toBeNull()
+  })
+
+  it('handles error when backing', async () => {
+    const testError = new Error('API error')
+    fetchWrapper.put.mockRejectedValue(testError)
+
+    const store = useParcelViewsStore()
+    await store.back()
+
+    expect(fetchWrapper.put).toHaveBeenCalledWith(`${apiUrl}/parcelviews`)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBe(testError)
+  })
+})


### PR DESCRIPTION
## Summary
- add parcel views store to interact with ParcelViewsController
- cover parcel views store with unit tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6894cf64f0808321b0608d9a78556c50