### PR TITLE
feat: add FEACN codes tree component

### DIFF
--- a/src/components/FeacnCodesTreeNode.vue
+++ b/src/components/FeacnCodesTreeNode.vue
@@ -1,0 +1,108 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import { formatFeacnNodeLabel } from '@/helpers/feacncodes.tree.helpers.js'
+
+defineOptions({ name: 'FeacnCodesTreeNode' })
+
+const props = defineProps({
+  node: { type: Object, required: true }
+})
+
+const emit = defineEmits(['toggle'])
+
+function handleToggle() {
+  // Don't allow toggling when loading
+  if (props.node.loading) {
+    return
+  }
+  emit('toggle', props.node)
+}
+</script>
+
+<template>
+  <li>
+    <span 
+      v-if="node.loaded && node.children.length === 0" 
+      class="toggle-placeholder"
+    />
+    <span 
+      v-else-if="node.loading"
+      class="toggle-loading"
+    >
+      <font-awesome-icon icon="fa-solid fa-spinner" spin />
+    </span>
+    <span 
+      v-else
+      class="toggle-icon"
+      @click="handleToggle"
+    >
+      <font-awesome-icon 
+        :icon="node.expanded ? 'fa-solid fa-minus' : 'fa-solid fa-plus'" 
+      />
+    </span>
+    
+    <span 
+      class="node-label" 
+      :class="{ 'loading': node.loading }"
+      @click="handleToggle"
+    >
+      {{ formatFeacnNodeLabel(node) }}
+    </span>
+    
+    <ul v-if="node.expanded && node.children.length > 0">
+      <FeacnCodesTreeNode 
+        v-for="child in node.children" 
+        :key="child.id" 
+        :node="child"
+        @toggle="$emit('toggle', $event)"
+      />
+    </ul>
+  </li>
+</template>
+
+<style scoped>
+.toggle-icon {
+  cursor: pointer;
+  width: 1em;
+  display: inline-block;
+}
+
+.toggle-placeholder, .toggle-loading {
+  display: inline-block;
+  width: 1em;
+}
+
+.node-label {
+  cursor: pointer;
+  margin-left: 0.25rem;
+}
+
+.node-label.loading {
+  opacity: 0.6;
+  cursor: wait;
+}
+</style>

--- a/src/components/FeacnCodes_Tree.vue
+++ b/src/components/FeacnCodes_Tree.vue
@@ -1,0 +1,122 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import { ref, onMounted, defineComponent, h, resolveComponent } from 'vue'
+import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
+import { mapFeacnCodesToNodes, formatFeacnNodeLabel } from '@/helpers/feacncodes.tree.helpers.js'
+
+defineOptions({ name: 'FeacnCodes_Tree' })
+
+const store = useFeacnCodesStore()
+const rootNodes = ref([])
+
+async function loadChildren(target = null) {
+  const parentId = target ? target.id : null
+  const children = await store.getChildren(parentId)
+  const mapped = mapFeacnCodesToNodes(children)
+  if (target) {
+    target.children = mapped
+    target.loaded = true
+  } else {
+    rootNodes.value = mapped
+  }
+}
+
+async function toggleNode(node) {
+  node.expanded = !node.expanded
+  if (node.expanded && !node.loaded) {
+    await loadChildren(node)
+  }
+}
+
+const TreeNode = defineComponent({
+  name: 'FeacnCodesTreeNode',
+  props: {
+    node: { type: Object, required: true }
+  },
+  setup(props) {
+    return () =>
+      h('li', [
+        (props.node.loaded && props.node.children.length === 0)
+          ? h('span', { class: 'toggle-placeholder' })
+          : h(
+              'span',
+              {
+                class: 'toggle-icon',
+                onClick: () => toggleNode(props.node)
+              },
+              [
+                h(resolveComponent('font-awesome-icon'), {
+                  icon: props.node.expanded ? 'fa-solid fa-minus' : 'fa-solid fa-plus'
+                })
+              ]
+            ),
+        h(
+          'span',
+          {
+            class: 'node-label',
+            onClick: () => toggleNode(props.node)
+          },
+          formatFeacnNodeLabel(props.node)
+        ),
+        props.node.expanded && props.node.children.length > 0
+          ? h('ul', props.node.children.map(child => h(TreeNode, { node: child, key: child.id })))
+          : null
+      ])
+  }
+})
+
+onMounted(() => {
+  loadChildren()
+})
+</script>
+
+<template>
+  <ul class="feacn-tree">
+    <TreeNode v-for="node in rootNodes" :key="node.id" :node="node" />
+  </ul>
+</template>
+
+<style scoped>
+.feacn-tree {
+  list-style-type: none;
+  padding-left: 0;
+}
+.toggle-icon {
+  cursor: pointer;
+  width: 1em;
+  display: inline-block;
+}
+.toggle-placeholder {
+  display: inline-block;
+  width: 1em;
+}
+.node-label {
+  cursor: pointer;
+  margin-left: 0.25rem;
+}
+</style>
+

