### PR TITLE
feat: add FEACN prefixes view and list

### DIFF
--- a/src/components/FeacnPrefixes_List.vue
+++ b/src/components/FeacnPrefixes_List.vue
@@ -1,0 +1,193 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import { onMounted, computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useFeacnPrefixesStore } from '@/stores/feacn.prefix.store.js'
+import { useAuthStore } from '@/stores/auth.store.js'
+import { useAlertStore } from '@/stores/alert.store.js'
+import ActionButton from '@/components/ActionButton.vue'
+import {
+  preloadFeacnInfo,
+  loadFeacnTooltipOnHover,
+  useFeacnTooltips
+} from '@/helpers/feacn.info.helpers.js'
+
+const prefixesStore = useFeacnPrefixesStore()
+const authStore = useAuthStore()
+const alertStore = useAlertStore()
+
+const { prefixes, loading } = storeToRefs(prefixesStore)
+const { alert } = storeToRefs(alertStore)
+
+// Shared FEACN info cache
+const feacnTooltips = useFeacnTooltips()
+
+// Tooltip width limitation
+const tooltipMaxWidth = computed(() => {
+  if (typeof window !== 'undefined') {
+    return `${window.innerWidth * 0.5}px`
+  }
+  return '400px'
+})
+
+const headers = [
+  { title: '', align: 'center', key: 'actions', sortable: false, width: '10%' },
+  { title: 'Префикс', key: 'code', align: 'start', width: '120px' },
+  { title: 'Описание', key: 'description', align: 'start' },
+  { title: 'Исключения', key: 'exceptions', align: 'start' }
+]
+
+onMounted(async () => {
+  await prefixesStore.getAll()
+  await preloadFeacnInfo(prefixes.value.map(p => p.code))
+})
+
+function openCreateDialog() {
+  console.log('openCreateDialog stub')
+}
+
+function openEditDialog(item) {
+  console.log('openEditDialog stub', item)
+}
+
+function deletePrefix(item) {
+  console.log('deletePrefix stub', item)
+}
+
+// Expose for testing
+defineExpose({
+  openCreateDialog,
+  openEditDialog,
+  deletePrefix
+})
+</script>
+
+<template>
+  <div class="settings table-3" data-testid="feacn-prefixes-list">
+    <h1 class="primary-heading">Префиксы ТН ВЭД</h1>
+    <hr class="hr" />
+
+    <div class="link-crt">
+      <a v-if="authStore.isAdmin" @click="openCreateDialog" class="link">
+        <font-awesome-icon
+          size="1x"
+          icon="fa-solid fa-plus"
+          class="link"
+        />&nbsp;&nbsp;&nbsp;Добавить префикс
+      </a>
+    </div>
+
+    <v-card>
+      <v-data-table
+        v-if="prefixes?.length"
+        :headers="headers"
+        :items="prefixes"
+        :loading="loading"
+        density="compact"
+        class="elevation-1 interlaced-table"
+      >
+        <template v-slot:[`item.code`]="{ item }">
+          <v-tooltip
+            location="top"
+            content-class="feacn-tooltip"
+            :max-width="tooltipMaxWidth"
+          >
+            <template v-slot:activator="{ props }">
+              <span
+                v-bind="props"
+                class="feacn-code-tooltip"
+                @mouseenter="loadFeacnTooltipOnHover(item.code)"
+              >
+                {{ item.code }}
+              </span>
+            </template>
+            <span>{{ feacnTooltips[item.code]?.name || 'Наведите для загрузки...' }}</span>
+          </v-tooltip>
+        </template>
+
+        <template v-slot:[`item.description`]="{ item }">
+          {{ feacnTooltips[item.code]?.name || '-' }}
+        </template>
+
+        <template v-slot:[`item.exceptions`]="{ item }">
+          <span v-if="item.exceptions && item.exceptions.length">
+            <span v-for="(code, index) in item.exceptions" :key="code">
+              <v-tooltip
+                location="top"
+                content-class="feacn-tooltip"
+                :max-width="tooltipMaxWidth"
+              >
+                <template v-slot:activator="{ props }">
+                  <span
+                    v-bind="props"
+                    class="feacn-code-tooltip"
+                    @mouseenter="loadFeacnTooltipOnHover(code)"
+                  >
+                    {{ code }}
+                  </span>
+                </template>
+                <span>{{ feacnTooltips[code]?.name || 'Наведите для загрузки...' }}</span>
+              </v-tooltip>
+              <span v-if="index < item.exceptions.length - 1">, </span>
+            </span>
+          </span>
+          <span v-else>-</span>
+        </template>
+
+        <template v-slot:[`item.actions`]="{ item }">
+          <div v-if="authStore.isAdmin" class="actions-container">
+            <ActionButton
+              :item="item"
+              icon="fa-solid fa-pen"
+              tooltip-text="Редактировать префикс"
+              @click="openEditDialog"
+            />
+            <ActionButton
+              :item="item"
+              icon="fa-solid fa-trash-can"
+              tooltip-text="Удалить префикс"
+              @click="deletePrefix"
+            />
+          </div>
+        </template>
+      </v-data-table>
+
+      <div v-if="!prefixes?.length" class="text-center m-5">Список префиксов пуст</div>
+    </v-card>
+
+    <div v-if="loading" class="text-center m-5">
+      <span class="spinner-border spinner-border-lg align-center"></span>
+    </div>
+
+    <!-- Alert -->
+    <div v-if="alert" class="alert alert-dismissable mt-3 mb-0" :class="alert.type">
+      <button @click="alertStore.clear()" class="btn btn-link close">×</button>
+      {{ alert.message }}
+    </div>
+  </div>
+</template>
+

