### PR TITLE
feat: add FEACN code lookup support

### DIFF
--- a/src/components/OzonParcels_List.vue
+++ b/src/components/OzonParcels_List.vue
@@ -170,7 +170,7 @@ async function validateParcel(item) {
 }
 
 async function lookupFeacnCodes(item) {
-  await lookupFeacn(item, alertStore)
+  await lookupFeacn(item, parcelsStore, alertStore, loadOrders)
 }
 
 async function approveParcel(item) {

--- a/src/components/WbrParcels_List.vue
+++ b/src/components/WbrParcels_List.vue
@@ -169,15 +169,15 @@ async function exportParcelXml(item) {
 }
 
 async function validateParcel(item) {
-  await validateParcelData(item, parcelsStore, loadOrders)
+  await validateParcelData(item, parcelsStore, alertStore, 'wbr', loadOrders)
 }
 
 async function lookupFeacnCodes(item) {
-  await lookupFeacn(item, alertStore)
+  await lookupFeacn(item, parcelsStore, alertStore, loadOrders)
 }
 
 async function approveParcel(item) {
-  await approveParcelData(item, parcelsStore, loadOrders)
+  await approveParcelData(item, parcelsStore, alertStore, 'wbr', loadOrders)
 }
 
 function getRowProps(data) {

--- a/src/helpers/parcels.list.helpers.js
+++ b/src/helpers/parcels.list.helpers.js
@@ -191,17 +191,22 @@ export async function exportParcelXmlData(item, parcelsStore, filename) {
 }
 
 /**
- * Looks up FEACN codes for a parcel (stub implementation)
+ * Looks up FEACN codes for a parcel
  * @param {Object} item - The parcel item
+ * @param {Object} parcelsStore - The parcels store instance
  * @param {Object} alertStore - The alert store instance
+ * @param {Function} loadOrdersFn - Function to reload orders
  * @returns {Promise<void>}
  */
-export async function lookupFeacn(item, alertStore) {
+export async function lookupFeacn(item, parcelsStore, alertStore, loadOrdersFn) {
   try {
-    // TODO: Implement FEACN lookup functionality
-    alertStore.info('Подбор кодов ТН ВЭД пока не реализован')
+    await parcelsStore.lookupFeacnCode(item.id)
+    if (loadOrdersFn) {
+      loadOrdersFn()
+    }
   } catch (error) {
     console.error('Failed to lookup FEACN codes:', error)
-    alertStore.error('Ошибка при подборе кодов ТН ВЭД')
+    parcelsStore.error = error?.response?.data?.message || 'Ошибка при подборе кодов ТН ВЭД'
+    alertStore?.error?.(parcelsStore.error)
   }
 }

--- a/src/stores/parcels.store.js
+++ b/src/stores/parcels.store.js
@@ -105,6 +105,11 @@ export const useParcelsStore = defineStore('parcels', () => {
       return true
   }
 
+  async function lookupFeacnCode(id) {
+      await fetchWrapper.post(`${baseUrl}/${id}/lookup-feacn-code`)
+      return true
+  }
+
   return {
     items,
     item,
@@ -118,6 +123,7 @@ export const useParcelsStore = defineStore('parcels', () => {
     update,
     generate,
     validate,
-    approve
+    approve,
+    lookupFeacnCode
   }
 })

--- a/tests/parcels.list.helpers.spec.js
+++ b/tests/parcels.list.helpers.spec.js
@@ -268,31 +268,41 @@ describe('Parcels List Helpers', () => {
   })
 
   describe('lookupFeacn', () => {
-    it('should show info message for stub implementation', async () => {
+    it('should lookup FEACN codes and reload orders', async () => {
+      const mockStore = {
+        lookupFeacnCode: vi.fn().mockResolvedValue(),
+        error: ''
+      }
       const mockAlertStore = {
-        info: vi.fn(),
         error: vi.fn()
       }
+      const mockLoadOrders = vi.fn()
       const item = { id: 123 }
 
-      await lookupFeacn(item, mockAlertStore)
+      await lookupFeacn(item, mockStore, mockAlertStore, mockLoadOrders)
 
-      expect(mockAlertStore.info).toHaveBeenCalledWith('Подбор кодов ТН ВЭД пока не реализован')
+      expect(mockStore.lookupFeacnCode).toHaveBeenCalledWith(123)
+      expect(mockLoadOrders).toHaveBeenCalled()
       expect(mockAlertStore.error).not.toHaveBeenCalled()
     })
 
-    it('should handle errors gracefully', async () => {
-      const mockAlertStore = {
-        info: vi.fn().mockImplementation(() => {
-          throw new Error('Alert error')
+    it('should handle lookup errors', async () => {
+      const mockStore = {
+        lookupFeacnCode: vi.fn().mockRejectedValue({
+          response: { data: { message: 'Lookup failed' } }
         }),
+        error: ''
+      }
+      const mockAlertStore = {
         error: vi.fn()
       }
+      const mockLoadOrders = vi.fn()
       const item = { id: 123 }
 
-      await lookupFeacn(item, mockAlertStore)
+      await lookupFeacn(item, mockStore, mockAlertStore, mockLoadOrders)
 
-      expect(mockAlertStore.error).toHaveBeenCalledWith('Ошибка при подборе кодов ТН ВЭД')
+      expect(mockStore.error).toBe('Lookup failed')
+      expect(mockLoadOrders).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
## Summary
- call new `/lookup-feacn-code` endpoint via parcels store
- expose helper for FEACN lookup and integrate with parcel list components
- test coverage for FEACN lookup behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0d1d445c0832194e63e4604c01148