### PR TITLE
Add FEACN insert item settings and views

### DIFF
--- a/src/components/ActionButton.vue
+++ b/src/components/ActionButton.vue
@@ -49,3 +49,12 @@ defineEmits(['click'])
     </template>
   </v-tooltip>
 </template>
+
+<style scoped>
+
+.anti-btn:focus {
+  border: none;
+  outline: none;
+}
+
+</style>

--- a/src/components/FeacnInsertItem_Settings.vue
+++ b/src/components/FeacnInsertItem_Settings.vue
@@ -60,8 +60,8 @@ const schema = toTypedSchema(
     code: Yup.string()
       .required('Код ТН ВЭД обязателен')
       .matches(/^\d{10}$/, 'Код ТН ВЭД должен содержать ровно 10 цифр'),
-    insertBefore: Yup.string().required('Текст перед обязателен'),
-    insertAfter: Yup.string().required('Текст после обязателен')
+    insBefore: Yup.string(),
+    insAfter: Yup.string()
   })
 )
 
@@ -69,14 +69,14 @@ const { errors, handleSubmit, resetForm, setFieldValue } = useForm({
   validationSchema: schema,
   initialValues: {
     code: '',
-    insertBefore: '',
-    insertAfter: ''
+    insBefore: '',
+    insAfter: ''
   }
 })
 
 const { value: code } = useField('code')
-const { value: insertBefore } = useField('insertBefore')
-const { value: insertAfter } = useField('insertAfter')
+const { value: insBefore } = useField('insBefore')
+const { value: insAfter } = useField('insAfter')
 
 const searchActive = ref(false)
 