--- a/src/views/FeacnPrefixes_View.vue
+++ b/src/views/FeacnPrefixes_View.vue
@@ -1,0 +1,33 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import FeacnPrefixes_List from '@/components/FeacnPrefixes_List.vue'
+</script>
+
+<template>
+  <FeacnPrefixes_List />
+</template>
+

--- a/tests/FeacnPrefixes_List.spec.js
+++ b/tests/FeacnPrefixes_List.spec.js
@@ -1,0 +1,92 @@
+/* @vitest-environment jsdom */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import FeacnPrefixesList from '@/components/FeacnPrefixes_List.vue'
+import { vuetifyStubs } from './helpers/test-utils.js'
+
+// Hoisted mocks
+const getAllPrefixes = vi.hoisted(() => vi.fn())
+const preloadFeacnInfo = vi.hoisted(() => vi.fn())
+const loadFeacnTooltipOnHover = vi.hoisted(() => vi.fn())
+
+const mockPrefixes = ref([
+  { id: 1, code: '0101', description: 'd1', exceptions: ['111'] },
+  { id: 2, code: '0202', description: 'd2', exceptions: [] }
+])
+
+const mockFeacnInfo = ref({
+  '0101': { name: 'Derived 0101' },
+  '0202': { name: 'Derived 0202' },
+  '111': { name: 'Exception 111' }
+})
+
+vi.mock('@/stores/feacn.prefix.store.js', () => ({
+  useFeacnPrefixesStore: () => ({
+    prefixes: mockPrefixes,
+    loading: ref(false),
+    getAll: getAllPrefixes
+  })
+}))
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: () => ({ isAdmin: ref(true) })
+}))
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => ({
+    alert: ref(null),
+    clear: vi.fn()
+  })
+}))
+
+vi.mock('@/helpers/feacn.info.helpers.js', () => ({
+  preloadFeacnInfo,
+  loadFeacnTooltipOnHover,
+  useFeacnTooltips: () => mockFeacnInfo
+}))
+
+describe('FeacnPrefixes_List.vue', () => {
+  let wrapper
+
+  beforeEach(() => {
+    getAllPrefixes.mockClear()
+    preloadFeacnInfo.mockClear()
+    loadFeacnTooltipOnHover.mockClear()
+    wrapper = mount(FeacnPrefixesList, { global: { stubs: vuetifyStubs } })
+  })
+
+  it('fetches prefixes and preloads FEACN info on mount', () => {
+    expect(getAllPrefixes).toHaveBeenCalled()
+    expect(preloadFeacnInfo).toHaveBeenCalledWith(['0101', '0202'])
+  })
+
+  it('renders prefixes using derived description', () => {
+    const rows = wrapper.findAll('[data-testid="v-data-table"] .v-data-table-row')
+    expect(rows.length).toBe(2)
+    const firstRowCells = rows[0].findAll('.v-data-table-cell')
+    expect(firstRowCells[2].text()).toBe('Derived 0101')
+  })
+
+  it('calls loadFeacnTooltipOnHover for exceptions on hover', async () => {
+    const exceptionSpan = wrapper
+      .findAll('[data-testid="v-data-table"] .v-data-table-row')[0]
+      .findAll('.v-data-table-cell')[3]
+      .findAll('.feacn-code-tooltip')[0]
+    await exceptionSpan.trigger('mouseenter')
+    expect(loadFeacnTooltipOnHover).toHaveBeenCalledWith('111')
+  })
+
+  it('provides stub action handlers', () => {
+    expect(typeof wrapper.vm.openCreateDialog).toBe('function')
+    expect(typeof wrapper.vm.openEditDialog).toBe('function')
+    expect(typeof wrapper.vm.deletePrefix).toBe('function')
+
+    const firstRowButtons = wrapper
+      .findAll('[data-testid="v-data-table"] .v-data-table-row')[0]
+      .findAll('.anti-btn')
+    expect(firstRowButtons.length).toBe(2)
+  })
+})
+

--- a/tests/FeacnPrefixes_View.spec.js
+++ b/tests/FeacnPrefixes_View.spec.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import FeacnPrefixes_View from '@/views/FeacnPrefixes_View.vue'
+import FeacnPrefixes_List from '@/components/FeacnPrefixes_List.vue'
+
+const vuetify = createVuetify()
+
+vi.mock('@/components/FeacnPrefixes_List.vue', () => ({
+  default: {
+    name: 'FeacnPrefixes_List',
+    template: '<div data-test="fp-list">FeacnPrefixes_List Component</div>'
+  }
+}))
+
+describe('FeacnPrefixes_View', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(FeacnPrefixes_View, { global: { plugins: [vuetify] } })
+  })
+
+  it('renders FeacnPrefixes_List component', () => {
+    const list = wrapper.findComponent(FeacnPrefixes_List)
+    expect(list.exists()).toBe(true)
+  })
+
+  it('has correct structure', () => {
+    expect(wrapper.find('[data-test="fp-list"]').exists()).toBe(true)
+  })
+})
+


### PR DESCRIPTION
## Summary
- add `FeacnPrefixes_View` and `FeacnPrefixes_List` for managing FEACN prefixes
- preload FEACN info to derive descriptions and show tooltips for exceptions
- cover prefixes UI with unit tests

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b5d86359c48321b54ed1c7c6fb68bb