### PR TITLE
feat: overlay FeacnCodeSearch and limit height

### DIFF
--- a/src/components/FeacnCodeSearch.vue
+++ b/src/components/FeacnCodeSearch.vue
@@ -172,11 +172,13 @@ function handleSelect(code) {
         </li>
       </ul>
     </div>
-    <FeacnCodesTree
-      ref="treeRef"
-      select-mode
-      @select="handleSelect"
-    />
+    <div class="tree-container">
+      <FeacnCodesTree
+        ref="treeRef"
+        select-mode
+        @select="handleSelect"
+      />
+    </div>
   </div>
 </template>
 
@@ -189,6 +191,9 @@ function handleSelect(code) {
   box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1);
   border: 1px solid var(--input-border-color);
   border-radius: 0.25rem;
+  max-height: max(200px, 50vh);
+  display: flex;
+  flex-direction: column;
 }
 
 .search-bar {
@@ -223,6 +228,10 @@ function handleSelect(code) {
   margin: 0;
   max-height: 200px;
   overflow-y: auto;
+}
+.tree-container {
+  overflow-y: auto;
+  flex: 1 1 auto;
 }
 .search-result-item {
   padding: 4px 8px;

--- a/src/components/KeyWord_Settings.vue
+++ b/src/components/KeyWord_Settings.vue
@@ -253,29 +253,35 @@ defineExpose({
         <div v-if="errors.word" class="invalid-feedback">{{ errors.word }}</div>
       </div>
 
-      <FieldArrayWithButtons
-        name="feacnCodes"
-        label="Код ТН ВЭД (10 цифр)"
-        field-type="input"
-        :field-props="({ index }) => ({ maxlength: 10, inputmode: 'numeric', pattern: '[0-9]*', onInput: (event) => onCodeInput(event, index) })"
-        placeholder="Введите код ТН ВЭД"
-        add-tooltip="Добавить код"
-        remove-tooltip="Удалить код"
-        :has-error="!!feacnCodesError"
-        :disabled="searchActive"
-      >
-        <template #extra="{ index }">
-          <ActionButton
-            :icon="searchIndex === index ? 'fa-solid fa-arrow-up' : 'fa-solid fa-arrow-down'"
-            :item="index"
-            @click="toggleSearch(index)"
-            class="button-o-c ml-2"
-            tooltip-text="Выбрать код"
-            :disabled="searchActive && searchIndex !== index"
-          />
-        </template>
-      </FieldArrayWithButtons>
-      <FeacnCodeSearch v-if="searchIndex !== null" class="mt-2" @select="handleCodeSelect" />
+      <div class="feacn-search-wrapper">
+        <FieldArrayWithButtons
+          name="feacnCodes"
+          label="Код ТН ВЭД (10 цифр)"
+          field-type="input"
+          :field-props="({ index }) => ({ maxlength: 10, inputmode: 'numeric', pattern: '[0-9]*', onInput: (event) => onCodeInput(event, index) })"
+          placeholder="Введите код ТН ВЭД"
+          add-tooltip="Добавить код"
+          remove-tooltip="Удалить код"
+          :has-error="!!feacnCodesError"
+          :disabled="searchActive"
+        >
+          <template #extra="{ index }">
+            <ActionButton
+              :icon="searchIndex === index ? 'fa-solid fa-arrow-up' : 'fa-solid fa-arrow-down'"
+              :item="index"
+              @click="toggleSearch(index)"
+              class="button-o-c ml-2"
+              tooltip-text="Выбрать код"
+              :disabled="searchActive && searchIndex !== index"
+            />
+          </template>
+        </FieldArrayWithButtons>
+        <FeacnCodeSearch
+          v-if="searchIndex !== null"
+          class="feacn-overlay"
+          @select="handleCodeSelect"
+        />
+      </div>
       <div v-if="feacnCodesError" class="invalid-feedback">{{ feacnCodesError }}</div>
       
       <div class="form-group">
@@ -325,6 +331,20 @@ defineExpose({
     <div v-if="alert" class="alert alert-dismissable mt-3 mb-0" :class="alert.type">
       <button @click="alertStore.clear()" class="btn btn-link close">×</button>
       {{ alert.message }}
-    </div>
+  </div>
   </div>
 </template>
+
+<style scoped>
+.feacn-search-wrapper {
+  position: relative;
+}
+
+.feacn-overlay {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  right: 0;
+  z-index: 100;
+}
+</style>


### PR DESCRIPTION
## Summary
- display `FeacnCodeSearch` as an overlay within `KeyWord_Settings`
- cap `FeacnCodeSearch` height and scroll tree content only

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9f24112f88321a321be0f0a5f5424