### PR TITLE
refactor: rename FeacnCodesTree component

### DIFF
--- a/src/components/FeacnCodesTree.vue
+++ b/src/components/FeacnCodesTree.vue
@@ -29,7 +29,7 @@ import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
 import { mapFeacnCodesToNodes } from '@/helpers/feacncodes.tree.helpers.js'
 import FeacnCodesTreeNode from '@/components/FeacnCodesTreeNode.vue'
 
-defineOptions({ name: 'FeacnCodes_Tree' })
+defineOptions({ name: 'FeacnCodesTree' })
 
 const store = useFeacnCodesStore()
 const rootNodes = ref([])

--- a/tests/FeacnCodesTree.spec.js
+++ b/tests/FeacnCodesTree.spec.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
-import FeacnCodes_Tree from '@/components/FeacnCodes_Tree.vue'
+import FeacnCodesTree from '@/components/FeacnCodesTree.vue'
 import { defaultGlobalStubs } from './helpers/test-utils.js'
 
 const mockGetChildren = vi.fn()
@@ -16,7 +16,7 @@ const globalStubs = {
   'font-awesome-icon': true
 }
 
-describe('FeacnCodes_Tree.vue', () => {
+describe('FeacnCodesTree.vue', () => {
   const root = { id: 1, code: '01', codeEx: '01', name: 'Root', parentId: null }
   const child = { id: 2, code: '0101', codeEx: '0101', name: 'Child', parentId: 1 }
 
@@ -30,7 +30,7 @@ describe('FeacnCodes_Tree.vue', () => {
   })
 
   function createWrapper() {
-    return mount(FeacnCodes_Tree, {
+    return mount(FeacnCodesTree, {
       global: { stubs: globalStubs }
     })
   }


### PR DESCRIPTION
## Summary
- rename FeacnCodes_Tree component to FeacnCodesTree
- adjust component name and test imports accordingly

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a866d34d5c832192869926477f972c