--- a/src/helpers/feacncodes.tree.helpers.js
+++ b/src/helpers/feacncodes.tree.helpers.js
@@ -33,7 +33,8 @@ export function mapFeacnCodesToNodes(codes = []) {
     ...c,
     children: [],
     expanded: false,
-    loaded: false
+    loaded: false,
+    loading: false
   }))
 }
 

--- a/src/helpers/feacncodes.tree.helpers.js
+++ b/src/helpers/feacncodes.tree.helpers.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * Maps raw FEACN code DTOs into tree node objects used by the tree component
+ * @param {Array} codes - Array of FeacnCodeDto
+ * @returns {Array} Array of tree node objects
+ */
+export function mapFeacnCodesToNodes(codes = []) {
+  return codes.map(c => ({
+    ...c,
+    children: [],
+    expanded: false,
+    loaded: false
+  }))
+}
+
+/**
+ * Builds display label for a tree node
+ * @param {Object} node - Tree node object
+ * @returns {string} Display string in format "<CodeEx> : <Name>"
+ */
+export function formatFeacnNodeLabel(node) {
+  return `${node.codeEx} : ${node.name}`
+}
+

--- a/src/init.app.js
+++ b/src/init.app.js
@@ -58,7 +58,8 @@ import {
   faArrowUp,
   faArrowDown,
   faArrowLeft,
-  faMagnifyingGlass
+  faMagnifyingGlass,
+  faSpinner
 } from '@fortawesome/free-solid-svg-icons'
 
 library.add(
@@ -89,7 +90,8 @@ library.add(
   faArrowUp,
   faArrowDown,
   faArrowLeft,
-  faMagnifyingGlass
+  faMagnifyingGlass,
+  faSpinner
 )
 
 import 'vuetify/styles'

--- a/tests/FeacnCodesTreeNode.spec.js
+++ b/tests/FeacnCodesTreeNode.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import FeacnCodesTreeNode from '@/components/FeacnCodesTreeNode.vue'
 import { defaultGlobalStubs } from './helpers/test-utils.js'

--- a/tests/FeacnCodes_Tree.spec.js
+++ b/tests/FeacnCodes_Tree.spec.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import FeacnCodes_Tree from '@/components/FeacnCodes_Tree.vue'
+import { defaultGlobalStubs } from './helpers/test-utils.js'
+
+const mockGetChildren = vi.fn()
+
+vi.mock('@/stores/feacn.codes.store.js', () => ({
+  useFeacnCodesStore: () => ({
+    getChildren: mockGetChildren
+  })
+}))
+
+const globalStubs = {
+  ...defaultGlobalStubs,
+  'font-awesome-icon': true
+}
+
+describe('FeacnCodes_Tree.vue', () => {
+  const root = { id: 1, code: '01', codeEx: '01', name: 'Root', parentId: null }
+  const child = { id: 2, code: '0101', codeEx: '0101', name: 'Child', parentId: 1 }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetChildren.mockImplementation(id => {
+      if (id === null || id === undefined) return Promise.resolve([root])
+      if (id === 1) return Promise.resolve([child])
+      return Promise.resolve([])
+    })
+  })
+
+  function createWrapper() {
+    return mount(FeacnCodes_Tree, {
+      global: { stubs: globalStubs }
+    })
+  }
+
+  it('loads root nodes on mount', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+    await flushPromises()
+
+    expect(mockGetChildren).toHaveBeenCalledWith(null)
+    expect(wrapper.text()).toContain('01 : Root')
+    const icon = wrapper.find('font-awesome-icon-stub')
+    expect(icon.exists()).toBe(true)
+    expect(icon.attributes('icon')).toBe('fa-solid fa-plus')
+  })
+
+  it('loads children when node expanded', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+    await flushPromises()
+
+    await wrapper.find('.toggle-icon').trigger('click')
+    await flushPromises()
+
+    expect(mockGetChildren).toHaveBeenCalledWith(1)
+    expect(wrapper.text()).toContain('0101 : Child')
+  })
+
+  it('shows minus icon when node expanded', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+    await flushPromises()
+
+    await wrapper.find('.toggle-icon').trigger('click')
+    await flushPromises()
+
+    const icon = wrapper.find('font-awesome-icon-stub')
+    expect(icon.attributes('icon')).toBe('fa-solid fa-minus')
+  })
+})
+

