### PR TITLE
feat: add FEACN lookup with progress

### DIFF
--- a/src/components/Registers_List.vue
+++ b/src/components/Registers_List.vue
@@ -59,9 +59,14 @@ import EditableCell from '@/components/EditableCell.vue'
 import ActionButton from '@/components/ActionButton.vue'
 
 const validationState = reactive(createValidationState())
-const pollingTimer = createPollingTimer(() => 
-  pollValidation(validationState, registersStore, alertStore, () => pollingTimer.stop())
-)
+validationState.operation = null
+let pollingFunction = null
+const pollingTimer = createPollingTimer(() => {
+  if (pollingFunction) {
+    // Allow async functions; errors are handled inside the polling functions
+    pollingFunction()
+  }
+})
 const progressPercent = computed(() => calculateValidationProgress(validationState))
 
 const registersStore = useRegistersStore()
@@ -244,22 +249,68 @@ async function deleteRegister(item) {
 }
 
 async function validateRegisterWrapper(item) {
+  validationState.operation = 'validation'
+  pollingFunction = () =>
+    pollValidation(validationState, registersStore, alertStore, () => pollingTimer.stop())
   await validateRegister(
-    item, 
-    validationState, 
-    registersStore, 
-    alertStore, 
+    item,
+    validationState,
+    registersStore,
+    alertStore,
     () => pollingTimer.stop(),
     () => pollingTimer.start()
   )
 }
 
+async function pollFeacnLookup() {
+  if (!validationState.handleId) return
+  try {
+    const progress = await registersStore.getLookupFeacnCodesProgress(validationState.handleId)
+    validationState.total = progress.total
+    validationState.processed = progress.processed
+
+    if (progress.finished || progress.total === -1 || progress.processed === -1) {
+      validationState.show = false
+      pollingTimer.stop()
+      await registersStore.getAll()
+    }
+  } catch (err) {
+    alertStore.error(err.message || String(err))
+    validationState.show = false
+    pollingTimer.stop()
+    await registersStore.getAll()
+  }
+}
+
 async function lookupFeacnCodes(item) {
-  console.log('Looking up FEACN codes for register', item.id)
+  try {
+    validationState.operation = 'lookup-feacn'
+    pollingTimer.stop()
+    pollingFunction = pollFeacnLookup
+    const res = await registersStore.lookupFeacnCodes(item.id)
+    validationState.handleId = res.id
+    validationState.total = 0
+    validationState.processed = 0
+    validationState.show = true
+    await pollFeacnLookup()
+    pollingTimer.start()
+  } catch (err) {
+    alertStore.error(err.message || String(err))
+  }
 }
 
 function cancelValidationWrapper() {
-  cancelValidation(validationState, registersStore, () => pollingTimer.stop())
+  if (validationState.operation === 'lookup-feacn') {
+    if (validationState.handleId) {
+      registersStore
+        .cancelLookupFeacnCodes(validationState.handleId)
+        .catch(() => {})
+    }
+    validationState.show = false
+    pollingTimer.stop()
+  } else {
+    cancelValidation(validationState, registersStore, () => pollingTimer.stop())
+  }
 }
 
 function formatDate(dateStr) {


### PR DESCRIPTION
## Summary
- support FEACN code lookup for registers with polling and cancellation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a102eb2730832188d53dcbafb77f1a