### PR TITLE
feat: add FEACN tooltip to parcel lists

### DIFF
--- a/src/components/FeacnCodeCurrent.vue
+++ b/src/components/FeacnCodeCurrent.vue
@@ -1,0 +1,46 @@
+<script setup>
+import { computed } from 'vue'
+import { getTnVedCellClass } from '@/helpers/parcels.list.helpers.js'
+import { useFeacnTooltips, loadFeacnTooltipOnHover } from '@/helpers/feacn.tooltip.helpers.js'
+
+const componentProps = defineProps({
+  item: { type: Object, required: true },
+  feacnCodes: { type: Array, default: () => [] }
+})
+
+const emit = defineEmits(['click'])
+
+const feacnTooltips = useFeacnTooltips()
+
+const cellClass = computed(() => {
+  const tnvedClass = getTnVedCellClass(componentProps.item.tnVed, componentProps.feacnCodes)
+  return tnvedClass ? `truncated-cell ${tnvedClass}` : 'truncated-cell feacn-code-tooltip'
+})
+
+function handleMouseEnter() {
+  if (componentProps.item.tnVed) {
+    loadFeacnTooltipOnHover(componentProps.item.tnVed)
+  }
+}
+</script>
+
+<template>
+  <v-tooltip content-class="feacn-tooltip" location="top">
+    <template #activator="{ props: tooltipProps }">
+      <span
+        v-bind="tooltipProps"
+        :class="cellClass"
+        @click="emit('click', componentProps.item)"
+        @mouseenter="handleMouseEnter"
+      >
+        {{ componentProps.item.tnVed || '' }}
+      </span>
+    </template>
+    <template #default>
+      <div class="d-flex align-center">
+        <font-awesome-icon icon="fa-solid fa-pen" class="mr-3" />
+        {{ feacnTooltips[componentProps.item.tnVed] || 'Наведите для загрузки...' }}
+      </div>
+    </template>
+  </v-tooltip>
+</template>

--- a/src/components/FeacnCodeSelector.vue
+++ b/src/components/FeacnCodeSelector.vue
@@ -69,7 +69,7 @@ async function loadTooltip(code) {
     try {
       const tooltip = await getFeacnTooltip(code)
       tooltipCache.value[code] = tooltip
-    } catch (error) {
+    } catch {
       tooltipCache.value[code] = 'Загрузка...'
     }
   }

--- a/src/components/OzonParcels_List.vue
+++ b/src/components/OzonParcels_List.vue
@@ -52,11 +52,11 @@ import {
   exportParcelXmlData,
   lookupFeacn,
   getFeacnCodesForKeywords,
-  getTnVedCellClass,
 } from '@/helpers/parcels.list.helpers.js'
 import EditableCell from '@/components/EditableCell.vue'
 import ActionButton from '@/components/ActionButton.vue'
 import FeacnCodeSelector from '@/components/FeacnCodeSelector.vue'
+import FeacnCodeCurrent from '@/components/FeacnCodeCurrent.vue'
 
 const props = defineProps({
   registerId: { type: Number, required: true }
@@ -299,14 +299,13 @@ function getGenericTemplateHeaders() {
           <EditableCell :item="item" :display-value="parcelCheckStatusStore.getStatusTitle(item.checkStatusId)" :cell-class="`truncated-cell status-cell ${getCheckStatusClass(item.checkStatusId)}`" data-test="editable-cell" :tooltip-text="getCheckStatusTooltip(item, parcelCheckStatusStore.getStatusTitle, feacnOrders, stopWords)" @click="editParcel" />
         </template>
 
-        <!-- Special template for tnVed to display with color coding based on FEACN match -->
+        <!-- Special template for tnVed to display with FEACN tooltip -->
         <template #[`item.tnVed`]="{ item }">
-          <EditableCell 
-            :item="item" 
-            :display-value="item.tnVed || ''" 
-            :cell-class="`truncated-cell ${getTnVedCellClass(item.tnVed, getFeacnCodesForKeywords(item.keyWordIds, keyWordsStore))}`" 
-            data-test="editable-cell" 
-            @click="editParcel" 
+          <FeacnCodeCurrent
+            :item="item"
+            :feacn-codes="getFeacnCodesForKeywords(item.keyWordIds, keyWordsStore)"
+            data-test="editable-cell"
+            @click="editParcel"
           />
         </template>
 

--- a/src/components/WbrParcels_List.vue
+++ b/src/components/WbrParcels_List.vue
@@ -52,11 +52,11 @@ import {
   exportParcelXmlData,
   lookupFeacn,
   getFeacnCodesForKeywords,
-  getTnVedCellClass,
 } from '@/helpers/parcels.list.helpers.js'
 import EditableCell from '@/components/EditableCell.vue'
 import ActionButton from '@/components/ActionButton.vue'
 import FeacnCodeSelector from '@/components/FeacnCodeSelector.vue'
+import FeacnCodeCurrent from '@/components/FeacnCodeCurrent.vue'
 
 const props = defineProps({
   registerId: { type: Number, required: true }
@@ -303,14 +303,13 @@ function getGenericTemplateHeaders() {
           <EditableCell :item="item" :display-value="parcelCheckStatusStore.getStatusTitle(item.checkStatusId)" :cell-class="`truncated-cell status-cell ${getCheckStatusClass(item.checkStatusId)}`" data-test="editable-cell" :tooltip-text="getCheckStatusTooltip(item, parcelCheckStatusStore.getStatusTitle, feacnOrders, stopWords)" @click="editParcel" />
         </template>
 
-        <!-- Special template for tnVed to display with color coding based on FEACN match -->
+        <!-- Special template for tnVed to display with FEACN tooltip -->
         <template #[`item.tnVed`]="{ item }">
-          <EditableCell 
-            :item="item" 
-            :display-value="item.tnVed || ''" 
-            :cell-class="`truncated-cell ${getTnVedCellClass(item.tnVed, getFeacnCodesForKeywords(item.keyWordIds, keyWordsStore))}`" 
-            data-test="editable-cell" 
-            @click="editParcel" 
+          <FeacnCodeCurrent
+            :item="item"
+            :feacn-codes="getFeacnCodesForKeywords(item.keyWordIds, keyWordsStore)"
+            data-test="editable-cell"
+            @click="editParcel"
           />
         </template>
 


### PR DESCRIPTION
## Summary
- add reusable `FeacnCodeCurrent` component with FEACN tooltip and dotted styling fallback
- use `FeacnCodeCurrent` in WBR and Ozon parcel lists for TN VED field
- clean up unused variable in `FeacnCodeSelector`

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a96a48dc308321881bc9eabc5e8dcc