--- a/tests/FeacnCodes_Tree.spec.js
+++ b/tests/FeacnCodes_Tree.spec.js
@@ -38,7 +38,9 @@ describe('FeacnCodes_Tree.vue', () => {
   it('loads root nodes on mount', async () => {
     const wrapper = createWrapper()
     await flushPromises()
-    await flushPromises()
+    // Wait for root node to appear
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
 
     expect(mockGetChildren).toHaveBeenCalledWith(null)
     expect(wrapper.text()).toContain('01 : Root')

--- a/tests/FeacnCodes_Tree.spec.js
+++ b/tests/FeacnCodes_Tree.spec.js
@@ -35,12 +35,15 @@ describe('FeacnCodes_Tree.vue', () => {
     })
   }
 
+  // Helper to wait for all async operations and DOM updates
+  async function waitForMount(wrapper) {
+    await flushPromises() // Wait for store operations
+    await wrapper.vm.$nextTick() // Wait for DOM updates
+  }
+
   it('loads root nodes on mount', async () => {
     const wrapper = createWrapper()
-    await flushPromises()
-    // Wait for root node to appear
-    await wrapper.vm.$nextTick()
-    await wrapper.vm.$nextTick()
+    await waitForMount(wrapper)
 
     expect(mockGetChildren).toHaveBeenCalledWith(null)
     expect(wrapper.text()).toContain('01 : Root')
@@ -51,11 +54,10 @@ describe('FeacnCodes_Tree.vue', () => {
 
   it('loads children when node expanded', async () => {
     const wrapper = createWrapper()
-    await flushPromises()
-    await flushPromises()
+    await waitForMount(wrapper)
 
     await wrapper.find('.toggle-icon').trigger('click')
-    await flushPromises()
+    await flushPromises() // Wait for child loading
 
     expect(mockGetChildren).toHaveBeenCalledWith(1)
     expect(wrapper.text()).toContain('0101 : Child')
@@ -63,11 +65,10 @@ describe('FeacnCodes_Tree.vue', () => {
 
   it('shows minus icon when node expanded', async () => {
     const wrapper = createWrapper()
-    await flushPromises()
-    await flushPromises()
+    await waitForMount(wrapper)
 
     await wrapper.find('.toggle-icon').trigger('click')
-    await flushPromises()
+    await flushPromises() // Wait for child loading
 
     const icon = wrapper.find('font-awesome-icon-stub')
     expect(icon.attributes('icon')).toBe('fa-solid fa-minus')

--- a/tests/feacn.orders.store.spec.js
+++ b/tests/feacn.orders.store.spec.js
@@ -25,7 +25,7 @@ describe('feacn.orders store', () => {
     const store = useFeacnOrdersStore()
     await store.getOrders()
 
-    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders`)
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders`)
     expect(store.orders).toEqual(mockOrders)
     expect(store.loading).toBe(false)
     expect(store.error).toBeNull()
@@ -39,7 +39,7 @@ describe('feacn.orders store', () => {
     const store = useFeacnOrdersStore()
     await store.getOrders()
 
-    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders`)
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders`)
     expect(store.orders).toEqual([])
     expect(store.loading).toBe(false)
     expect(store.error).toBe(testError)
@@ -53,7 +53,7 @@ describe('feacn.orders store', () => {
     const store = useFeacnOrdersStore()
     await store.getPrefixes(1)
 
-    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/1/prefixes`)
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders/1/prefixes`)
     expect(store.prefixes).toEqual(mockPrefixes)
     expect(store.loading).toBe(false)
     expect(store.error).toBeNull()
@@ -66,7 +66,7 @@ describe('feacn.orders store', () => {
     const store = useFeacnOrdersStore()
     await store.getPrefixes(1)
 
-    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/1/prefixes`)
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders/1/prefixes`)
     expect(store.loading).toBe(false)
     expect(store.error).toBe(testError)
   })
@@ -88,8 +88,8 @@ describe('feacn.orders store', () => {
     const store = useFeacnOrdersStore()
     await store.update()
 
-    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/update`)
-    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders`)
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacnorders/update`)
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders`)
     expect(store.loading).toBe(false)
     expect(store.error).toBeNull()
   })
@@ -101,7 +101,7 @@ describe('feacn.orders store', () => {
     const store = useFeacnOrdersStore()
     await store.update()
 
-    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/update`)
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacnorders/update`)
     expect(fetchWrapper.get).not.toHaveBeenCalled()
     expect(store.loading).toBe(false)
     expect(store.error).toBe(testError)
@@ -114,8 +114,8 @@ describe('feacn.orders store', () => {
     const store = useFeacnOrdersStore()
     await store.enable(3)
 
-    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/3/enable`)
-    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders`)
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders/3/enable`)
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders`)
     expect(store.loading).toBe(false)
     expect(store.error).toBeNull()
   })
@@ -127,7 +127,7 @@ describe('feacn.orders store', () => {
     const store = useFeacnOrdersStore()
     await store.enable(3)
 
-    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/3/enable`)
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders/3/enable`)
     expect(fetchWrapper.get).not.toHaveBeenCalled()
     expect(store.loading).toBe(false)
     expect(store.error).toBe(testError)
@@ -140,8 +140,8 @@ describe('feacn.orders store', () => {
     const store = useFeacnOrdersStore()
     await store.disable(4)
 
-    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/4/disable`)
-    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders`)
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders/4/disable`)
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders`)
     expect(store.loading).toBe(false)
     expect(store.error).toBeNull()
   })
@@ -153,7 +153,7 @@ describe('feacn.orders store', () => {
     const store = useFeacnOrdersStore()
     await store.disable(4)
 
-    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/4/disable`)
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders/4/disable`)
     expect(fetchWrapper.get).not.toHaveBeenCalled()
     expect(store.loading).toBe(false)
     expect(store.error).toBe(testError)
@@ -167,7 +167,7 @@ describe('feacn.orders store', () => {
     await store.ensureLoaded()
     
     // First call should call getOrders
-    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders`)
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders`)
     expect(store.isInitialized).toBe(true)
     
     // Reset the mock to verify it's not called again
@@ -185,8 +185,8 @@ describe('feacn.orders store', () => {
     const store = useFeacnOrdersStore()
     await store.toggleEnabled(5, true)
 
-    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/5/enable`)
-    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders`)
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders/5/enable`)
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders`)
   })
   
   it('toggleEnabled calls disable when en is false', async () => {
@@ -196,7 +196,7 @@ describe('feacn.orders store', () => {
     const store = useFeacnOrdersStore()
     await store.toggleEnabled(6, false)
 
-    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders/6/disable`)
-    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacncodes/orders`)
+    expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders/6/disable`)
+    expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/feacnorders/orders`)
   })
 })


### PR DESCRIPTION
## Summary
- add FeacnCodes_Tree component with lazy loading and expandable nodes
- map FEACN code DTOs to tree nodes and formatting helpers
- cover tree component with unit tests

## Testing
- `npm test -- tests/FeacnCodes_Tree.spec.js --run`
- `npm test -- --run` *(fails: tests/router.spec.js > allows logist user to access parcels)*

------
https://chatgpt.com/codex/tasks/task_e_68a831502aac83218e0ede648b54e131