@@ -134,8 +134,8 @@ onMounted(async () => {
         resetForm({
           values: {
             code: item.code || '',
-            insertBefore: item.insertBefore || '',
-            insertAfter: item.insertAfter || ''
+            insBefore: item.insBefore || '',
+            insAfter: item.insAfter || ''
           }
         })
       }
@@ -170,7 +170,7 @@ function cancel() {
 </script>
 
 <template>
-  <div class="settings form-2">
+  <div class="settings form-3">
     <h1 class="primary-heading">{{ getTitle() }}</h1>
     <hr class="hr" />
 
@@ -180,63 +180,62 @@ function cancel() {
 
     <form v-else @submit.prevent="onSubmit">
       <div class="feacn-search-wrapper">
-        <label for="code" class="label">Код ТН ВЭД:</label>
-        <div class="d-flex">
-          <input
-            name="code"
-            id="code"
-            type="text"
-            class="form-control input"
-            :class="{ 'is-invalid': errors.code }"
-            maxlength="10"
-            inputmode="numeric"
-            pattern="[0-9]*"
-            v-model="code"
-            @input="onCodeInput"
-            :disabled="searchActive"
-            placeholder="Введите код ТН ВЭД"
-          />
-          <ActionButton
-            :icon="searchActive ? 'fa-solid fa-arrow-up' : 'fa-solid fa-arrow-down'"
-            :item="null"
-            @click="toggleSearch"
-            class="ml-2"
-            tooltip-text="Выбрать код"
-            :disabled="false"
-          />
+        <div class="form-group">
+            <label for="code" class="label">Код ТН ВЭД:</label>
+            <input
+                name="code"
+                id="code"
+                type="text"
+                class="form-control input"
+                :class="{ 'is-invalid': errors.code }"
+                maxlength="10"
+                inputmode="numeric"
+                pattern="[0-9]*"
+                v-model="code"
+                @input="onCodeInput"
+                :disabled="searchActive"
+                placeholder="Введите код ТН ВЭД"
+            />
+            <ActionButton
+                :icon="searchActive ? 'fa-solid fa-arrow-up' : 'fa-solid fa-arrow-down'"
+                :item="null"
+                @click="toggleSearch"
+                class="ml-2 mr-2"
+                tooltip-text="Выбрать код"
+                :disabled="false"
+            />
+            <div v-if="errors.code" class="invalid-feedback">{{ errors.code }}</div>
+            <FeacnCodeSearch v-if="searchActive" class="feacn-overlay" @select="handleCodeSelect" />
         </div>
-        <div v-if="errors.code" class="invalid-feedback">{{ errors.code }}</div>
-        <FeacnCodeSearch v-if="searchActive" class="feacn-overlay" @select="handleCodeSelect" />
+      </div>
+      <div class="form-group">
+        <label for="insBefore" class="label">Вставить перед:</label>
+        <input
+          name="insBefore"
+          id="insBefore"
+          type="text"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.insBefore }"
+          v-model="insBefore"
+          :disabled="searchActive"
+          placeholder="Текст для вставки перед описанием (не обязательно)"
+        />
+        <div v-if="errors.insBefore" class="invalid-feedback">{{ errors.insBefore }}</div>
       </div>
 
       <div class="form-group">
-        <label for="insertBefore" class="label">Вставить перед:</label>
+        <label for="insAfter" class="label">Вставить после:</label>
         <input
-          name="insertBefore"
-          id="insertBefore"
+          name="insAfter"
+          id="insAfter"
           type="text"
           class="form-control input"
-          :class="{ 'is-invalid': errors.insertBefore }"
-          v-model="insertBefore"
+          :class="{ 'is-invalid': errors.insAfter }"
+          v-model="insAfter"
           :disabled="searchActive"
-          placeholder="Текст перед"
+          placeholder="Текст для вставки после описанием (не обязательно)"
         />
-        <div v-if="errors.insertBefore" class="invalid-feedback">{{ errors.insertBefore }}</div>
-      </div>
-
-      <div class="form-group">
-        <label for="insertAfter" class="label">Вставить после:</label>
-        <input
-          name="insertAfter"
-          id="insertAfter"
-          type="text"
-          class="form-control input"
-          :class="{ 'is-invalid': errors.insertAfter }"
-          v-model="insertAfter"
-          :disabled="searchActive"
-          placeholder="Текст после"
-        />
-        <div v-if="errors.insertAfter" class="invalid-feedback">{{ errors.insertAfter }}</div>
+        <div v-if="errors.insAfter" class="invalid-feedback">{{ errors.insAfter }}</div>
       </div>
 
       <div class="form-group mt-8">

--- a/src/components/FeacnInsertItem_Settings.vue
+++ b/src/components/FeacnInsertItem_Settings.vue
@@ -1,0 +1,278 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import { ref, computed, onMounted, watch, onUnmounted } from 'vue'
+import router from '@/router'
+import { storeToRefs } from 'pinia'
+import { useForm, useField } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/yup'
+import * as Yup from 'yup'
+import { useFeacnInsertItemsStore } from '@/stores/feacn.insert.items.store.js'
+import { useAlertStore } from '@/stores/alert.store.js'
+import FeacnCodeSearch from '@/components/FeacnCodeSearch.vue'
+import ActionButton from '@/components/ActionButton.vue'
+
+const props = defineProps({
+  mode: {
+    type: String,
+    required: true,
+    validator: (value) => ['create', 'edit'].includes(value)
+  },
+  insertItemId: {
+    type: [String, Number],
+    required: false
+  }
+})
+
+const insertItemsStore = useFeacnInsertItemsStore()
+const alertStore = useAlertStore()
+const { alert } = storeToRefs(alertStore)
+
+const isCreate = computed(() => props.mode === 'create')
+const saving = ref(false)
+const loading = ref(false)
+
+const schema = toTypedSchema(
+  Yup.object({
+    code: Yup.string()
+      .required('Код ТН ВЭД обязателен')
+      .matches(/^\d{10}$/, 'Код ТН ВЭД должен содержать ровно 10 цифр'),
+    insertBefore: Yup.string().required('Текст перед обязателен'),
+    insertAfter: Yup.string().required('Текст после обязателен')
+  })
+)
+
+const { errors, handleSubmit, resetForm, setFieldValue } = useForm({
+  validationSchema: schema,
+  initialValues: {
+    code: '',
+    insertBefore: '',
+    insertAfter: ''
+  }
+})
+
+const { value: code } = useField('code')
+const { value: insertBefore } = useField('insertBefore')
+const { value: insertAfter } = useField('insertAfter')
+
+const searchActive = ref(false)
+
+function getTitle() {
+  return isCreate.value
+    ? 'Создание правила для формирования описания продукта'
+    : 'Редактирование правила для формирования описания продукта'
+}
+
+function getButtonText() {
+  return isCreate.value ? 'Создать' : 'Сохранить'
+}
+
+function onCodeInput(event) {
+  const inputValue = event.target.value.replace(/\D/g, '').slice(0, 10)
+  if (inputValue !== event.target.value) {
+    event.target.value = inputValue
+  }
+  setFieldValue('code', inputValue)
+}
+
+function toggleSearch() {
+  searchActive.value = !searchActive.value
+}
+
+function handleCodeSelect(feacnCode) {
+  setFieldValue('code', feacnCode)
+  searchActive.value = false
+}
+
+function handleEscape(event) {
+  if (event.key === 'Escape') {
+    searchActive.value = false
+  }
+}
+
+watch(searchActive, (val) => {
+  if (val) {
+    document.addEventListener('keydown', handleEscape)
+  } else {
+    document.removeEventListener('keydown', handleEscape)
+  }
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleEscape)
+})
+
+onMounted(async () => {
+  if (!isCreate.value) {
+    loading.value = true
+    try {
+      const item = await insertItemsStore.getById(props.insertItemId)
+      if (item) {
+        resetForm({
+          values: {
+            code: item.code || '',
+            insertBefore: item.insertBefore || '',
+            insertAfter: item.insertAfter || ''
+          }
+        })
+      }
+    } catch {
+      alertStore.error('Ошибка при загрузке данных правила')
+      router.push('/feacn/insertitems')
+    } finally {
+      loading.value = false
+    }
+  }
+})
+
+const onSubmit = handleSubmit(async (values, { setErrors }) => {
+  saving.value = true
+  try {
+    if (isCreate.value) {
+      await insertItemsStore.create(values)
+    } else {
+      await insertItemsStore.update(props.insertItemId, values)
+    }
+    router.push('/feacn/insertitems')
+  } catch (error) {
+    setErrors({ apiError: error.message || 'Ошибка при сохранении правила' })
+  } finally {
+    saving.value = false
+  }
+})
+
+function cancel() {
+  router.push('/feacn/insertitems')
+}
+</script>
+
+<template>
+  <div class="settings form-2">
+    <h1 class="primary-heading">{{ getTitle() }}</h1>
+    <hr class="hr" />
+
+    <div v-if="loading" class="text-center m-5">
+      <span class="spinner-border spinner-border-lg align-center"></span>
+    </div>
+
+    <form v-else @submit.prevent="onSubmit">
+      <div class="feacn-search-wrapper">
+        <label for="code" class="label">Код ТН ВЭД:</label>
+        <div class="d-flex">
+          <input
+            name="code"
+            id="code"
+            type="text"
+            class="form-control input"
+            :class="{ 'is-invalid': errors.code }"
+            maxlength="10"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            v-model="code"
+            @input="onCodeInput"
+            :disabled="searchActive"
+            placeholder="Введите код ТН ВЭД"
+          />
+          <ActionButton
+            :icon="searchActive ? 'fa-solid fa-arrow-up' : 'fa-solid fa-arrow-down'"
+            :item="null"
+            @click="toggleSearch"
+            class="ml-2"
+            tooltip-text="Выбрать код"
+            :disabled="false"
+          />
+        </div>
+        <div v-if="errors.code" class="invalid-feedback">{{ errors.code }}</div>
+        <FeacnCodeSearch v-if="searchActive" class="feacn-overlay" @select="handleCodeSelect" />
+      </div>
+
+      <div class="form-group">
+        <label for="insertBefore" class="label">Вставить перед:</label>
+        <input
+          name="insertBefore"
+          id="insertBefore"
+          type="text"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.insertBefore }"
+          v-model="insertBefore"
+          :disabled="searchActive"
+          placeholder="Текст перед"
+        />
+        <div v-if="errors.insertBefore" class="invalid-feedback">{{ errors.insertBefore }}</div>
+      </div>
+
+      <div class="form-group">
+        <label for="insertAfter" class="label">Вставить после:</label>
+        <input
+          name="insertAfter"
+          id="insertAfter"
+          type="text"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.insertAfter }"
+          v-model="insertAfter"
+          :disabled="searchActive"
+          placeholder="Текст после"
+        />
+        <div v-if="errors.insertAfter" class="invalid-feedback">{{ errors.insertAfter }}</div>
+      </div>
+
+      <div class="form-group mt-8">
+        <button class="button primary" type="submit" :disabled="saving || searchActive">
+          <span v-show="saving" class="spinner-border spinner-border-sm mr-1"></span>
+          <font-awesome-icon size="1x" icon="fa-solid fa-check-double" class="mr-1" />
+          {{ getButtonText() }}
+        </button>
+        <button class="button secondary" type="button" @click="cancel" :disabled="searchActive">
+          <font-awesome-icon size="1x" icon="fa-solid fa-xmark" class="mr-1" />
+          Отменить
+        </button>
+      </div>
+
+      <div v-if="errors.apiError" class="alert alert-danger mt-3 mb-0">{{ errors.apiError }}</div>
+    </form>
+
+    <!-- Alert -->
+    <div v-if="alert" class="alert alert-dismissable mt-3 mb-0" :class="alert.type">
+      <button @click="alertStore.clear()" class="btn btn-link close">×</button>
+      {{ alert.message }}
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.feacn-search-wrapper {
+  position: relative;
+}
+
+.feacn-overlay {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  right: 0;
+  z-index: 100;
+}
+</style>
+

