### PR TITLE
Add FEACN prefixes store and tests

### DIFF
--- a/src/stores/feacn.prefix.store.js
+++ b/src/stores/feacn.prefix.store.js
@@ -1,0 +1,132 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/feacnprefixes`
+
+export const useFeacnPrefixesStore = defineStore('feacnPrefixes', () => {
+  const prefixes = ref([])
+  const prefix = ref({ loading: true })
+  const loading = ref(false)
+  const error = ref(null)
+  const isInitialized = ref(false)
+
+  async function getAll() {
+    loading.value = true
+    try {
+      const response = await fetchWrapper.get(baseUrl)
+      prefixes.value = response || []
+      isInitialized.value = true
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function ensureLoaded() {
+    if (!isInitialized.value && !loading.value) {
+      await getAll()
+    }
+  }
+
+  async function getById(id, refresh = false) {
+    if (refresh) {
+      prefix.value = { loading: true }
+    }
+    loading.value = true
+    try {
+      const response = await fetchWrapper.get(`${baseUrl}/${id}`)
+      prefix.value = response
+      return response
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function create(data) {
+    loading.value = true
+    try {
+      const response = await fetchWrapper.post(baseUrl, data)
+      await getAll()
+      return response
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function update(id, data) {
+    loading.value = true
+    try {
+      const response = await fetchWrapper.put(`${baseUrl}/${id}`, data)
+      await getAll()
+      return response
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function remove(id) {
+    loading.value = true
+    try {
+      await fetchWrapper.delete(`${baseUrl}/${id}`)
+      await getAll()
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    prefixes,
+    prefix,
+    loading,
+    error,
+    isInitialized,
+    getAll,
+    getById,
+    create,
+    update,
+    remove,
+    ensureLoaded
+  }
+})
+

--- a/tests/feacn.prefix.store.spec.js
+++ b/tests/feacn.prefix.store.spec.js
@@ -1,0 +1,136 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { useFeacnPrefixesStore } from '@/stores/feacn.prefix.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn()
+  }
+}))
+
+vi.mock('@/helpers/config.js', () => ({
+  apiUrl: 'http://localhost:3000/api'
+}))
+
+describe('feacn.prefix.store.js', () => {
+  let store
+  let pinia
+
+  const mockPrefixes = [
+    { id: 1, code: '0101', intervalCode: '0', description: 'd1', comment: 'c1', exceptions: ['111'] },
+    { id: 2, code: '0202', intervalCode: '0', description: 'd2', comment: 'c2', exceptions: ['222', '333'] }
+  ]
+
+  const mockPrefix = { id: 1, code: '0101', intervalCode: '0', description: 'd1', comment: 'c1', exceptions: ['111'] }
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    store = useFeacnPrefixesStore()
+    vi.clearAllMocks()
+    store.error = null
+  })
+
+  describe('initial state', () => {
+    it('sets defaults', () => {
+      expect(store.prefixes).toEqual([])
+      expect(store.prefix).toEqual({ loading: true })
+      expect(store.loading).toBe(false)
+    })
+  })
+
+  describe('CRUD operations', () => {
+    it('getAll retrieves prefixes', async () => {
+      fetchWrapper.get.mockResolvedValue(mockPrefixes)
+      await store.getAll()
+      expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:3000/api/feacnprefixes')
+      expect(store.prefixes).toEqual(mockPrefixes)
+    })
+
+    it('getById retrieves prefix by id', async () => {
+      fetchWrapper.get.mockResolvedValue(mockPrefix)
+      const res = await store.getById(1)
+      expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:3000/api/feacnprefixes/1')
+      expect(res).toEqual(mockPrefix)
+      expect(store.prefix).toEqual(mockPrefix)
+    })
+
+    it('create posts prefix and refreshes list', async () => {
+      fetchWrapper.post.mockResolvedValue({})
+      fetchWrapper.get.mockResolvedValue(mockPrefixes)
+      await store.create(mockPrefix)
+      expect(fetchWrapper.post).toHaveBeenCalledWith('http://localhost:3000/api/feacnprefixes', mockPrefix)
+      expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:3000/api/feacnprefixes')
+    })
+
+    it('update puts prefix and refreshes list', async () => {
+      fetchWrapper.put.mockResolvedValue({})
+      fetchWrapper.get.mockResolvedValue(mockPrefixes)
+      await store.update(1, mockPrefix)
+      expect(fetchWrapper.put).toHaveBeenCalledWith('http://localhost:3000/api/feacnprefixes/1', mockPrefix)
+      expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:3000/api/feacnprefixes')
+    })
+
+    it('remove deletes prefix and refreshes list', async () => {
+      fetchWrapper.delete.mockResolvedValue()
+      fetchWrapper.get.mockResolvedValue([])
+      await store.remove(1)
+      expect(fetchWrapper.delete).toHaveBeenCalledWith('http://localhost:3000/api/feacnprefixes/1')
+      expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:3000/api/feacnprefixes')
+    })
+
+    it('getById refresh flag resets prefix before fetch', async () => {
+      fetchWrapper.get.mockResolvedValue(mockPrefix)
+      store.prefix = { id: 99 }
+      await store.getById(1, true)
+      expect(store.prefix).toEqual(mockPrefix)
+    })
+
+    it('ensureLoaded fetches prefixes when not initialized', async () => {
+      fetchWrapper.get.mockResolvedValue(mockPrefixes)
+      await store.ensureLoaded()
+      expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:3000/api/feacnprefixes')
+      expect(store.prefixes).toEqual(mockPrefixes)
+    })
+
+    it('ensureLoaded skips fetch when already initialized', async () => {
+      store.isInitialized = true
+      await store.ensureLoaded()
+      expect(fetchWrapper.get).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('error handling', () => {
+    it('sets error when getAll fails', async () => {
+      const err = new Error('fail')
+      fetchWrapper.get.mockRejectedValue(err)
+      await expect(store.getAll()).rejects.toThrow('fail')
+      expect(store.error).toBe(err)
+    })
+
+    it('sets error when create fails', async () => {
+      const err = new Error('fail')
+      fetchWrapper.post.mockRejectedValue(err)
+      await expect(store.create(mockPrefix)).rejects.toThrow('fail')
+      expect(store.error).toBe(err)
+    })
+
+    it('sets error when update fails', async () => {
+      const err = new Error('fail')
+      fetchWrapper.put.mockRejectedValue(err)
+      await expect(store.update(1, mockPrefix)).rejects.toThrow('fail')
+      expect(store.error).toBe(err)
+    })
+
+    it('sets error when remove fails', async () => {
+      const err = new Error('fail')
+      fetchWrapper.delete.mockRejectedValue(err)
+      await expect(store.remove(1)).rejects.toThrow('fail')
+      expect(store.error).toBe(err)
+    })
+  })
+})
+


### PR DESCRIPTION
## Summary
- add Pinia store for FEACN prefixes with CRUD helpers
- cover FEACN prefixes store with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5c545ce488321a552ede842c91a94