### PR TITLE
feat: enhance FEACN search overlay

### DIFF
--- a/src/components/FeacnCodesTree.vue
+++ b/src/components/FeacnCodesTree.vue
@@ -31,7 +31,7 @@ import FeacnCodesTreeNode from '@/components/FeacnCodesTreeNode.vue'
 
 defineOptions({ name: 'FeacnCodesTree' })
 
-const { disabled = false, selectMode = false } = defineProps({
+const { disabled = false, selectMode = false, selectedCode = '' } = defineProps({
   disabled: {
     type: Boolean,
     default: false
@@ -39,6 +39,10 @@ const { disabled = false, selectMode = false } = defineProps({
   selectMode: {
     type: Boolean,
     default: false
+  },
+  selectedCode: {
+    type: String,
+    default: ''
   }
 })
 
@@ -127,6 +131,7 @@ defineExpose({
         :node="node"
         :disabled="disabled"
         :select-mode="selectMode"
+        :selected-code="selectedCode"
         @toggle="toggleNode"
         @select="handleSelect"
       />

--- a/src/components/FeacnCodesTreeNode.vue
+++ b/src/components/FeacnCodesTreeNode.vue
@@ -35,6 +35,10 @@ const props = defineProps({
   selectMode: {
     type: Boolean,
     default: false
+  },
+  selectedCode: {
+    type: String,
+    default: ''
   }
 })
 
@@ -72,7 +76,8 @@ function isLeafNode(node) {
         class="node-code"
         :class="{
           'clickable': (selectMode || !isLeafNode(node)) && !disabled,
-          'disabled': disabled
+          'disabled': disabled,
+          'selected': node.code === selectedCode
         }"
         @click="!disabled ? handleClick() : null"
       >
@@ -117,7 +122,8 @@ function isLeafNode(node) {
           :class="{
             'loading': node.loading,
             'clickable': (selectMode || !isLeafNode(node)) && !disabled,
-            'disabled': disabled
+            'disabled': disabled,
+            'selected': node.code === selectedCode
           }"
           @click="!disabled ? handleClick() : null"
         >
@@ -251,6 +257,11 @@ function isLeafNode(node) {
   opacity: 0.6;
   cursor: not-allowed;
   pointer-events: none;
+}
+
+.node-label.selected,
+.node-code.selected {
+  background-color: #e6f7ff;
 }
 
 .child-nodes {

--- a/src/components/KeyWord_Settings.vue
+++ b/src/components/KeyWord_Settings.vue
@@ -244,7 +244,7 @@ defineExpose({
       >
         <template #extra="{ index }">
           <ActionButton
-            icon="fa-solid fa-arrow-down"
+            :icon="searchIndex === index ? 'fa-solid fa-arrow-up' : 'fa-solid fa-arrow-down'"
             :item="index"
             @click="toggleSearch(index)"
             class="button-o-c ml-2"
@@ -252,7 +252,13 @@ defineExpose({
           />
         </template>
       </FieldArrayWithButtons>
-      <FeacnCodeSearch v-if="searchIndex !== null" class="mt-2" @select="handleCodeSelect" />
+      <FeacnCodeSearch
+        v-if="searchIndex !== null"
+        :selected-code="feacnCodes[searchIndex]"
+        :initial-query="word || feacnCodes[searchIndex]"
+        @select="handleCodeSelect"
+        @close="searchIndex = null"
+      />
       <div v-if="feacnCodesError" class="invalid-feedback">{{ feacnCodesError }}</div>
       
       <div class="form-group">

--- a/tests/FeacnCodeSearch.spec.js
+++ b/tests/FeacnCodeSearch.spec.js
@@ -6,6 +6,7 @@ import { defaultGlobalStubs } from './helpers/test-utils.js'
 const mockLookup = vi.fn()
 const mockGetById = vi.fn()
 const mockGetChildren = vi.fn()
+const mockFormatFeacnName = vi.hoisted(() => vi.fn(code => Promise.resolve(`Name ${code}`)))
 
 vi.mock('@/stores/feacn.codes.store.js', () => ({
   useFeacnCodesStore: () => ({
@@ -13,6 +14,10 @@ vi.mock('@/stores/feacn.codes.store.js', () => ({
     getById: mockGetById,
     getChildren: mockGetChildren
   })
+}))
+
+vi.mock('@/helpers/feacn.tooltip.helpers.js', () => ({
+  formatFeacnName: mockFormatFeacnName
 }))
 
 const globalStubs = {

--- a/tests/KeyWord_Settings.spec.js
+++ b/tests/KeyWord_Settings.spec.js
@@ -73,9 +73,16 @@ vi.mock('@/stores/alert.store.js', () => ({
 vi.mock('@/stores/feacn.codes.store.js', () => ({
   useFeacnCodesStore: () => ({
     getChildren: vi.fn(() => Promise.resolve([])),
+    lookup: vi.fn(() => Promise.resolve([])),
+    getById: vi.fn(() => Promise.resolve(null)),
+    getByCode: vi.fn(() => Promise.resolve(null)),
     loading: ref(false),
     error: ref(null)
   })
+}))
+
+vi.mock('@/helpers/feacn.tooltip.helpers.js', () => ({
+  formatFeacnName: vi.fn(code => Promise.resolve(`Name ${code}`))
 }))
 
 // Mock router


### PR DESCRIPTION
## Summary
- display FEACN search as overlay panel with scrollable height and bordered input
- highlight and auto-scroll to selected FEACN codes in search tree
- toggle arrow icon and prefill search based on keyword settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9b15745e08321b18a5c96f804d10e