### PR TITLE
refactor: rename orders check helpers to parcels

### DIFF
--- a/src/components/OzonParcel_EditDialog.vue
+++ b/src/components/OzonParcel_EditDialog.vue
@@ -39,7 +39,7 @@ import { useParcelViewsStore } from '@/stores/parcel.views.store.js'
 import { storeToRefs } from 'pinia'
 import { ref, watch, computed } from 'vue'
 import { ozonRegisterColumnTitles, ozonRegisterColumnTooltips } from '@/helpers/ozon.register.mapping.js'
-import { HasIssues, getCheckStatusInfo, getCheckStatusClass } from '@/helpers/orders.check.helper.js'
+import { HasIssues, getCheckStatusInfo, getCheckStatusClass } from '@/helpers/parcels.check.helpers.js'
 import { getFieldTooltip } from '@/helpers/parcel.tooltip.helpers.js'
 import { useRegistersStore } from '@/stores/registers.store.js'
 import {

--- a/src/components/OzonParcels_List.vue
+++ b/src/components/OzonParcels_List.vue
@@ -39,7 +39,7 @@ import router from '@/router'
 import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
 import { storeToRefs } from 'pinia'
 import { ozonRegisterColumnTitles } from '@/helpers/ozon.register.mapping.js'
-import { HasIssues, getCheckStatusClass } from '@/helpers/orders.check.helper.js'
+import { HasIssues, getCheckStatusClass } from '@/helpers/parcels.check.helpers.js'
 import { getCheckStatusTooltip } from '@/helpers/parcel.tooltip.helpers.js'
 import { ensureHttps } from '@/helpers/url.helpers.js'
 import {

--- a/src/components/WbrParcel_EditDialog.vue
+++ b/src/components/WbrParcel_EditDialog.vue
@@ -40,7 +40,7 @@ import { useRegistersStore } from '@/stores/registers.store.js'
 import { storeToRefs } from 'pinia'
 import { ref, watch, computed } from 'vue'
 import { wbrRegisterColumnTitles, wbrRegisterColumnTooltips } from '@/helpers/wbr.register.mapping.js'
-import { HasIssues, getCheckStatusInfo, getCheckStatusClass } from '@/helpers/orders.check.helper.js'
+import { HasIssues, getCheckStatusInfo, getCheckStatusClass } from '@/helpers/parcels.check.helpers.js'
 import { getFieldTooltip } from '@/helpers/parcel.tooltip.helpers.js'
 import {
   getFeacnCodesForKeywords,

--- a/src/components/WbrParcels_List.vue
+++ b/src/components/WbrParcels_List.vue
@@ -39,7 +39,7 @@ import router from '@/router'
 import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
 import { storeToRefs } from 'pinia'
 import { wbrRegisterColumnTitles } from '@/helpers/wbr.register.mapping.js'
-import { HasIssues, getCheckStatusClass } from '@/helpers/orders.check.helper.js'
+import { HasIssues, getCheckStatusClass } from '@/helpers/parcels.check.helpers.js'
 import { getCheckStatusTooltip } from '@/helpers/parcel.tooltip.helpers.js'
 import { ensureHttps } from '@/helpers/url.helpers.js'
 import {

--- a/src/helpers/parcel.tooltip.helpers.js
+++ b/src/helpers/parcel.tooltip.helpers.js
@@ -23,7 +23,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { HasIssues, getCheckStatusInfo } from '@/helpers/orders.check.helper.js'
+import { HasIssues, getCheckStatusInfo } from '@/helpers/parcels.check.helpers.js'
 
 /**
  * Get tooltip for form fields combining title and tooltip information

--- a/src/helpers/parcels.check.helpers.js
+++ b/src/helpers/parcels.check.helpers.js
@@ -25,7 +25,7 @@
 
 /**
  * Generates stopwords text for display
- * @param {Object} item - The order item containing stopWordIds
+ * @param {Object} item - The parcel item containing stopWordIds
  * @param {Array} stopWordsCollection - Collection of all stopwords
  * @returns {string|null} - Formatted stopwords text or null if no stopwords
  */
@@ -45,7 +45,7 @@ export function getStopWordsText(item, stopWordsCollection) {
 
 /**
  * Generates feacn orders comment text for display
- * @param {Object} item - The order item containing feacnOrderIds
+ * @param {Object} item - The parcel item containing feacnOrderIds
  * @param {Array} feacnOrdersCollection - Collection of all feacn orders
  * @returns {string|null} - Formatted feacn orders comment text or null if no orders
  */
@@ -65,7 +65,7 @@ export function getFeacnOrdersText(item, feacnOrdersCollection) {
 
 /**
  * Generates complete stopwords information text
- * @param {Object} item - The order item containing stopWordIds
+ * @param {Object} item - The parcel item containing stopWordIds
  * @param {Array} stopWordsCollection - Collection of all stopwords
  * @returns {string|null} - Formatted complete stopwords information or null
  */
@@ -81,7 +81,7 @@ export function getStopWordsInfo(item, stopWordsCollection) {
 
 /**
  * Generates complete feacn orders information text
- * @param {Object} item - The order item containing feacnOrderIds
+ * @param {Object} item - The parcel item containing feacnOrderIds
  * @param {Array} feacnOrdersCollection - Collection of all feacn orders
  * @returns {string|null} - Formatted complete feacn orders information or null
  */
@@ -96,8 +96,8 @@ export function getFeacnOrdersInfo(item, feacnOrdersCollection) {
 }
 
 /**
- * Generates combined check order information text with both feacn orders and stopwords
- * @param {Object} item - The order item containing feacnOrderIds and stopWordIds
+ * Generates combined check information text with both feacn orders and stopwords
+ * @param {Object} item - The parcel item containing feacnOrderIds and stopWordIds
  * @param {Array} feacnOrdersCollection - Collection of all feacn orders
  * @param {Array} stopWordsCollection - Collection of all stopwords
  * @returns {string|null} - Combined formatted information or null if neither present

--- a/src/helpers/parcels.list.helpers.js
+++ b/src/helpers/parcels.list.helpers.js
@@ -27,7 +27,7 @@
  * Helper functions for parcels list functionality shared between WBR and Ozon components
  */
 
-import { HasIssues } from '@/helpers/orders.check.helper.js'
+import { HasIssues } from '@/helpers/parcels.check.helpers.js'
 
 /**
  * Navigates to edit parcel page

--- a/tests/parcel.tooltip.helpers.spec.js
+++ b/tests/parcel.tooltip.helpers.spec.js
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { getFieldTooltip, getCheckStatusTooltip } from '@/helpers/parcel.tooltip.helpers.js'
-import * as ordersCheckHelper from '@/helpers/orders.check.helper.js'
+import * as parcelsCheckHelpers from '@/helpers/parcels.check.helpers.js'
 
-// Mock the orders check helper
-vi.mock('@/helpers/orders.check.helper.js', () => ({
+// Mock the parcels check helpers
+vi.mock('@/helpers/parcels.check.helpers.js', () => ({
   HasIssues: vi.fn(),
   getCheckStatusInfo: vi.fn()
 }))
@@ -77,14 +77,14 @@ describe('parcel tooltip helpers', () => {
       const stopWords = []
       
       mockGetStatusTitle.mockReturnValue('Статус 50')
-      vi.mocked(ordersCheckHelper.HasIssues).mockReturnValue(false)
+        vi.mocked(parcelsCheckHelpers.HasIssues).mockReturnValue(false)
       
       const result = getCheckStatusTooltip(item, mockGetStatusTitle, feacnOrders, stopWords)
       
       expect(result).toBe('Статус 50')
       expect(mockGetStatusTitle).toHaveBeenCalledWith(50)
-      expect(ordersCheckHelper.HasIssues).toHaveBeenCalledWith(50)
-      expect(ordersCheckHelper.getCheckStatusInfo).not.toHaveBeenCalled()
+        expect(parcelsCheckHelpers.HasIssues).toHaveBeenCalledWith(50)
+        expect(parcelsCheckHelpers.getCheckStatusInfo).not.toHaveBeenCalled()
     })
 
     it('returns base title when item has issues but no check info', () => {
@@ -93,15 +93,15 @@ describe('parcel tooltip helpers', () => {
       const stopWords = []
       
       mockGetStatusTitle.mockReturnValue('Статус 150')
-      vi.mocked(ordersCheckHelper.HasIssues).mockReturnValue(true)
-      vi.mocked(ordersCheckHelper.getCheckStatusInfo).mockReturnValue(null)
+        vi.mocked(parcelsCheckHelpers.HasIssues).mockReturnValue(true)
+        vi.mocked(parcelsCheckHelpers.getCheckStatusInfo).mockReturnValue(null)
       
       const result = getCheckStatusTooltip(item, mockGetStatusTitle, feacnOrders, stopWords)
       
       expect(result).toBe('Статус 150')
       expect(mockGetStatusTitle).toHaveBeenCalledWith(150)
-      expect(ordersCheckHelper.HasIssues).toHaveBeenCalledWith(150)
-      expect(ordersCheckHelper.getCheckStatusInfo).toHaveBeenCalledWith(item, feacnOrders, stopWords)
+        expect(parcelsCheckHelpers.HasIssues).toHaveBeenCalledWith(150)
+        expect(parcelsCheckHelpers.getCheckStatusInfo).toHaveBeenCalledWith(item, feacnOrders, stopWords)
     })
 
     it('returns combined title and check info when item has issues and check info', () => {
@@ -120,15 +120,15 @@ describe('parcel tooltip helpers', () => {
       ]
       
       mockGetStatusTitle.mockReturnValue('Статус 150')
-      vi.mocked(ordersCheckHelper.HasIssues).mockReturnValue(true)
-      vi.mocked(ordersCheckHelper.getCheckStatusInfo).mockReturnValue('Возможные ограничения по коду ТН ВЭД:\nOrder 1, Order 2\n\nСтоп-слова и фразы:\nforbidden, restricted')
+        vi.mocked(parcelsCheckHelpers.HasIssues).mockReturnValue(true)
+        vi.mocked(parcelsCheckHelpers.getCheckStatusInfo).mockReturnValue('Возможные ограничения по коду ТН ВЭД:\nOrder 1, Order 2\n\nСтоп-слова и фразы:\nforbidden, restricted')
       
       const result = getCheckStatusTooltip(item, mockGetStatusTitle, feacnOrders, stopWords)
       
       expect(result).toBe('Статус 150\nВозможные ограничения по коду ТН ВЭД:\nOrder 1, Order 2\n\nСтоп-слова и фразы:\nforbidden, restricted')
       expect(mockGetStatusTitle).toHaveBeenCalledWith(150)
-      expect(ordersCheckHelper.HasIssues).toHaveBeenCalledWith(150)
-      expect(ordersCheckHelper.getCheckStatusInfo).toHaveBeenCalledWith(item, feacnOrders, stopWords)
+      expect(parcelsCheckHelpers.HasIssues).toHaveBeenCalledWith(150)
+      expect(parcelsCheckHelpers.getCheckStatusInfo).toHaveBeenCalledWith(item, feacnOrders, stopWords)
     })
 
     it('handles empty arrays for feacnOrders and stopWords', () => {
@@ -137,13 +137,13 @@ describe('parcel tooltip helpers', () => {
       const stopWords = []
       
       mockGetStatusTitle.mockReturnValue('Статус 150')
-      vi.mocked(ordersCheckHelper.HasIssues).mockReturnValue(true)
-      vi.mocked(ordersCheckHelper.getCheckStatusInfo).mockReturnValue('')
+        vi.mocked(parcelsCheckHelpers.HasIssues).mockReturnValue(true)
+        vi.mocked(parcelsCheckHelpers.getCheckStatusInfo).mockReturnValue('')
       
       const result = getCheckStatusTooltip(item, mockGetStatusTitle, feacnOrders, stopWords)
       
       expect(result).toBe('Статус 150')
-      expect(ordersCheckHelper.getCheckStatusInfo).toHaveBeenCalledWith(item, feacnOrders, stopWords)
+      expect(parcelsCheckHelpers.getCheckStatusInfo).toHaveBeenCalledWith(item, feacnOrders, stopWords)
     })
 
     it('handles undefined checkStatusId', () => {
@@ -152,7 +152,7 @@ describe('parcel tooltip helpers', () => {
       const stopWords = []
       
       mockGetStatusTitle.mockReturnValue('Неизвестный статус')
-      vi.mocked(ordersCheckHelper.HasIssues).mockReturnValue(false)
+        vi.mocked(parcelsCheckHelpers.HasIssues).mockReturnValue(false)
       
       const result = getCheckStatusTooltip(item, mockGetStatusTitle, feacnOrders, stopWords)
       

--- a/tests/parcels.check.helpers.spec.js
+++ b/tests/parcels.check.helpers.spec.js
@@ -10,9 +10,9 @@ import {
   HasNoIssues,
   IsApproved,
   getCheckStatusClass
-} from '@/helpers/orders.check.helper.js'
+} from '@/helpers/parcels.check.helpers.js'
 
-describe('orders.check.helper', () => {
+describe('parcels.check.helpers', () => {
   const mockStopWords = [
     { id: 1, word: 'forbidden' },
     { id: 2, word: 'banned' },

--- a/tests/parcels.list.helpers.spec.js
+++ b/tests/parcels.list.helpers.spec.js
@@ -17,7 +17,7 @@ vi.mock('../src/helpers/config.js', () => ({
 }))
 
 // Mock helper functions
-vi.mock('../src/helpers/orders.check.helper.js', () => ({
+vi.mock('../src/helpers/parcels.check.helpers.js', () => ({
   HasIssues: vi.fn(() => false)
 }))
 
@@ -218,7 +218,7 @@ describe('Parcels List Helpers', () => {
 
   describe('getRowPropsForParcel', () => {
     it('should return class for parcel with issues', async () => {
-      const { HasIssues } = await vi.importMock('../src/helpers/orders.check.helper.js')
+      const { HasIssues } = await vi.importMock('../src/helpers/parcels.check.helpers.js')
       HasIssues.mockReturnValue(true)
 
       const data = {
@@ -232,7 +232,7 @@ describe('Parcels List Helpers', () => {
     })
 
     it('should return empty class for parcel without issues', async () => {
-      const { HasIssues } = await vi.importMock('../src/helpers/orders.check.helper.js')
+      const { HasIssues } = await vi.importMock('../src/helpers/parcels.check.helpers.js')
       HasIssues.mockReturnValue(false)
 
       const data = {

--- a/tests/wbr.register.mapping.spec.js
+++ b/tests/wbr.register.mapping.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { HasIssues } from '@/helpers/orders.check.helper.js'
+import { HasIssues } from '@/helpers/parcels.check.helpers.js'
 
-describe('orders.check.helper.js HasIssues', () => {
+describe('parcels.check.helpers.js HasIssues', () => {
 
   describe('HasIssues', () => {
     it('returns true when checkStatusId is between 101 and 200', () => {


### PR DESCRIPTION
## Summary
- rename orders.check.helper module to parcels.check.helpers
- update imports and comments for parcels
- adjust affected tests

## Testing
- `npm test tests/parcels.check.helpers.spec.js tests/parcels.list.helpers.spec.js tests/parcel.tooltip.helpers.spec.js tests/wbr.register.mapping.spec.js`

------
https://chatgpt.com/codex/tasks/task_e_68a82f9ad4ac8321bbb8d1b18d6c274a