### PR TITLE
feat: navigate to previous parcel

### DIFF
--- a/src/components/OzonParcel_EditDialog.vue
+++ b/src/components/OzonParcel_EditDialog.vue
@@ -149,6 +149,24 @@ function onSave(values) {
     })
 }
 
+// Save current parcel and navigate to the previous one if available
+async function onBack(values) {
+  try {
+    await parcelsStore.update(props.id, values)
+    const prevParcel = await parcelViewsStore.back()
+
+    if (prevParcel) {
+      const prevUrl = `/registers/${props.registerId}/parcels/edit/${prevParcel.id}`
+      router.push(prevUrl)
+    } else {
+      const fallbackUrl = `/registers/${props.registerId}/parcels`
+      router.push(fallbackUrl)
+    }
+  } catch (error) {
+    parcelsStore.error = error?.message || String(error)
+  }
+}
+
 // Generate XML for this parcel
 async function generateXml(values) {
   try {
@@ -278,7 +296,7 @@ async function generateXml(values) {
           <font-awesome-icon size="1x" icon="fa-solid fa-file-export" class="mr-1" />
           Накладная
         </button>
-        <button class="button secondary" type="button" @click="console.log('Назад')" :disabled="isSubmitting">
+        <button class="button secondary" type="button" @click="onBack(values)" :disabled="isSubmitting">
           <font-awesome-icon size="1x" icon="fa-solid fa-arrow-left" class="mr-1" />
           Назад
         </button>

--- a/src/components/WbrParcel_EditDialog.vue
+++ b/src/components/WbrParcel_EditDialog.vue
@@ -152,6 +152,24 @@ function onSave(values) {
     })
 }
 
+// Save current parcel and navigate to the previous one if available
+async function onBack(values) {
+  try {
+    await parcelsStore.update(props.id, values)
+    const prevParcel = await parcelViewsStore.back()
+
+    if (prevParcel) {
+      const prevUrl = `/registers/${props.registerId}/parcels/edit/${prevParcel.id}`
+      router.push(prevUrl)
+    } else {
+      const fallbackUrl = `/registers/${props.registerId}/parcels`
+      router.push(fallbackUrl)
+    }
+  } catch (error) {
+    parcelsStore.error = error?.message || String(error)
+  }
+}
+
 // Generate XML for this parcel
 async function generateXml(values) {
   try {
@@ -294,7 +312,7 @@ async function generateXml(values) {
           <font-awesome-icon size="1x" icon="fa-solid fa-file-export" class="mr-1" />
           Накладная
         </button>
-        <button class="button secondary" type="button" @click="console.log('Назад')" :disabled="isSubmitting">
+        <button class="button secondary" type="button" @click="onBack(values)" :disabled="isSubmitting">
           <font-awesome-icon size="1x" icon="fa-solid fa-arrow-left" class="mr-1" />
           Назад
         </button>

--- a/tests/OzonParcel_EditDialog.spec.js
+++ b/tests/OzonParcel_EditDialog.spec.js
@@ -5,6 +5,7 @@ import { nextTick, ref } from 'vue'
 import { createPinia } from 'pinia'
 import { defaultGlobalStubs, createMockStore } from './test-utils.js'
 import ParcelEditDialog from '@/components/OzonParcel_EditDialog.vue'
+import router from '@/router'
 
 // Mock router - create the mock function directly in the factory
 vi.mock('@/router', () => ({
@@ -126,7 +127,8 @@ const mockCountriesStore = createMockStore({
 })
 
 const mockParcelViewsStore = createMockStore({
-  add: vi.fn().mockResolvedValue({})
+  add: vi.fn().mockResolvedValue({}),
+  back: vi.fn().mockResolvedValue({ id: 5 })
 })
 
 const mockRegistersStore = createMockStore({
@@ -295,6 +297,17 @@ describe('OzonParcel_EditDialog', () => {
 
   it('calls getById on mount', () => {
     expect(mockOrdersStore.getById).toHaveBeenCalledWith(1)
+  })
+
+  it('saves parcel and loads previous one when back button is clicked', async () => {
+    const backButton = wrapper.findAll('button').find(btn => btn.text().includes('Назад'))
+    expect(backButton).toBeTruthy()
+
+    await backButton.trigger('click')
+
+    expect(mockOrdersStore.update).toHaveBeenCalledWith(1, {})
+    expect(mockParcelViewsStore.back).toHaveBeenCalled()
+    expect(router.push).toHaveBeenCalledWith('/registers/1/parcels/edit/5')
   })
 
   it('calls ensureStatusesLoaded on mount', () => {

--- a/tests/WbrParcel_EditDialog.spec.js
+++ b/tests/WbrParcel_EditDialog.spec.js
@@ -5,6 +5,7 @@ import { nextTick, ref } from 'vue'
 import { defaultGlobalStubs, createMockStore } from './test-utils.js'
 import ParcelEditDialog from '@/components/WbrParcel_EditDialog.vue'
 import ActionButton from '@/components/ActionButton.vue'
+import router from '@/router'
 
 // Mock router - create the mock function directly in the factory
 vi.mock('@/router', () => ({
@@ -124,7 +125,8 @@ const mockCountriesStore = createMockStore({
 })
 
 const mockParcelViewsStore = createMockStore({
-  add: vi.fn().mockResolvedValue({})
+  add: vi.fn().mockResolvedValue({}),
+  back: vi.fn().mockResolvedValue({ id: 5 })
 })
 
 // Mock registers store
@@ -308,6 +310,17 @@ describe('WbrParcel_EditDialog', () => {
 
   it('calls getById on mount', () => {
     expect(mockOrdersStore.getById).toHaveBeenCalledWith(1)
+  })
+
+  it('saves parcel and loads previous one when back button is clicked', async () => {
+    const backButton = wrapper.findAll('button').find(btn => btn.text().includes('Назад'))
+    expect(backButton).toBeTruthy()
+
+    await backButton.trigger('click')
+
+    expect(mockOrdersStore.update).toHaveBeenCalledWith(1, {})
+    expect(mockParcelViewsStore.back).toHaveBeenCalled()
+    expect(router.push).toHaveBeenCalledWith('/registers/1/parcels/edit/5')
   })
 
   it('calls ensureStatusesLoaded on mount', () => {


### PR DESCRIPTION
## Summary
- save parcel and navigate to previous viewed parcel via `onBack`
- connect back buttons in parcel edit dialogs to the new navigation logic
- test back navigation in parcel edit dialogs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68951de2ed6483218ecf69f2b8cd72e7