--- a/src/components/FeacnInsertItems_List.vue
+++ b/src/components/FeacnInsertItems_List.vue
@@ -59,8 +59,8 @@ const tooltipMaxWidth = computed(() => {
 const headers = [
   { title: '', align: 'center', key: 'actions', sortable: false, width: '10%' },
   { title: 'Код ТН ВЭД', key: 'code', sortable: true , width: '20%'},
-  { title: 'Вставить перед', key: 'insertBefore', sortable: true, width: '35%' },
-  { title: 'Вставить после', key: 'insertAfter', sortable: true, width: '35%' }
+  { title: 'Вставить перед', key: 'insBefore', sortable: true, width: '35%' },
+  { title: 'Вставить после', key: 'insAfter', sortable: true, width: '35%' }
 ]
 
 onMounted(async () => {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -160,6 +160,21 @@ const router = createRouter({
       meta: { requiresAdmin: true }
     },
     {
+      path: '/feacninsertitem/create',
+      name: 'Создание правила формирования описания продукта',
+      component: () => import('@/views/FeacnInsertItem_CreateView.vue'),
+      meta: { requiresAdmin: true }
+    },
+    {
+      path: '/feacninsertitem/edit/:id',
+      name: 'Редактирование правила формирования описания продукта',
+      component: () => import('@/views/FeacnInsertItem_EditView.vue'),
+      props: (route) => ({
+        id: Number(route.params.id)
+      }),
+      meta: { requiresAdmin: true }
+    },
+    {
       path: '/registers',
       name: 'Реестры',
       component: () => import('@/views/Registers_View.vue'),

--- a/src/views/FeacnInsertItem_CreateView.vue
+++ b/src/views/FeacnInsertItem_CreateView.vue
@@ -1,0 +1,32 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import FeacnInsertItem_Settings from '@/components/FeacnInsertItem_Settings.vue'
+</script>
+
+<template>
+  <FeacnInsertItem_Settings :mode="'create'" />
+</template>

--- a/src/views/FeacnInsertItem_EditView.vue
+++ b/src/views/FeacnInsertItem_EditView.vue
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import { useRoute } from 'vue-router'
+import FeacnInsertItem_Settings from '@/components/FeacnInsertItem_Settings.vue'
+
+const route = useRoute()
+</script>
+
+<template>
+  <FeacnInsertItem_Settings :mode="'edit'" :insert-item-id="route.params.id" />
+</template>

--- a/tests/FeacnInsertItem_CreateView.spec.js
+++ b/tests/FeacnInsertItem_CreateView.spec.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import FeacnInsertItem_CreateView from '@/views/FeacnInsertItem_CreateView.vue'
+import FeacnInsertItem_Settings from '@/components/FeacnInsertItem_Settings.vue'
+
+const vuetify = createVuetify()
+
+vi.mock('@/components/FeacnInsertItem_Settings.vue', () => ({
+  default: {
+    name: 'FeacnInsertItem_Settings',
+    template: '<div data-test="fi-settings">FeacnInsertItem_Settings Component</div>'
+  }
+}))
+
+describe('FeacnInsertItem_CreateView.vue', () => {
+  it('renders FeacnInsertItem_Settings component', () => {
+    const wrapper = mount(FeacnInsertItem_CreateView, {
+      global: { plugins: [vuetify] }
+    })
+    const comp = wrapper.findComponent(FeacnInsertItem_Settings)
+    expect(comp.exists()).toBe(true)
+    expect(wrapper.html()).toContain('FeacnInsertItem_Settings Component')
+  })
+})

--- a/tests/FeacnInsertItem_EditView.spec.js
+++ b/tests/FeacnInsertItem_EditView.spec.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import FeacnInsertItem_EditView from '@/views/FeacnInsertItem_EditView.vue'
+import FeacnInsertItem_Settings from '@/components/FeacnInsertItem_Settings.vue'
+
+const vuetify = createVuetify()
+
+const mockRoute = {
+  params: {
+    id: '123'
+  }
+}
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute
+}))
+
+vi.mock('@/components/FeacnInsertItem_Settings.vue', () => ({
+  default: {
+    name: 'FeacnInsertItem_Settings',
+    props: ['mode', 'insertItemId'],
+    template: '<div data-test="fi-settings">Fi Settings {{ insertItemId }}</div>'
+  }
+}))
+
+describe('FeacnInsertItem_EditView.vue', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(FeacnInsertItem_EditView, {
+      global: { plugins: [vuetify] }
+    })
+  })
+
+  it('renders FeacnInsertItem_Settings component', () => {
+    const comp = wrapper.findComponent(FeacnInsertItem_Settings)
+    expect(comp.exists()).toBe(true)
+  })
+
+  it('passes route id to FeacnInsertItem_Settings', () => {
+    const comp = wrapper.findComponent(FeacnInsertItem_Settings)
+    expect(comp.props('insertItemId')).toBe('123')
+  })
+
+  it('renders stub content', () => {
+    expect(wrapper.html()).toContain('Fi Settings 123')
+  })
+})

