### PR TITLE
feat: add Feacn code search component

### DIFF
--- a/src/components/FeacnCodeSearch.vue
+++ b/src/components/FeacnCodeSearch.vue
@@ -87,7 +87,9 @@ async function selectSearchResult(item) {
     }
     await openPath(path)
   } catch (err) {
-    console.error('Failed to open path:', err)
+    searchError.value = err
+    searchResults.value = []
+    dropdownVisible.value = true
   }
 }
 
@@ -104,7 +106,6 @@ async function openPath(pathIds = []) {
   for (const id of pathIds) {
     const currentNode = nodes.find(n => n.id === id)
     if (!currentNode) {
-      console.warn('Node not found:', id)
       return
     }
     currentNode.expanded = true

--- a/src/components/FeacnCodeSearch.vue
+++ b/src/components/FeacnCodeSearch.vue
@@ -1,0 +1,216 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import { ref, nextTick } from 'vue'
+import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
+import FeacnCodesTree from '@/components/FeacnCodesTree.vue'
+import ActionButton from '@/components/ActionButton.vue'
+
+defineOptions({ name: 'FeacnCodeSearch' })
+
+const emit = defineEmits(['select'])
+
+const store = useFeacnCodesStore()
+const searchKey = ref('')
+const searchResults = ref([])
+const dropdownVisible = ref(false)
+const searching = ref(false)
+const searchError = ref(null)
+
+const treeRef = ref(null)
+
+async function performSearch() {
+  const key = searchKey.value.trim()
+  if (!key) {
+    dropdownVisible.value = false
+    searchResults.value = []
+    return
+  }
+
+  searching.value = true
+  searchError.value = null
+  try {
+    const items = await store.lookup(key)
+    searchResults.value = items || []
+  } catch (err) {
+    searchError.value = err
+    searchResults.value = []
+  } finally {
+    dropdownVisible.value = true
+    searching.value = false
+  }
+}
+
+async function selectSearchResult(item) {
+  dropdownVisible.value = false
+  if (!item || !item.id) {
+    return
+  }
+
+  try {
+    const node = await store.getById(item.id)
+    if (!node) {
+      return
+    }
+    const path = []
+    let current = node
+    while (current) {
+      path.unshift(current.id)
+      if (current.parentId) {
+        current = await store.getById(current.parentId)
+      } else {
+        current = null
+      }
+    }
+    await openPath(path)
+  } catch (err) {
+    console.error('Failed to open path:', err)
+  }
+}
+
+async function openPath(pathIds = []) {
+  if (!treeRef.value) {
+    return
+  }
+  await treeRef.value.loadChildren()
+  await nextTick()
+  let nodes = treeRef.value.rootNodes
+  if (!nodes || !Array.isArray(nodes)) {
+    return
+  }
+  for (const id of pathIds) {
+    const currentNode = nodes.find(n => n.id === id)
+    if (!currentNode) {
+      console.warn('Node not found:', id)
+      return
+    }
+    currentNode.expanded = true
+    if (!currentNode.loaded) {
+      await treeRef.value.loadChildren(currentNode)
+      await nextTick()
+    }
+    nodes = currentNode.children
+  }
+}
+
+function handleSelect(code) {
+  emit('select', code)
+}
+</script>
+
+<template>
+  <div class="feacn-code-search">
+    <div class="search-bar">
+      <input
+        v-model="searchKey"
+        @keyup.enter="performSearch"
+        type="text"
+        class="search-input"
+        :disabled="searching"
+      />
+      <ActionButton
+        class="search-button"
+        :item="searchKey"
+        icon="fa-solid fa-magnifying-glass"
+        tooltip-text="Поиск"
+        :disabled="searching"
+        @click="performSearch"
+      />
+      <ul v-if="dropdownVisible" class="search-results">
+        <li
+          v-for="result in searchResults"
+          :key="result.id"
+          @click="selectSearchResult(result)"
+          class="search-result-item"
+        >
+          <span class="result-code">{{ result.code }}</span>
+          <span class="result-name">{{ result.name }}</span>
+        </li>
+        <li v-if="searchResults.length === 0 && !searchError" class="no-results">
+          Ничего не найдено
+        </li>
+        <li v-if="searchError" class="search-error">
+          Ошибка поиска
+        </li>
+      </ul>
+    </div>
+    <FeacnCodesTree
+      ref="treeRef"
+      select-mode
+      @select="handleSelect"
+    />
+  </div>
+</template>
+
+<style scoped>
+.feacn-code-search {
+  position: relative;
+}
+.search-bar {
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+.search-input {
+  flex: 1;
+  padding: 4px 8px;
+}
+.search-bar :deep(.search-button) {
+  margin-left: 4px;
+  float: none;
+  cursor: pointer;
+}
+.search-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: white;
+  border: 1px solid #ccc;
+  z-index: 10;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.search-result-item {
+  padding: 4px 8px;
+  cursor: pointer;
+}
+.search-result-item:hover {
+  background-color: #f0f0f0;
+}
+.result-code {
+  font-family: 'Courier New', monospace;
+  margin-right: 8px;
+}
+.no-results,
+.search-error {
+  padding: 4px 8px;
+  color: #666;
+}
+</style>

--- a/src/components/FeacnCodesTree.vue
+++ b/src/components/FeacnCodesTree.vue
@@ -107,9 +107,10 @@ onMounted(() => {
   }
 })
 
-// Expose loadChildren method to parent component
+// Expose methods and state to parent component
 defineExpose({
-  loadChildren
+  loadChildren,
+  rootNodes
 })
 </script>
 

--- a/tests/FeacnCodeSearch.spec.js
+++ b/tests/FeacnCodeSearch.spec.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import FeacnCodeSearch from '@/components/FeacnCodeSearch.vue'
+import { defaultGlobalStubs } from './helpers/test-utils.js'
+
+const mockLookup = vi.fn()
+const mockGetById = vi.fn()
+const mockGetChildren = vi.fn()
+
+vi.mock('@/stores/feacn.codes.store.js', () => ({
+  useFeacnCodesStore: () => ({
+    lookup: mockLookup,
+    getById: mockGetById,
+    getChildren: mockGetChildren
+  })
+}))
+
+const globalStubs = {
+  ...defaultGlobalStubs,
+  'font-awesome-icon': true
+}
+
+function createWrapper() {
+  return mount(FeacnCodeSearch, {
+    global: { stubs: globalStubs }
+  })
+}
+
+async function waitForUpdates(wrapper) {
+  await flushPromises()
+  await wrapper.vm.$nextTick()
+}
+
+describe('FeacnCodeSearch.vue', () => {
+  const root = { id: 1, code: '01', codeEx: '01', name: 'Root', parentId: null }
+  const child = { id: 2, code: '0101', codeEx: '0101', name: 'Child', parentId: 1 }
+  const leaf = { id: 3, code: '0101010101', codeEx: '0101010101', name: 'Leaf', parentId: 2 }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLookup.mockResolvedValue([])
+    mockGetById.mockImplementation(id => {
+      if (id === 3) return Promise.resolve(leaf)
+      if (id === 2) return Promise.resolve(child)
+      if (id === 1) return Promise.resolve(root)
+      return Promise.resolve(null)
+    })
+    mockGetChildren.mockImplementation(id => {
+      if (id === null || id === undefined) return Promise.resolve([root])
+      if (id === 1) return Promise.resolve([child])
+      if (id === 2) return Promise.resolve([leaf])
+      return Promise.resolve([])
+    })
+  })
+
+  it('re-emits select event from tree', async () => {
+    const wrapper = createWrapper()
+    await waitForUpdates(wrapper)
+
+    await wrapper.find('.toggle-icon').trigger('click')
+    await waitForUpdates(wrapper)
+    const childToggle = wrapper.findAll('.toggle-icon').at(1)
+    await childToggle.trigger('click')
+    await waitForUpdates(wrapper)
+
+    const leafLabel = wrapper.findAll('.node-label').find(n => n.text() === 'Leaf')
+    await leafLabel.trigger('click')
+
+    expect(wrapper.emitted('select')).toBeTruthy()
+    expect(wrapper.emitted('select')[0][0]).toBe('0101010101')
+  })
+
+  it('searches and opens path from result', async () => {
+    mockLookup.mockResolvedValueOnce([{ id: 3, code: '0101010101', name: 'Leaf' }])
+    const wrapper = createWrapper()
+    await waitForUpdates(wrapper)
+
+    const input = wrapper.find('.search-input')
+    await input.setValue('leaf')
+    const searchButton = wrapper.findComponent({ name: 'ActionButton' })
+    expect(searchButton.exists()).toBe(true)
+    await searchButton.find('button').trigger('click')
+    await waitForUpdates(wrapper)
+
+    expect(mockLookup).toHaveBeenCalledWith('leaf')
+    const resultItem = wrapper.find('.search-result-item')
+    expect(resultItem.exists()).toBe(true)
+
+    await resultItem.trigger('click')
+    await waitForUpdates(wrapper)
+
+    expect(mockGetById).toHaveBeenCalledWith(3)
+    expect(mockGetById).toHaveBeenCalledWith(2)
+    expect(mockGetById).toHaveBeenCalledWith(1)
+  })
+
+  it('shows message when lookup returns no results', async () => {
+    mockLookup.mockResolvedValueOnce([])
+    const wrapper = createWrapper()
+
+    const input = wrapper.find('.search-input')
+    await input.setValue('none')
+    const searchButton = wrapper.findComponent({ name: 'ActionButton' })
+    expect(searchButton.exists()).toBe(true)
+    await searchButton.find('button').trigger('click')
+    await waitForUpdates(wrapper)
+
+    expect(wrapper.find('.no-results').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add `FeacnCodeSearch` component combining lookup input and code tree
- expose `rootNodes` from `FeacnCodesTree` to allow programmatic navigation
- use shared `ActionButton` for lookup trigger and refresh tests

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a8d3ea84148321b8f183a68c024fe9