### PR TITLE
refactor: rename feacn codes store to feacn orders

### DIFF
--- a/src/components/FeacnCodes_List.vue
+++ b/src/components/FeacnCodes_List.vue
@@ -27,13 +27,13 @@
 
 import { ref, onMounted, watch, computed } from 'vue'
 import { storeToRefs } from 'pinia'
-import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
+import { useFeacnOrdersStore } from '@/stores/feacn.orders.store.js'
 import { useAuthStore } from '@/stores/auth.store.js'
 import { useAlertStore } from '@/stores/alert.store.js'
 import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
 import { mdiMagnify } from '@mdi/js'
 
-const feacnStore = useFeacnCodesStore()
+const feacnStore = useFeacnOrdersStore()
 const alertStore = useAlertStore()
 const authStore = useAuthStore()
 

--- a/src/components/OzonParcel_EditDialog.vue
+++ b/src/components/OzonParcel_EditDialog.vue
@@ -33,7 +33,7 @@ import { useParcelStatusesStore } from '@/stores/parcel.statuses.store.js'
 import { useParcelCheckStatusStore } from '@/stores/parcel.checkstatuses.store.js'
 import { useStopWordsStore } from '@/stores/stop.words.store.js'
 import { useKeyWordsStore } from '@/stores/key.words.store.js'
-import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
+import { useFeacnOrdersStore } from '@/stores/feacn.orders.store.js'
 import { useCountriesStore } from '@/stores/countries.store.js'
 import { useParcelViewsStore } from '@/stores/parcel.views.store.js'
 import { storeToRefs } from 'pinia'
@@ -63,7 +63,7 @@ const statusStore = useParcelStatusesStore()
 const parcelCheckStatusStore = useParcelCheckStatusStore()
 const stopWordsStore = useStopWordsStore()
 const keyWordsStore = useKeyWordsStore()
-const feacnCodesStore = useFeacnCodesStore()
+const feacnOrdersStore = useFeacnOrdersStore()
 const countriesStore = useCountriesStore()
 const parcelViewsStore = useParcelViewsStore()
 
@@ -71,14 +71,14 @@ await statusStore.ensureLoaded()
 await parcelCheckStatusStore.ensureLoaded()
 await stopWordsStore.ensureLoaded()
 await keyWordsStore.ensureLoaded()
-await feacnCodesStore.ensureLoaded()
+await feacnOrdersStore.ensureLoaded()
 await countriesStore.ensureLoaded()
 await parcelsStore.getById(props.id)
 await parcelViewsStore.add(props.id)
 
 const { item } = storeToRefs(parcelsStore)
 const { stopWords } = storeToRefs(stopWordsStore)
-const { orders: feacnOrders } = storeToRefs(feacnCodesStore)
+const { orders: feacnOrders } = storeToRefs(feacnOrdersStore)
 const { countries } = storeToRefs(countriesStore)
 
 // Reactive reference to track current statusId for color updates

--- a/src/components/OzonParcels_List.vue
+++ b/src/components/OzonParcels_List.vue
@@ -32,7 +32,7 @@ import { useParcelStatusesStore } from '@/stores/parcel.statuses.store.js'
 import { useParcelCheckStatusStore } from '@/stores/parcel.checkstatuses.store.js'
 import { useKeyWordsStore } from '@/stores/key.words.store.js'
 import { useStopWordsStore } from '@/stores/stop.words.store.js'
-import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
+import { useFeacnOrdersStore } from '@/stores/feacn.orders.store.js'
 import { useCountriesStore } from '@/stores/countries.store.js'
 import { useAuthStore } from '@/stores/auth.store.js'
 import router from '@/router'
@@ -68,13 +68,13 @@ const parcelStatusStore = useParcelStatusesStore()
 const parcelCheckStatusStore = useParcelCheckStatusStore()
 const keyWordsStore = useKeyWordsStore()
 const stopWordsStore = useStopWordsStore()
