### PR TITLE
Handle multiple FEACN codes per keyword

### DIFF
--- a/src/helpers/parcels.list.helpers.js
+++ b/src/helpers/parcels.list.helpers.js
@@ -165,12 +165,15 @@ export function getFeacnCodesForKeywords(keywordIds, keyWordsStore) {
   if (!keywordIds || !Array.isArray(keywordIds) || keywordIds.length === 0) {
     return []
   }
-  
+
   return keywordIds
-    .map(id => {
+    .reduce((acc, id) => {
       const keyword = keyWordsStore.keyWords.find(kw => kw.id === id)
-      return keyword ? keyword.feacnCode : null
-    })
+      if (keyword && Array.isArray(keyword.feacnCodes)) {
+        acc.push(...keyword.feacnCodes)
+      }
+      return acc
+    }, [])
     .filter(code => code !== null && code !== '')
     .sort((a, b) => {
       const numA = parseInt(a, 10)

--- a/tests/parcels.list.helpers.spec.js
+++ b/tests/parcels.list.helpers.spec.js
@@ -29,7 +29,8 @@ import {
   getRowPropsForParcel,
   filterGenericTemplateHeadersForParcel,
   generateRegisterName,
-  lookupFeacn
+  lookupFeacn,
+  getFeacnCodesForKeywords
 } from '../src/helpers/parcels.list.helpers.js'
 
 describe('Parcels List Helpers', () => {
@@ -282,6 +283,25 @@ describe('Parcels List Helpers', () => {
       const result = generateRegisterName('   ', 'file.xlsx')
 
       expect(result).toBe('Реестр для сделки без номера (файл: file.xlsx)')
+    })
+  })
+
+  describe('getFeacnCodesForKeywords', () => {
+    it('should extract and sort FEACN codes from keywords', () => {
+      const store = {
+        keyWords: [
+          { id: 1, feacnCodes: ['1234567890', '0987654321'] },
+          { id: 2, feacnCodes: ['2345678901'] }
+        ]
+      }
+      const result = getFeacnCodesForKeywords([1, 2], store)
+      expect(result).toEqual(['0987654321', '1234567890', '2345678901'])
+    })
+
+    it('should return empty array for invalid input', () => {
+      const store = { keyWords: [] }
+      expect(getFeacnCodesForKeywords(null, store)).toEqual([])
+      expect(getFeacnCodesForKeywords([], store)).toEqual([])
     })
   })
 


### PR DESCRIPTION
## Summary
- expand keyword lookup helper to aggregate multiple FEACN codes
- add tests covering new FEACN code aggregation

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a1eafb11908321b6198a2b7a44a8b0