### PR TITLE
Handle multiple FEACN codes per keyword

### DIFF
--- a/src/components/OzonParcel_EditDialog.vue
+++ b/src/components/OzonParcel_EditDialog.vue
@@ -46,6 +46,7 @@ import {
   getFeacnCodesForKeywords,
   getFeacnCodeItemClass,
   getTnVedCellClass,
+  getKeywordFeacnPairs,
 } from '@/helpers/parcels.list.helpers.js'
 import OzonFormField from './OzonFormField.vue'
 import { ensureHttps } from '@/helpers/url.helpers.js'
@@ -90,16 +91,10 @@ watch(() => item.value?.statusId, (newStatusId) => {
 
 const productLinkWithProtocol = computed(() => ensureHttps(item.value?.productLink))
 
-// Computed property for keywords with FEACN codes
-const keywordsWithFeacn = computed(() => {
-  if (!item.value?.keyWordIds || !Array.isArray(item.value.keyWordIds)) {
-    return []
-  }
-  
-  return item.value.keyWordIds
-    .map(keywordId => keyWordsStore.keyWords.find(kw => kw.id === keywordId))
-    .filter(keyword => keyword && keyword.feacnCode)
-})
+// Computed property for keyword/FEACN pairs
+const keywordsWithFeacn = computed(() =>
+  getKeywordFeacnPairs(item.value?.keyWordIds, keyWordsStore)
+)
 
 const schema = Yup.object().shape({
   statusId: Yup.number().required('Необходимо выбрать статус'),

--- a/src/components/WbrParcel_EditDialog.vue
+++ b/src/components/WbrParcel_EditDialog.vue
@@ -46,6 +46,7 @@ import {
   getFeacnCodesForKeywords,
   getFeacnCodeItemClass,
   getTnVedCellClass,
+  getKeywordFeacnPairs,
 } from '@/helpers/parcels.list.helpers.js'
 import WbrFormField from './WbrFormField.vue'
 import { ensureHttps } from '@/helpers/url.helpers.js'
@@ -90,16 +91,10 @@ watch(() => item.value?.statusId, (newStatusId) => {
 
 const productLinkWithProtocol = computed(() => ensureHttps(item.value?.productLink))
 
-// Computed property for keywords with FEACN codes
-const keywordsWithFeacn = computed(() => {
-  if (!item.value?.keyWordIds || !Array.isArray(item.value.keyWordIds)) {
-    return []
-  }
-  
-  return item.value.keyWordIds
-    .map(keywordId => keyWordsStore.keyWords.find(kw => kw.id === keywordId))
-    .filter(keyword => keyword && keyword.feacnCode)
-})
+// Computed property for keyword/FEACN pairs
+const keywordsWithFeacn = computed(() =>
+  getKeywordFeacnPairs(item.value?.keyWordIds, keyWordsStore)
+)
 
 const isDescriptionVisible = ref(false)
 

--- a/src/helpers/parcels.list.helpers.js
+++ b/src/helpers/parcels.list.helpers.js
@@ -183,6 +183,34 @@ export function getFeacnCodesForKeywords(keywordIds, keyWordsStore) {
 }
 
 /**
+ * Helper function to get keyword/FEACN code pairs
+ * @param {Array<number>} keywordIds - Array of keyword IDs
+ * @param {Object} keyWordsStore - The keywords store instance
+ * @returns {Array<Object>} Array of objects { id, word, feacnCode }
+ */
+export function getKeywordFeacnPairs(keywordIds, keyWordsStore) {
+  if (!keywordIds || !Array.isArray(keywordIds) || keywordIds.length === 0) {
+    return []
+  }
+
+  return keywordIds
+    .flatMap((id) => {
+      const keyword = keyWordsStore.keyWords.find((kw) => kw.id === id)
+      if (keyword && Array.isArray(keyword.feacnCodes)) {
+        return keyword.feacnCodes
+          .filter((code) => code !== null && code !== '')
+          .map((code) => ({ id: `${id}-${code}`, word: keyword.word, feacnCode: code }))
+      }
+      return []
+    })
+    .sort((a, b) => {
+      const numA = parseInt(a.feacnCode, 10)
+      const numB = parseInt(b.feacnCode, 10)
+      return numA - numB
+    })
+}
+
+/**
  * Helper function to get CSS class for FEACN code item based on match status
  * @param {string} feacnCode - The FEACN code to check
  * @param {string} tnVed - The current TN VED code

--- a/tests/parcels.list.helpers.spec.js
+++ b/tests/parcels.list.helpers.spec.js
@@ -30,7 +30,8 @@ import {
   filterGenericTemplateHeadersForParcel,
   generateRegisterName,
   lookupFeacn,
-  getFeacnCodesForKeywords
+  getFeacnCodesForKeywords,
+  getKeywordFeacnPairs
 } from '../src/helpers/parcels.list.helpers.js'
 
 describe('Parcels List Helpers', () => {
@@ -302,6 +303,29 @@ describe('Parcels List Helpers', () => {
       const store = { keyWords: [] }
       expect(getFeacnCodesForKeywords(null, store)).toEqual([])
       expect(getFeacnCodesForKeywords([], store)).toEqual([])
+    })
+  })
+
+  describe('getKeywordFeacnPairs', () => {
+    it('should create keyword/FEACN code pairs', () => {
+      const store = {
+        keyWords: [
+          { id: 1, word: 'alpha', feacnCodes: ['123', '456'] },
+          { id: 2, word: 'beta', feacnCodes: ['789'] }
+        ]
+      }
+      const result = getKeywordFeacnPairs([1, 2], store)
+      expect(result).toEqual([
+        { id: '1-123', word: 'alpha', feacnCode: '123' },
+        { id: '1-456', word: 'alpha', feacnCode: '456' },
+        { id: '2-789', word: 'beta', feacnCode: '789' }
+      ])
+    })
+
+    it('should return empty array for invalid input', () => {
+      const store = { keyWords: [] }
+      expect(getKeywordFeacnPairs(null, store)).toEqual([])
+      expect(getKeywordFeacnPairs([], store)).toEqual([])
     })
   })
 


### PR DESCRIPTION
## Summary
- add helper to build keyword/FEACN code pairs
- show all FEACN code matches for keywords in parcel edit dialogs
- cover new helper with tests

## Testing
- `npx vitest run tests/parcels.list.helpers.spec.js`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a210257f34832184db983da804e772