-const feacnCodesStore = useFeacnCodesStore()
+const feacnOrdersStore = useFeacnOrdersStore()
 const countriesStore = useCountriesStore()
 const authStore = useAuthStore()
 
 const { items, loading, error, totalCount } = storeToRefs(parcelsStore)
 const { stopWords } = storeToRefs(stopWordsStore)
-const { orders: feacnOrders } = storeToRefs(feacnCodesStore)
+const { orders: feacnOrders } = storeToRefs(feacnOrdersStore)
 const {
   parcels_per_page,
   parcels_sort_by,
@@ -139,7 +139,7 @@ onMounted(async () => {
     await parcelCheckStatusStore.ensureLoaded()
     if (!isComponentMounted.value) return
     
-    await feacnCodesStore.ensureLoaded()
+    await feacnOrdersStore.ensureLoaded()
     if (!isComponentMounted.value) return
     
     await countriesStore.ensureLoaded()

--- a/src/components/WbrParcel_EditDialog.vue
+++ b/src/components/WbrParcel_EditDialog.vue
@@ -33,7 +33,7 @@ import { useParcelStatusesStore } from '@/stores/parcel.statuses.store.js'
 import { useParcelCheckStatusStore } from '@/stores/parcel.checkstatuses.store.js'
 import { useStopWordsStore } from '@/stores/stop.words.store.js'
 import { useKeyWordsStore } from '@/stores/key.words.store.js'
-import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
+import { useFeacnOrdersStore } from '@/stores/feacn.orders.store.js'
 import { useCountriesStore } from '@/stores/countries.store.js'
 import { useParcelViewsStore } from '@/stores/parcel.views.store.js'
 import { useRegistersStore } from '@/stores/registers.store.js'
@@ -63,7 +63,7 @@ const statusStore = useParcelStatusesStore()
 const parcelCheckStatusStore = useParcelCheckStatusStore()
 const stopWordsStore = useStopWordsStore()
 const keyWordsStore = useKeyWordsStore()
-const feacnCodesStore = useFeacnCodesStore()
+const feacnOrdersStore = useFeacnOrdersStore()
 const countriesStore = useCountriesStore()
 const parcelViewsStore = useParcelViewsStore()
 
@@ -71,14 +71,14 @@ await statusStore.ensureLoaded()
 await parcelCheckStatusStore.ensureLoaded()
 await stopWordsStore.ensureLoaded()
 await keyWordsStore.ensureLoaded()
-await feacnCodesStore.ensureLoaded()
+await feacnOrdersStore.ensureLoaded()
 await countriesStore.ensureLoaded()
 await parcelsStore.getById(props.id)
 await parcelViewsStore.add(props.id)
 
 const { item } = storeToRefs(parcelsStore)
 const { stopWords } = storeToRefs(stopWordsStore)
-const { orders: feacnOrders } = storeToRefs(feacnCodesStore)
+const { orders: feacnOrders } = storeToRefs(feacnOrdersStore)
 const { countries } = storeToRefs(countriesStore)
 
 // Reactive reference to track current statusId for color updates

--- a/src/components/WbrParcels_List.vue
+++ b/src/components/WbrParcels_List.vue
@@ -32,7 +32,7 @@ import { useParcelStatusesStore } from '@/stores/parcel.statuses.store.js'
 import { useParcelCheckStatusStore } from '@/stores/parcel.checkstatuses.store.js'
 import { useKeyWordsStore } from '@/stores/key.words.store.js'
 import { useStopWordsStore } from '@/stores/stop.words.store.js'
-import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
+import { useFeacnOrdersStore } from '@/stores/feacn.orders.store.js'
 import { useCountriesStore } from '@/stores/countries.store.js'
 import { useAuthStore } from '@/stores/auth.store.js'
 import router from '@/router'
@@ -68,13 +68,13 @@ const parcelStatusStore = useParcelStatusesStore()
 const parcelCheckStatusStore = useParcelCheckStatusStore()
 const stopWordsStore = useStopWordsStore()
 const keyWordsStore = useKeyWordsStore()
-const feacnCodesStore = useFeacnCodesStore()
+const feacnOrdersStore = useFeacnOrdersStore()
 const countriesStore = useCountriesStore()
 const authStore = useAuthStore()
 
 const { items, loading, error, totalCount } = storeToRefs(parcelsStore)
 const { stopWords } = storeToRefs(stopWordsStore)
-const { orders: feacnOrders } = storeToRefs(feacnCodesStore)
+const { orders: feacnOrders } = storeToRefs(feacnOrdersStore)
 const {
   parcels_per_page,
   parcels_sort_by,
@@ -139,7 +139,7 @@ onMounted(async () => {
     await parcelCheckStatusStore.ensureLoaded()
     if (!isComponentMounted.value) return
     
-    await feacnCodesStore.ensureLoaded()
+    await feacnOrdersStore.ensureLoaded()
     if (!isComponentMounted.value) return
     
     await countriesStore.ensureLoaded()

--- a/src/init.app.js
+++ b/src/init.app.js
@@ -102,7 +102,7 @@ import App from '@/App.vue'
 import router from '@/router'
 
 import { useAuthStore } from '@/stores/auth.store.js'
-import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
+import { useFeacnOrdersStore } from '@/stores/feacn.orders.store.js'
 import { useTransportationTypesStore } from '@/stores/transportation.types.store.js'
 import { useCustomsProceduresStore } from '@/stores/customs.procedures.store.js'
 import { useCountriesStore } from '@/stores/countries.store.js'
@@ -165,13 +165,13 @@ export function initializeApp() {
     .use(VuetifyUseDialog)
 
   // Initialize global data after Pinia is set up
-  const feacnCodesStore = useFeacnCodesStore()
+  const feacnOrdersStore = useFeacnOrdersStore()
   const transportationTypesStore = useTransportationTypesStore()
   const customsProceduresStore = useCustomsProceduresStore()
   const countriesStore = useCountriesStore()
 
-  // Load feacnOrders globally at app startup
-  feacnCodesStore.ensureLoaded()
+  // Load FEACN orders globally at app startup
+  feacnOrdersStore.ensureLoaded()
   transportationTypesStore.ensureLoaded()
   customsProceduresStore.ensureLoaded()
   countriesStore.ensureLoaded()

--- a/src/stores/feacn.orders.store.js
+++ b/src/stores/feacn.orders.store.js
@@ -30,7 +30,7 @@ import { apiUrl } from '@/helpers/config.js'
 
 const baseUrl = `${apiUrl}/feacncodes`
 
-export const useFeacnCodesStore = defineStore('feacn.codes', () => {
+export const useFeacnOrdersStore = defineStore('feacn.orders', () => {
   const orders = ref([])
   const prefixes = ref([])
   const loading = ref(false)

--- a/tests/FeacnCodes_List.spec.js
+++ b/tests/FeacnCodes_List.spec.js
@@ -43,7 +43,7 @@ vi.mock('pinia', async () => {
   }
 })
 
-const mockFeacnCodesStore = createMockStore({
+const mockFeacnOrdersStore = createMockStore({
   orders: ref([
     { id: 1, title: 'Doc1', url: 'http://a' },
     { id: 2, title: 'Doc2', url: 'http://b' }
@@ -80,8 +80,8 @@ const mockAuthStore = createMockStore({
   isAdmin: ref(false)
 })
 
-vi.mock('@/stores/feacn.codes.store.js', () => ({
-  useFeacnCodesStore: vi.fn(() => mockFeacnCodesStore)
+vi.mock('@/stores/feacn.orders.store.js', () => ({
+  useFeacnOrdersStore: vi.fn(() => mockFeacnOrdersStore)
 }))
 
 vi.mock('@/stores/alert.store.js', () => ({
@@ -102,31 +102,31 @@ describe('FeacnCodes_List.vue', () => {
     setActivePinia(createPinia())
     
     vi.clearAllMocks()
-    mockFeacnCodesStore.orders.value = [
+    mockFeacnOrdersStore.orders.value = [
       { id: 1, title: 'Doc1', url: 'http://a' },
       { id: 2, title: 'Doc2', url: 'http://b' }
     ]
-    mockFeacnCodesStore.loading.value = false
-    mockFeacnCodesStore.error.value = null
-    mockFeacnCodesStore.prefixes.value = []
+    mockFeacnOrdersStore.loading.value = false
+    mockFeacnOrdersStore.error.value = null
+    mockFeacnOrdersStore.prefixes.value = []
     mockAuthStore.feacnorders_search.value = ''
     mockAuthStore.isAdmin.value = false
   })
 
   it('calls ensureLoaded on mount', () => {
     mount(FeacnCodesList, { global: { stubs: vuetifyStubs } })
-    expect(mockFeacnCodesStore.ensureLoaded).toHaveBeenCalled()
+    expect(mockFeacnOrdersStore.ensureLoaded).toHaveBeenCalled()
   })
 
   it('updateCodes calls store update', async () => {
-    mockFeacnCodesStore.update.mockResolvedValue()
+    mockFeacnOrdersStore.update.mockResolvedValue()
     const wrapper = mount(FeacnCodesList, { global: { stubs: vuetifyStubs } })
     await wrapper.vm.updateCodes()
-    expect(mockFeacnCodesStore.update).toHaveBeenCalled()
+    expect(mockFeacnOrdersStore.update).toHaveBeenCalled()
   })
 
   it('shows empty message when no orders', () => {
-    mockFeacnCodesStore.orders.value = []
+    mockFeacnOrdersStore.orders.value = []
     const wrapper = mount(FeacnCodesList, { global: { stubs: vuetifyStubs } })
     expect(wrapper.text()).toContain('Список документов пуст')
   })
@@ -138,8 +138,8 @@ describe('FeacnCodes_List.vue', () => {
   })
 
   it('shows spinner and error message', () => {
-    mockFeacnCodesStore.loading.value = true
-    mockFeacnCodesStore.error.value = 'bad'
+    mockFeacnOrdersStore.loading.value = true
+    mockFeacnOrdersStore.error.value = 'bad'
     const wrapper = mount(FeacnCodesList, { global: { stubs: vuetifyStubs } })
     expect(wrapper.html()).toContain('spinner-border')
     expect(wrapper.html()).toContain('Ошибка при загрузке информации')

--- a/tests/feacn.orders.store.spec.js
+++ b/tests/feacn.orders.store.spec.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
+import { useFeacnOrdersStore } from '@/stores/feacn.orders.store.js'
 import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
 import { apiUrl } from '@/helpers/config.js'
 
@@ -12,7 +12,7 @@ vi.mock('@/helpers/config.js', () => ({
   apiUrl: 'http://localhost:8080/api'
 }))
 
-describe('feacn.codes store', () => {
+describe('feacn.orders store', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
@@ -22,7 +22,7 @@ describe('feacn.codes store', () => {
     const mockOrders = [{ id: 1, title: 'doc', url: 'u' }]
     fetchWrapper.get.mockResolvedValue(mockOrders)
 
-    const store = useFeacnCodesStore()
+    const store = useFeacnOrdersStore()
     await store.getOrders()
 
     expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders`)
@@ -36,7 +36,7 @@ describe('feacn.codes store', () => {
     const testError = new Error('API error')
     fetchWrapper.get.mockRejectedValue(testError)
 
-    const store = useFeacnCodesStore()
+    const store = useFeacnOrdersStore()
     await store.getOrders()
 
     expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders`)
@@ -50,7 +50,7 @@ describe('feacn.codes store', () => {
     const mockPrefixes = [{ id: 1, code: '1', exceptions: [] }]
     fetchWrapper.get.mockResolvedValue(mockPrefixes)
 
-    const store = useFeacnCodesStore()
+    const store = useFeacnOrdersStore()
     await store.getPrefixes(1)
 
     expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/1/prefixes`)
@@ -63,7 +63,7 @@ describe('feacn.codes store', () => {
     const testError = new Error('API error')
     fetchWrapper.get.mockRejectedValue(testError)
 
-    const store = useFeacnCodesStore()
+    const store = useFeacnOrdersStore()
     await store.getPrefixes(1)
 
     expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/1/prefixes`)
@@ -72,7 +72,7 @@ describe('feacn.codes store', () => {
   })
   
   it('clears prefixes when no orderId is provided', async () => {
-    const store = useFeacnCodesStore()
+    const store = useFeacnOrdersStore()
     store.prefixes.value = [{ id: 1 }] // Set some initial value
     
     await store.getPrefixes(null)
@@ -85,7 +85,7 @@ describe('feacn.codes store', () => {
     fetchWrapper.post.mockResolvedValue({})
     fetchWrapper.get.mockResolvedValue([])
 
-    const store = useFeacnCodesStore()
+    const store = useFeacnOrdersStore()
     await store.update()
 
     expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/update`)
@@ -98,7 +98,7 @@ describe('feacn.codes store', () => {
     const testError = new Error('API error')
     fetchWrapper.post.mockRejectedValue(testError)
 
-    const store = useFeacnCodesStore()
+    const store = useFeacnOrdersStore()
     await store.update()
 
     expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/update`)
@@ -111,7 +111,7 @@ describe('feacn.codes store', () => {
     fetchWrapper.post.mockResolvedValue({})
     fetchWrapper.get.mockResolvedValue([])
 
-    const store = useFeacnCodesStore()
+    const store = useFeacnOrdersStore()
     await store.enable(3)
 
     expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/3/enable`)
@@ -124,7 +124,7 @@ describe('feacn.codes store', () => {
     const testError = new Error('API error')
     fetchWrapper.post.mockRejectedValue(testError)
 
-    const store = useFeacnCodesStore()
+    const store = useFeacnOrdersStore()
     await store.enable(3)
 
     expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/3/enable`)
@@ -137,7 +137,7 @@ describe('feacn.codes store', () => {
     fetchWrapper.post.mockResolvedValue({})
     fetchWrapper.get.mockResolvedValue([])
 
-    const store = useFeacnCodesStore()
+    const store = useFeacnOrdersStore()
     await store.disable(4)
 
     expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/4/disable`)
@@ -150,7 +150,7 @@ describe('feacn.codes store', () => {
     const testError = new Error('API error')
     fetchWrapper.post.mockRejectedValue(testError)
 
-    const store = useFeacnCodesStore()
+    const store = useFeacnOrdersStore()
     await store.disable(4)
 
     expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/4/disable`)
@@ -163,7 +163,7 @@ describe('feacn.codes store', () => {
     const mockOrders = [{ id: 1, title: 'doc', url: 'u' }]
     fetchWrapper.get.mockResolvedValue(mockOrders)
 
-    const store = useFeacnCodesStore()
+    const store = useFeacnOrdersStore()
     await store.ensureLoaded()
     
     // First call should call getOrders
@@ -182,7 +182,7 @@ describe('feacn.codes store', () => {
     fetchWrapper.post.mockResolvedValue({})
     fetchWrapper.get.mockResolvedValue([])
 
-    const store = useFeacnCodesStore()
+    const store = useFeacnOrdersStore()
     await store.toggleEnabled(5, true)
 
     expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/5/enable`)
@@ -193,7 +193,7 @@ describe('feacn.codes store', () => {
     fetchWrapper.post.mockResolvedValue({})
     fetchWrapper.get.mockResolvedValue([])
 
-    const store = useFeacnCodesStore()
+    const store = useFeacnOrdersStore()
     await store.toggleEnabled(6, false)
 
     expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/6/disable`)


### PR DESCRIPTION
## Summary
- rename feacn.codes.store to feacn.orders.store
- update imports and references across components and initialization
- adjust related tests

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a8112f6e18832194ebeb5658cea73d