--- a/tests/FeacnInsertItem_Settings.spec.js
+++ b/tests/FeacnInsertItem_Settings.spec.js
@@ -1,0 +1,108 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { ref } from 'vue'
+import FeacnInsertItem_Settings from '@/components/FeacnInsertItem_Settings.vue'
+
+// Stub components
+vi.mock('@/components/FeacnCodeSearch.vue', () => ({
+  default: {
+    name: 'FeacnCodeSearch',
+    emits: ['select'],
+    template: '<div class="feacn-code-search-stub" @click="$emit(\'select\', \'9876543210\')"></div>'
+  }
+}))
+
+vi.mock('@/components/ActionButton.vue', () => ({
+  default: {
+    name: 'ActionButton',
+    props: ['item', 'icon', 'tooltipText', 'iconSize', 'disabled'],
+    emits: ['click'],
+    template: '<button data-test="action-btn" @click="$emit(\'click\', item)"></button>'
+  }
+}))
+
+// Mock stores
+const getById = vi.fn()
+const create = vi.fn()
+const update = vi.fn()
+
+vi.mock('@/stores/feacn.insert.items.store.js', () => ({
+  useFeacnInsertItemsStore: () => ({
+    getById,
+    create,
+    update
+  })
+}))
+
+const alertError = vi.fn()
+const alertClear = vi.fn()
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => ({
+    error: alertError,
+    clear: alertClear
+  })
+}))
+
+vi.mock('@/router', () => ({
+  default: {
+    push: vi.fn()
+  }
+}))
+
+// Mock storeToRefs
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return {
+    ...actual,
+    storeToRefs: () => ({
+      alert: ref(null)
+    })
+  }
+})
+
+describe('FeacnInsertItem_Settings.vue', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  const mountComponent = (props = { mode: 'create' }) =>
+    mount(FeacnInsertItem_Settings, {
+      props,
+      global: {
+        stubs: { 'font-awesome-icon': true }
+      }
+    })
+
+  it('renders create mode and submits', async () => {
+    create.mockResolvedValue({})
+    const wrapper = mountComponent()
+    wrapper.vm.setFieldValue('code', '1234567890')
+    wrapper.vm.setFieldValue('insertBefore', 'before')
+    wrapper.vm.setFieldValue('insertAfter', 'after')
+    await wrapper.vm.onSubmit()
+    expect(create).toHaveBeenCalledWith({ code: '1234567890', insertBefore: 'before', insertAfter: 'after' })
+  })
+
+  it('loads data in edit mode and updates', async () => {
+    getById.mockResolvedValue({ code: '1111111111', insertBefore: 'b', insertAfter: 'a' })
+    update.mockResolvedValue({})
+    const wrapper = mountComponent({ mode: 'edit', insertItemId: 1 })
+    await flushPromises()
+    await wrapper.vm.onSubmit()
+    expect(getById).toHaveBeenCalledWith(1)
+    expect(update).toHaveBeenCalledWith(1, { code: '1111111111', insertBefore: 'b', insertAfter: 'a' })
+  })
+
+  it('toggles FeacnCodeSearch and selects code', async () => {
+    const wrapper = mountComponent()
+    expect(wrapper.find('.feacn-code-search-stub').exists()).toBe(false)
+    await wrapper.find('[data-test="action-btn"]').trigger('click')
+    expect(wrapper.find('.feacn-code-search-stub').exists()).toBe(true)
+    await wrapper.find('.feacn-code-search-stub').trigger('click')
+    expect(wrapper.find('input[name="code"]').element.value).toBe('9876543210')
+  })
+})

