### PR TITLE
feat: support multiple FEACN codes for keywords

### DIFF
--- a/src/components/KeyWords_List.vue
+++ b/src/components/KeyWords_List.vue
@@ -62,7 +62,7 @@ function filterKeyWords(value, query, item) {
 
   return (
     (i.word?.toLocaleUpperCase() ?? '').indexOf(q) !== -1 ||
-    (i.feacnCode?.toLocaleUpperCase() ?? '').indexOf(q) !== -1
+    (i.feacnCodes?.some(code => code.toLocaleUpperCase().includes(q)) ?? false)
   )
 }
 
@@ -70,8 +70,8 @@ function filterKeyWords(value, query, item) {
 const headers = [
   { title: '', align: 'center', key: 'actions', sortable: false, width: '10%' },
   { title: 'Ключевое слово или фраза', key: 'word', sortable: true },
-  { title: 'Коды ТН ВЭД', key: 'feacnCode', sortable: true },
-  { title: 'Тип соответствия', key: 'matchTypeId', sortable: true }  
+  { title: 'Коды ТН ВЭД', key: 'feacnCodes', sortable: true },
+  { title: 'Тип соответствия', key: 'matchTypeId', sortable: true }
 ]
 
 function getMatchTypeText(id) {
@@ -229,6 +229,10 @@ defineExpose({
               @click="deleteKeyWord"
             />
           </div>
+        </template>
+
+        <template v-slot:[`item.feacnCodes`]="{ item }">
+          <div v-for="code in item.feacnCodes" :key="code">{{ code }}</div>
         </template>
 
         <template v-slot:[`item.matchTypeId`]="{ item }">

--- a/tests/KeyWord_Settings.spec.js
+++ b/tests/KeyWord_Settings.spec.js
@@ -11,7 +11,7 @@ const vuetify = createVuetify()
 // Mock data
 const mockKeyWord = {
   id: 1,
-  feacnCode: '1234567890',
+  feacnCodes: ['1234567890'],
   word: 'тест',
   matchTypeId: 41
 }
@@ -108,11 +108,12 @@ describe('KeyWord_Settings.vue', () => {
       await resolveAll()
 
       expect(wrapper.find('h1').text()).toBe('Регистрация слова или фразы для подбора ТН ВЭД')
-      expect(wrapper.find('input[name="feacnCode"]').exists()).toBe(true)
+      expect(wrapper.find('input[name="feacnCodes[0]"]').exists()).toBe(true)
       expect(wrapper.find('input[name="word"]').exists()).toBe(true)
       expect(wrapper.find('input[type="radio"]').exists()).toBe(true)
       expect(wrapper.find('button[type="submit"]').text()).toContain('Сохранить')
-      expect(wrapper.find('button[type="button"]').text()).toContain('Отменить')
+      const buttons = wrapper.findAll('button[type="button"]')
+      expect(buttons[buttons.length - 1].text()).toContain('Отменить')
     })
 
     it('renders edit mode correctly', async () => {
@@ -190,31 +191,33 @@ describe('KeyWord_Settings.vue', () => {
       await resolveAll()
 
       // Call the handler directly with a mocked event
-      await wrapper.vm.onCodeInput({ 
-        target: { 
-          value: 'abc123def456', 
+      const event = {
+        target: {
+          value: 'abc123def456',
           selectionStart: 12
-        } 
-      })
-      
+        }
+      }
+      await wrapper.vm.onCodeInput(event)
+
       // Should only keep digits
-      expect(wrapper.vm.feacnCode).toBe('123456')
+      expect(event.target.value).toBe('123456')
     })
-    
+
     it('limits code input to 10 digits', async () => {
       const wrapper = mountComponent()
       await resolveAll()
 
       // Call the handler directly with a mocked event
-      await wrapper.vm.onCodeInput({ 
-        target: { 
-          value: '12345678901234', 
+      const event = {
+        target: {
+          value: '12345678901234',
           selectionStart: 14
-        } 
-      })
-      
+        }
+      }
+      await wrapper.vm.onCodeInput(event)
+
       // Should truncate to 10 digits
-      expect(wrapper.vm.feacnCode).toBe('1234567890')
+      expect(event.target.value).toBe('1234567890')
     })
   })
 
@@ -225,8 +228,7 @@ describe('KeyWord_Settings.vue', () => {
 
       expect(getById).toHaveBeenCalledWith(1)
       
-      // Check the reactive properties directly
-      expect(wrapper.vm.feacnCode).toBe('1234567890')
+      // Check loaded values in the form
       expect(wrapper.vm.word).toBe('тест')
       expect(wrapper.vm.matchTypeId).toBe(41)
     })
@@ -250,9 +252,9 @@ describe('KeyWord_Settings.vue', () => {
       const wrapper = mountComponent()
       await resolveAll()
 
-      const cancelButton = wrapper.find('button[type="button"]')
+      const cancelButton = wrapper.findAll('button').find(b => b.text().includes('Отменить'))
       await cancelButton.trigger('click')
-      
+
       expect(routerPush).toHaveBeenCalledWith('/keywords')
     })
   })

--- a/tests/KeyWords_List.spec.js
+++ b/tests/KeyWords_List.spec.js
@@ -56,9 +56,9 @@ vi.mock('vuetify-use-dialog', () => ({
 
 // Centralized mock data
 const mockKeyWords = ref([
-  { id: 1, word: 'стол', matchTypeId: 41 },
-  { id: 2, word: 'деревянный', matchTypeId: 1 },
-  { id: 3, word: 'стул', matchTypeId: 41 }
+  { id: 1, word: 'стол', matchTypeId: 41, feacnCodes: ['1234567890'] },
+  { id: 2, word: 'деревянный', matchTypeId: 1, feacnCodes: [] },
+  { id: 3, word: 'стул', matchTypeId: 41, feacnCodes: ['1111111111', '2222222222'] }
 ])
 
 // Mock stores
@@ -174,9 +174,9 @@ describe('KeyWords_List.vue', () => {
 
     // Reset reactive data
     mockKeyWords.value = [
-      { id: 1, word: 'стол', matchTypeId: 41 },
-      { id: 2, word: 'деревянный', matchTypeId: 1 },
-      { id: 3, word: 'стул', matchTypeId: 41 }
+      { id: 1, word: 'стол', matchTypeId: 41, feacnCodes: ['1234567890'] },
+      { id: 2, word: 'деревянный', matchTypeId: 1, feacnCodes: [] },
+      { id: 3, word: 'стул', matchTypeId: 41, feacnCodes: ['1111111111', '2222222222'] }
     ]
 
     wrapper = mount(KeyWordsList, {
@@ -335,18 +335,21 @@ describe('KeyWords_List.vue', () => {
 
       // Test with matching word
       expect(filterFn('сто', 'сто', { raw: { word: 'стол' } })).toBe(true)
-      
+
       // Test with non-matching word
       expect(filterFn('xyz', 'xyz', { raw: { word: 'стол' } })).toBe(false)
-      
+
       // Test with uppercase query
       expect(filterFn('СТОЛ', 'СТОЛ', { raw: { word: 'стол' } })).toBe(true)
-      
+
+      // Test with matching code
+      expect(filterFn('123', '123', { raw: { feacnCodes: ['1234567890'] } })).toBe(true)
+
       // Test with null values
       expect(filterFn(null, null, { raw: { word: 'стол' } })).toBe(false)
       expect(filterFn('test', 'test', null)).toBe(false)
       expect(filterFn('test', 'test', { raw: null })).toBe(false)
-      
+
       // Test with undefined word (to cover line 61)
       expect(filterFn('test', 'test', { raw: { } })).toBe(false)
     })


### PR DESCRIPTION
## Summary
- allow keywords to manage multiple FEACN codes
- show all FEACN codes in list view
- adjust tests for new keyword model

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a1ea09ef848321885e86038b8eb228