### PR TITLE
Track parcel views on dialog open

### DIFF
--- a/src/components/OzonParcel_EditDialog.vue
+++ b/src/components/OzonParcel_EditDialog.vue
@@ -34,6 +34,7 @@ import { useParcelCheckStatusStore } from '@/stores/parcel.checkstatuses.store.j
 import { useStopWordsStore } from '@/stores/stop.words.store.js'
 import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
 import { useCountriesStore } from '@/stores/countries.store.js'
+import { useParcelViewsStore } from '@/stores/parcel.views.store.js'
 import { storeToRefs } from 'pinia'
 import { ref, watch, computed } from 'vue'
 import { ozonRegisterColumnTitles, ozonRegisterColumnTooltips } from '@/helpers/ozon.register.mapping.js'
@@ -56,6 +57,7 @@ const parcelCheckStatusStore = useParcelCheckStatusStore()
 const stopWordsStore = useStopWordsStore()
 const feacnCodesStore = useFeacnCodesStore()
 const countriesStore = useCountriesStore()
+const parcelViewsStore = useParcelViewsStore()
 
 countriesStore.ensureLoaded()
 statusStore.ensureStatusesLoaded()
@@ -78,6 +80,7 @@ const productLinkWithProtocol = computed(() => ensureHttps(item.value?.productLi
 
 await stopWordsStore.getAll()
 await parcelsStore.getById(props.id)
+await parcelViewsStore.add(props.id)
 
 const schema = Yup.object().shape({
   statusId: Yup.number().required('Необходимо выбрать статус'),

--- a/src/components/WbrParcel_EditDialog.vue
+++ b/src/components/WbrParcel_EditDialog.vue
@@ -34,6 +34,7 @@ import { useParcelCheckStatusStore } from '@/stores/parcel.checkstatuses.store.j
 import { useStopWordsStore } from '@/stores/stop.words.store.js'
 import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
 import { useCountriesStore } from '@/stores/countries.store.js'
+import { useParcelViewsStore } from '@/stores/parcel.views.store.js'
 import { useRegistersStore } from '@/stores/registers.store.js'
 import { storeToRefs } from 'pinia'
 import { ref, watch, computed } from 'vue'
@@ -56,6 +57,7 @@ const parcelCheckStatusStore = useParcelCheckStatusStore()
 const stopWordsStore = useStopWordsStore()
 const feacnCodesStore = useFeacnCodesStore()
 const countriesStore = useCountriesStore()
+const parcelViewsStore = useParcelViewsStore()
 
 const { item } = storeToRefs(parcelsStore)
 const { stopWords } = storeToRefs(stopWordsStore)
@@ -79,6 +81,7 @@ parcelCheckStatusStore.ensureStatusesLoaded()
 await stopWordsStore.getAll()
 countriesStore.ensureLoaded()
 await parcelsStore.getById(props.id)
+await parcelViewsStore.add(props.id)
 
 const schema = Yup.object().shape({
   statusId: Yup.number().required('Необходимо выбрать статус'),

--- a/tests/OzonParcel_EditDialog.spec.js
+++ b/tests/OzonParcel_EditDialog.spec.js
@@ -125,6 +125,10 @@ const mockCountriesStore = createMockStore({
   ensureLoaded: vi.fn()
 })
 
+const mockParcelViewsStore = createMockStore({
+  add: vi.fn().mockResolvedValue({})
+})
+
 const mockRegistersStore = createMockStore({
   nextParcel: vi.fn().mockResolvedValue({ id: 2, registerId: 1 })
 })
@@ -156,6 +160,10 @@ vi.mock('@/stores/countries.store.js', () => ({
 
 vi.mock('@/stores/registers.store.js', () => ({
   useRegistersStore: vi.fn(() => mockRegistersStore)
+}))
+
+vi.mock('@/stores/parcel.views.store.js', () => ({
+  useParcelViewsStore: vi.fn(() => mockParcelViewsStore)
 }))
 
 // Mock the next item helper
@@ -205,6 +213,7 @@ describe('OzonParcel_EditDialog', () => {
     // Wait for async operations to complete
     await nextTick()
     await nextTick() // Extra tick to ensure async operations complete
+    await nextTick()
   })
 
   afterEach(() => {
@@ -216,6 +225,10 @@ describe('OzonParcel_EditDialog', () => {
     const heading = wrapper.find('h1')
     expect(heading.exists()).toBe(true)
     expect(heading.text()).toContain('Посылка')
+  })
+
+  it('records parcel view when opened', () => {
+    expect(mockParcelViewsStore.add).toHaveBeenCalledWith(1)
   })
 
   it('includes all required order fields', () => {

--- a/tests/WbrParcel_EditDialog.spec.js
+++ b/tests/WbrParcel_EditDialog.spec.js
@@ -123,6 +123,10 @@ const mockCountriesStore = createMockStore({
   ensureLoaded: vi.fn()
 })
 
+const mockParcelViewsStore = createMockStore({
+  add: vi.fn().mockResolvedValue({})
+})
+
 // Mock registers store
 const mockRegistersStore = createMockStore({
   nextParcel: vi.fn().mockResolvedValue({ id: 2, registerId: 1 }),
@@ -157,6 +161,10 @@ vi.mock('@/stores/countries.store.js', () => ({
 
 vi.mock('@/stores/registers.store.js', () => ({
   useRegistersStore: vi.fn(() => mockRegistersStore)
+}))
+
+vi.mock('@/stores/parcel.views.store.js', () => ({
+  useParcelViewsStore: vi.fn(() => mockParcelViewsStore)
 }))
 
 describe('WbrParcel_EditDialog', () => {
@@ -197,6 +205,7 @@ describe('WbrParcel_EditDialog', () => {
     // Wait for async operations to complete
     await nextTick()
     await nextTick() // Extra tick to ensure async operations complete
+    await nextTick()
   })
 
   afterEach(() => {
@@ -208,6 +217,10 @@ describe('WbrParcel_EditDialog', () => {
     const heading = wrapper.find('h1')
     expect(heading.exists()).toBe(true)
     expect(heading.text()).toContain('Посылка')
+  })
+
+  it('records parcel view when opened', () => {
+    expect(mockParcelViewsStore.add).toHaveBeenCalledWith(1)
   })
 
   it('includes all required order fields', () => {


### PR DESCRIPTION
## Summary
- record parcel view when a parcel edit dialog opens
- verify parcel view tracking in WBR and Ozon dialog tests

## Testing
- `npx vitest run tests/WbrParcel_EditDialog.spec.js tests/OzonParcel_EditDialog.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_6895180278e88321b9f1db57d61c58d6