--- a/tests/FeacnInsertItem_Settings.spec.js
+++ b/tests/FeacnInsertItem_Settings.spec.js
@@ -81,20 +81,20 @@ describe('FeacnInsertItem_Settings.vue', () => {
     create.mockResolvedValue({})
     const wrapper = mountComponent()
     wrapper.vm.setFieldValue('code', '1234567890')
-    wrapper.vm.setFieldValue('insertBefore', 'before')
-    wrapper.vm.setFieldValue('insertAfter', 'after')
+    wrapper.vm.setFieldValue('insBefore', 'before')
+    wrapper.vm.setFieldValue('insAfter', 'after')
     await wrapper.vm.onSubmit()
-    expect(create).toHaveBeenCalledWith({ code: '1234567890', insertBefore: 'before', insertAfter: 'after' })
+    expect(create).toHaveBeenCalledWith({ code: '1234567890', insBefore: 'before', insAfter: 'after' })
   })
 
   it('loads data in edit mode and updates', async () => {
-    getById.mockResolvedValue({ code: '1111111111', insertBefore: 'b', insertAfter: 'a' })
+    getById.mockResolvedValue({ code: '1111111111', insBefore: 'b', insAfter: 'a' })
     update.mockResolvedValue({})
     const wrapper = mountComponent({ mode: 'edit', insertItemId: 1 })
     await flushPromises()
     await wrapper.vm.onSubmit()
     expect(getById).toHaveBeenCalledWith(1)
-    expect(update).toHaveBeenCalledWith(1, { code: '1111111111', insertBefore: 'b', insertAfter: 'a' })
+    expect(update).toHaveBeenCalledWith(1, { code: '1111111111', insBefore: 'b', insAfter: 'a' })
   })
 
   it('toggles FeacnCodeSearch and selects code', async () => {

--- a/tests/FeacnInsertItems_List.spec.js
+++ b/tests/FeacnInsertItems_List.spec.js
@@ -41,8 +41,8 @@ const mockSuccess = vi.hoisted(() => vi.fn())
 const mockLoadTooltip = vi.hoisted(() => vi.fn())
 
 const mockInsertItems = ref([
-  { id: 1, code: '1234567890', insertBefore: 'before1', insertAfter: 'after1' },
-  { id: 2, code: '0987654321', insertBefore: 'before2', insertAfter: 'after2' }
+  { id: 1, code: '1234567890', insBefore: 'before1', insAfter: 'after1' },
+  { id: 2, code: '0987654321', insBefore: 'before2', insAfter: 'after2' }
 ])
 
 // Mock stores and modules

--- a/tests/feacn.insert.items.store.spec.js
+++ b/tests/feacn.insert.items.store.spec.js
@@ -20,11 +20,11 @@ describe('feacn.insert.items.store.js', () => {
   let pinia
 
   const mockItems = [
-    { id: 1, code: '1234567890', insertBefore: '111', insertAfter: '222' },
-    { id: 2, code: '0987654321', insertBefore: '333', insertAfter: '444' }
+    { id: 1, code: '1234567890', insBefore: '111', insAfter: '222' },
+    { id: 2, code: '0987654321', insBefore: '333', insAfter: '444' }
   ]
 
-  const mockItem = { id: 1, code: '1234567890', insertBefore: '111', insertAfter: '222' }
+  const mockItem = { id: 1, code: '1234567890', insBefore: '111', insAfter: '222' }
 
   beforeEach(() => {
     pinia = createPinia()


### PR DESCRIPTION
## Summary
- add FeacnInsertItem_Settings component with FEACN code search
- add create/edit views for FEACN insert item rules and router entries
- cover new components with tests

## Testing
- `npm test` *(fails: environment issues capturing output)*

------
https://chatgpt.com/codex/tasks/task_e_68aa350518948321ad5f4b2c65dde499