### PR TITLE
Disable export XML action when parcel has issues

### DIFF
--- a/src/components/OzonParcels_List.vue
+++ b/src/components/OzonParcels_List.vue
@@ -289,7 +289,13 @@ function getGenericTemplateHeaders() {
         <template #[`item.actions`]="{ item }">
           <div class="actions-container">
             <ActionButton :item="item" icon="fa-solid fa-pen" tooltip-text="Редактировать информацию о посылке" @click="editParcel" />
-            <ActionButton :item="item" icon="fa-solid fa-upload" tooltip-text="Выгрузить накладную для посылки" @click="exportParcelXml" disabled="HasIssues(item?.checkStatusId)" />
+            <ActionButton
+              :item="item"
+              icon="fa-solid fa-upload"
+              tooltip-text="Выгрузить накладную для посылки"
+              @click="exportParcelXml"
+              :disabled="HasIssues(item?.checkStatusId)"
+            />
             <ActionButton :item="item" icon="fa-solid fa-clipboard-check" tooltip-text="Проверить посылку" @click="validateParcel" />
             <ActionButton :item="item" icon="fa-solid fa-check-circle" tooltip-text="Согласовать" @click="approveParcel" />
           </div>

--- a/src/components/WbrParcels_List.vue
+++ b/src/components/WbrParcels_List.vue
@@ -296,7 +296,13 @@ function getGenericTemplateHeaders() {
         <template #[`item.actions`]="{ item }">
           <div class="actions-container">
             <ActionButton :item="item" icon="fa-solid fa-pen" tooltip-text="Редактировать посылку" @click="editParcel" />
-            <ActionButton :item="item" icon="fa-solid fa-upload" tooltip-text="Выгрузить накладную для посылки" @click="exportParcelXml" disabled="HasIssues(item?.checkStatusId)"/>
+            <ActionButton
+              :item="item"
+              icon="fa-solid fa-upload"
+              tooltip-text="Выгрузить накладную для посылки"
+              @click="exportParcelXml"
+              :disabled="HasIssues(item?.checkStatusId)"
+            />
             <ActionButton :item="item" icon="fa-solid fa-clipboard-check" tooltip-text="Проверить посылку" @click="validateParcel" />
             <ActionButton :item="item" icon="fa-solid fa-check-circle" tooltip-text="Согласовать" @click="approveParcel" />
           </div>

--- a/tests/Parcels_List.spec.js
+++ b/tests/Parcels_List.spec.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('Parcels list export button', () => {
+  it('OzonParcels_List disables export when HasIssues returns true', () => {
+    const content = readFileSync(resolve('src/components/OzonParcels_List.vue'), 'utf8')
+    expect(content).toMatch(/<ActionButton[\s\S]*?:disabled="HasIssues\(item\?\.checkStatusId\)"/)
+  })
+
+  it('WbrParcels_List disables export when HasIssues returns true', () => {
+    const content = readFileSync(resolve('src/components/WbrParcels_List.vue'), 'utf8')
+    expect(content).toMatch(/<ActionButton[\s\S]*?:disabled="HasIssues\(item\?\.checkStatusId\)"/)
+  })
+})


### PR DESCRIPTION
## Summary
- Bind parcel export button's disabled state to `HasIssues` in Ozon and WBR parcel lists
- Add tests to ensure export buttons are conditionally disabled

## Testing
- `npx vitest run tests/Parcels_List.spec.js`

------
https://chatgpt.com/codex/tasks/task_e_6895007662a48321aa6f0068762c24ce