### PR TITLE
Rename FEACN restrictions route

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -104,7 +104,7 @@ function getUserName() {
             <RouterLink to="/countries" class="link">Страны</RouterLink>
           </v-list-item>
           <v-list-item>
-            <RouterLink to="/feacn" class="link">Запреты ТН ВЭД</RouterLink>
+            <RouterLink to="/feacn/orders" class="link">Ограничения по кодам ТН ВЭД</RouterLink>
           </v-list-item>
           <v-list-item>
             <RouterLink to="/keywords" class="link">Подбор ТН ВЭД</RouterLink>

--- a/src/components/FeacnOrders_List.vue
+++ b/src/components/FeacnOrders_List.vue
@@ -148,13 +148,13 @@ async function handleToggleOrderEnabled(order) {
 
 <template>
   <div class="settings table-3" data-testid="feacn-orders-list">
-    <h1 class="primary-heading">Коды ТН ВЭД с ограничениями</h1>
+    <h1 class="primary-heading">Ограничения по кодам ТН ВЭД</h1>
     <hr class="hr" />
 
     <div class="link-crt" v-if="isAdmin">
       <a @click="updateCodes" class="link">
         <font-awesome-icon size="1x" icon="fa-solid fa-file-import" class="link" />
-        &nbsp;&nbsp;&nbsp;Обновить информацию о кодах ТН ВЭД с ограничениями
+        &nbsp;&nbsp;&nbsp;Обновить информацию об ограничениях по кодам ТН ВЭД
       </a>
     </div>
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -144,8 +144,8 @@ const router = createRouter({
       component: () => import('@/views/Countries_View.vue')
     },
     {
-      path: '/feacn',
-      name: 'Коды ТН ВЭД',
+      path: '/feacn/orders',
+      name: 'Ограничения по кодам ТН ВЭД',
       component: () => import('@/views/FeacnOrders_View.vue')
     },
     {

--- a/tests/App.logout.spec.js
+++ b/tests/App.logout.spec.js
@@ -81,7 +81,7 @@ const router = createRouter({
     { path: '/keywords', component: { template: '<div>Keywords</div>' } },
     { path: '/keyword/create', component: { template: '<div>Create Keyword</div>' } },
     { path: '/keyword/edit/:id', component: { template: '<div>Edit Keyword</div>' } },
-    { path: '/feacn', component: { template: '<div>Feacn</div>' } }
+    { path: '/feacn/orders', component: { template: '<div>Feacn</div>' } }
   ]
 })
 

--- a/tests/FeacnOrders_List.spec.js
+++ b/tests/FeacnOrders_List.spec.js
@@ -134,7 +134,7 @@ describe('FeacnOrders_List.vue', () => {
   it('renders admin update button when user is admin', () => {
     mockAuthStore.isAdmin.value = true
     const wrapper = mount(FeacnOrdersList, { global: { stubs: vuetifyStubs } })
-    expect(wrapper.text()).toContain('Обновить информацию о кодах')
+    expect(wrapper.text()).toContain('Обновить информацию об ограничениях')
   })
 
   it('shows spinner and error message', () => {


### PR DESCRIPTION
## Summary
- rename `/feacn` route to `/feacn/orders` with title "Ограничения по кодам ТН ВЭД"
- update navigation and list component text for new route
- adjust tests to use new route path and wording

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a833ad01508321b20281e2aeabcd50