### PR TITLE
feat: add Feacn prefix management

### DIFF
--- a/src/components/FeacnCodeInput.vue
+++ b/src/components/FeacnCodeInput.vue
@@ -1,0 +1,120 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import { ref, watch, onUnmounted } from 'vue'
+import FeacnCodeSearch from '@/components/FeacnCodeSearch.vue'
+import ActionButton from '@/components/ActionButton.vue'
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+  disabled: { type: Boolean, default: false },
+  inputId: { type: String, default: '' },
+  placeholder: { type: String, default: 'Введите код ТН ВЭД' }
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const internalValue = ref(props.modelValue)
+const searchActive = ref(false)
+
+watch(() => props.modelValue, val => {
+  internalValue.value = val
+})
+
+watch(internalValue, val => emit('update:modelValue', val))
+
+function onInput(event) {
+  const value = event.target.value.replace(/\D/g, '').slice(0, 10)
+  internalValue.value = value
+}
+
+function toggleSearch() {
+  searchActive.value = !searchActive.value
+}
+
+function handleSelect(code) {
+  internalValue.value = code
+  searchActive.value = false
+}
+
+function handleEscape(event) {
+  if (event.key === 'Escape') {
+    searchActive.value = false
+  }
+}
+
+watch(searchActive, val => {
+  if (val) {
+    document.addEventListener('keydown', handleEscape)
+  } else {
+    document.removeEventListener('keydown', handleEscape)
+  }
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleEscape)
+})
+</script>
+
+<template>
+  <div class="feacn-search-wrapper">
+    <input
+      :id="inputId"
+      class="form-control input"
+      :disabled="disabled || searchActive"
+      :value="internalValue"
+      :placeholder="placeholder"
+      @input="onInput"
+    />
+    <ActionButton
+      data-test="feacn-code-search-btn"
+      :icon="searchActive ? 'fa-solid fa-arrow-up' : 'fa-solid fa-arrow-down'"
+      :item="null"
+      @click="toggleSearch"
+      class="ml-2"
+      :disabled="disabled"
+    />
+    <FeacnCodeSearch
+      v-if="searchActive"
+      class="feacn-overlay"
+      @select="handleSelect"
+    />
+  </div>
+</template>
+
+<style scoped>
+.feacn-search-wrapper {
+  position: relative;
+}
+
+.feacn-overlay {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  right: 0;
+  z-index: 100;
+}
+</style>

--- a/src/components/FeacnPrefix_Settings.vue
+++ b/src/components/FeacnPrefix_Settings.vue
@@ -1,0 +1,185 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import router from '@/router'
+import { storeToRefs } from 'pinia'
+import { useForm, useField } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/yup'
+import * as Yup from 'yup'
+import { useFeacnPrefixesStore } from '@/stores/feacn.prefix.store.js'
+import { useAlertStore } from '@/stores/alert.store.js'
+import FieldArrayWithButtons from '@/components/FieldArrayWithButtons.vue'
+import FeacnCodeInput from '@/components/FeacnCodeInput.vue'
+
+const props = defineProps({
+  mode: {
+    type: String,
+    required: true,
+    validator: (value) => ['create', 'edit'].includes(value)
+  },
+  prefixId: {
+    type: [String, Number],
+    required: false
+  }
+})
+
+const prefixesStore = useFeacnPrefixesStore()
+const alertStore = useAlertStore()
+const { alert } = storeToRefs(alertStore)
+
+const isCreate = computed(() => props.mode === 'create')
+const saving = ref(false)
+const loading = ref(false)
+
+const schema = toTypedSchema(
+  Yup.object({
+    code: Yup.string().required('Префикс обязателен'),
+    comment: Yup.string(),
+    exceptions: Yup.array().of(Yup.string())
+  })
+)
+
+const { errors, handleSubmit, resetForm, setFieldValue, values } = useForm({
+  validationSchema: schema,
+  initialValues: {
+    code: '',
+    comment: '',
+    exceptions: [],
+  }
+})
+
+if (!values.exceptions.length) {
+  setFieldValue('exceptions', [''])
+}
+
+const { value: code } = useField('code')
+const { value: comment } = useField('comment')
+
+onMounted(async () => {
+  if (!isCreate.value) {
+    loading.value = true
+    try {
+      const item = await prefixesStore.getById(props.prefixId)
+      if (item) {
+        resetForm({
+          values: {
+            code: item.code || '',
+            comment: item.comment || '',
+            exceptions: item.exceptions && item.exceptions.length ? item.exceptions : ['']
+          }
+        })
+      }
+    } catch {
+      alertStore.error('Ошибка при загрузке данных префикса')
+      router.push('/feacn/prefixes')
+    } finally {
+      loading.value = false
+    }
+  }
+})
+
+const onSubmit = handleSubmit(async (values, { setErrors }) => {
+  saving.value = true
+  try {
+    if (isCreate.value) {
+      await prefixesStore.create(values)
+    } else {
+      await prefixesStore.update(props.prefixId, values)
+    }
+    router.push('/feacn/prefixes')
+  } catch (error) {
+    setErrors({ apiError: error.message || 'Ошибка при сохранении префикса' })
+  } finally {
+    saving.value = false
+  }
+})
+
+function cancel() {
+  router.push('/feacn/prefixes')
+}
+</script>
+
+<template>
+  <div class="settings form-3">
+    <h1 class="primary-heading">{{ isCreate ? 'Создание префикса' : 'Редактирование префикса' }}</h1>
+    <hr class="hr" />
+
+    <div v-if="loading" class="text-center m-5">
+      <span class="spinner-border spinner-border-lg align-center"></span>
+    </div>
+
+    <form v-else @submit.prevent="onSubmit">
+      <div class="form-group">
+        <label for="code" class="label">Префикс ТН ВЭД:</label>
+        <FeacnCodeInput input-id="code" v-model="code" />
+        <div v-if="errors.code" class="invalid-feedback">{{ errors.code }}</div>
+      </div>
+
+      <div class="form-group">
+        <label for="comment" class="label">Комментарий:</label>
+        <input
+          name="comment"
+          id="comment"
+          type="text"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.comment }"
+          v-model="comment"
+          placeholder="Комментарий (не обязательно)"
+        />
+        <div v-if="errors.comment" class="invalid-feedback">{{ errors.comment }}</div>
+      </div>
+
+      <FieldArrayWithButtons
+        name="exceptions"
+        label="Исключения"
+        :field-type="FeacnCodeInput"
+        :default-value="''"
+        :field-props="({ index }) => ({ inputId: `exceptions_${index}`, placeholder: 'Введите исключение' })"
+      />
+
+      <div class="form-group mt-8">
+        <button class="button primary" type="submit" :disabled="saving">
+          <span v-show="saving" class="spinner-border spinner-border-sm mr-1"></span>
+          <font-awesome-icon size="1x" icon="fa-solid fa-check-double" class="mr-1" />
+          {{ isCreate ? 'Создать' : 'Сохранить' }}
+        </button>
+        <button class="button secondary" type="button" @click="cancel">
+          <font-awesome-icon size="1x" icon="fa-solid fa-xmark" class="mr-1" />
+          Отменить
+        </button>
+      </div>
+
+      <div v-if="errors.apiError" class="alert alert-danger mt-3 mb-0">{{ errors.apiError }}</div>
+    </form>
+
+    <div v-if="alert" class="alert alert-dismissable mt-3 mb-0" :class="alert.type">
+      <button @click="alertStore.clear()" class="btn btn-link close">×</button>
+      {{ alert.message }}
+    </div>
+  </div>
+</template>
+

--- a/src/components/FieldArrayWithButtons.vue
+++ b/src/components/FieldArrayWithButtons.vue
@@ -34,9 +34,14 @@ const props = defineProps({
     required: true
   },
   fieldType: {
-    type: String,
+    type: [String, Object],
     default: 'select',
-    validator: (value) => ['select', 'input', 'textarea'].includes(value)
+    validator: (value) => {
+      if (typeof value === 'string') {
+        return ['select', 'input', 'textarea'].includes(value)
+      }
+      return typeof value === 'object'
+    }
   },
   options: {
     type: Array,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -154,6 +154,21 @@ const router = createRouter({
       component: () => import('@/views/FeacnPrefixes_View.vue')
     },
     {
+      path: '/feacnprefix/create',
+      name: 'Создание префикса ТН ВЭД',
+      component: () => import('@/views/FeacnPrefix_CreateView.vue'),
+      meta: { requiresAdmin: true }
+    },
+    {
+      path: '/feacnprefix/edit/:id',
+      name: 'Редактирование префикса ТН ВЭД',
+      component: () => import('@/views/FeacnPrefix_EditView.vue'),
+      props: (route) => ({
+        id: Number(route.params.id)
+      }),
+      meta: { requiresAdmin: true }
+    },
+    {
       path: '/feacn/codes',
       name: 'Коды ТН ВЭД',
       component: () => import('@/views/FeacnCodes_View.vue')

--- a/src/views/FeacnPrefix_CreateView.vue
+++ b/src/views/FeacnPrefix_CreateView.vue
@@ -1,0 +1,32 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import FeacnPrefix_Settings from '@/components/FeacnPrefix_Settings.vue'
+</script>
+
+<template>
+  <FeacnPrefix_Settings :mode="'create'" />
+</template>

--- a/src/views/FeacnPrefix_EditView.vue
+++ b/src/views/FeacnPrefix_EditView.vue
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import { useRoute } from 'vue-router'
+import FeacnPrefix_Settings from '@/components/FeacnPrefix_Settings.vue'
+
+const route = useRoute()
+</script>
+
+<template>
+  <FeacnPrefix_Settings :mode="'edit'" :prefix-id="route.params.id" />
+</template>

--- a/tests/FeacnPrefix_CreateView.spec.js
+++ b/tests/FeacnPrefix_CreateView.spec.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import FeacnPrefix_CreateView from '@/views/FeacnPrefix_CreateView.vue'
+import FeacnPrefix_Settings from '@/components/FeacnPrefix_Settings.vue'
+
+const vuetify = createVuetify()
+
+vi.mock('@/components/FeacnPrefix_Settings.vue', () => ({
+  default: {
+    name: 'FeacnPrefix_Settings',
+    template: '<div data-test="fp-settings">FeacnPrefix_Settings Component</div>'
+  }
+}))
+
+describe('FeacnPrefix_CreateView.vue', () => {
+  it('renders FeacnPrefix_Settings component', () => {
+    const wrapper = mount(FeacnPrefix_CreateView, {
+      global: { plugins: [vuetify] }
+    })
+    const comp = wrapper.findComponent(FeacnPrefix_Settings)
+    expect(comp.exists()).toBe(true)
+    expect(wrapper.html()).toContain('FeacnPrefix_Settings Component')
+  })
+})

--- a/tests/FeacnPrefix_EditView.spec.js
+++ b/tests/FeacnPrefix_EditView.spec.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import FeacnPrefix_EditView from '@/views/FeacnPrefix_EditView.vue'
+import FeacnPrefix_Settings from '@/components/FeacnPrefix_Settings.vue'
+
+const vuetify = createVuetify()
+
+const mockRoute = {
+  params: { id: '123' }
+}
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute
+}))
+
+vi.mock('@/components/FeacnPrefix_Settings.vue', () => ({
+  default: {
+    name: 'FeacnPrefix_Settings',
+    props: ['mode', 'prefixId'],
+    template: '<div data-test="fp-settings">Fp Settings {{ prefixId }}</div>'
+  }
+}))
+
+describe('FeacnPrefix_EditView.vue', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(FeacnPrefix_EditView, {
+      global: { plugins: [vuetify] }
+    })
+  })
+
+  it('renders FeacnPrefix_Settings component', () => {
+    const comp = wrapper.findComponent(FeacnPrefix_Settings)
+    expect(comp.exists()).toBe(true)
+  })
+
+  it('passes route id to FeacnPrefix_Settings', () => {
+    const comp = wrapper.findComponent(FeacnPrefix_Settings)
+    expect(comp.props('prefixId')).toBe('123')
+  })
+
+  it('renders stub content', () => {
+    expect(wrapper.html()).toContain('Fp Settings 123')
+  })
+})

--- a/tests/FeacnPrefix_Settings.spec.js
+++ b/tests/FeacnPrefix_Settings.spec.js
@@ -1,0 +1,120 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { ref } from 'vue'
+import FeacnPrefix_Settings from '@/components/FeacnPrefix_Settings.vue'
+import FeacnCodeInput from '@/components/FeacnCodeInput.vue'
+
+vi.mock('@/components/FeacnCodeSearch.vue', () => ({
+  default: {
+    name: 'FeacnCodeSearch',
+    emits: ['select'],
+    template: '<div class="feacn-code-search-stub" @click="$emit(\'select\', \'9876543210\')"></div>'
+  }
+}))
+
+vi.mock('@/components/ActionButton.vue', () => ({
+  default: {
+    name: 'ActionButton',
+    props: ['item', 'icon', 'tooltipText', 'iconSize', 'disabled'],
+    emits: ['click'],
+    template: '<button v-bind="$attrs" @click="$emit(\'click\', item)"></button>'
+  }
+}))
+
+const getById = vi.fn()
+const create = vi.fn()
+const update = vi.fn()
+
+vi.mock('@/stores/feacn.prefix.store.js', () => ({
+  useFeacnPrefixesStore: () => ({
+    getById,
+    create,
+    update
+  })
+}))
+
+const alertError = vi.fn()
+const alertClear = vi.fn()
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => ({
+    error: alertError,
+    clear: alertClear
+  })
+}))
+
+vi.mock('@/router', () => ({
+  default: {
+    push: vi.fn()
+  }
+}))
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return {
+    ...actual,
+    storeToRefs: () => ({
+      alert: ref(null)
+    })
+  }
+})
+
+describe('FeacnPrefix_Settings.vue', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  const mountComponent = (props = { mode: 'create' }) =>
+    mount(FeacnPrefix_Settings, {
+      props,
+      global: {
+        stubs: { 'font-awesome-icon': true }
+      }
+    })
+
+  it('renders create mode and submits', async () => {
+    create.mockResolvedValue({})
+    const wrapper = mountComponent()
+    wrapper.vm.setFieldValue('code', '1234')
+    wrapper.vm.setFieldValue('comment', 'comm')
+    wrapper.vm.setFieldValue('exceptions[0]', '5678')
+    await wrapper.vm.onSubmit()
+    expect(create).toHaveBeenCalledWith({ code: '1234', comment: 'comm', exceptions: ['5678'] })
+  })
+
+  it('loads data in edit mode and updates', async () => {
+    getById.mockResolvedValue({ code: '0101', comment: 'c1', exceptions: ['111', '222'] })
+    update.mockResolvedValue({})
+    const wrapper = mountComponent({ mode: 'edit', prefixId: 1 })
+    await flushPromises()
+    expect(getById).toHaveBeenCalledWith(1)
+    // ensure values loaded
+    expect(wrapper.find('input#code').element.value).toBe('0101')
+    await wrapper.vm.setFieldValue('exceptions', ['111', '222'])
+    await wrapper.vm.onSubmit()
+    expect(update).toHaveBeenCalledWith(1, { code: '0101', comment: 'c1', exceptions: ['111', '222'] })
+  })
+
+  it('toggles code search and selects value', async () => {
+    const wrapper = mountComponent()
+    const buttons = wrapper.findAll('[data-test="feacn-code-search-btn"]')
+    expect(wrapper.find('.feacn-code-search-stub').exists()).toBe(false)
+    await buttons[0].trigger('click')
+    expect(wrapper.find('.feacn-code-search-stub').exists()).toBe(true)
+    await wrapper.find('.feacn-code-search-stub').trigger('click')
+    expect(wrapper.find('input#code').element.value).toBe('9876543210')
+  })
+
+  it('allows selecting exception code', async () => {
+    const wrapper = mountComponent()
+    await flushPromises()
+    const inputs = wrapper.findAllComponents(FeacnCodeInput)
+    await inputs[1].find('[data-test="feacn-code-search-btn"]').trigger('click')
+    const overlay = wrapper.find('.feacn-code-search-stub')
+    await overlay.trigger('click')
+    expect(wrapper.find('input#exceptions_0').element.value).toBe('9876543210')
+  })
+})

--- a/tests/FieldArrayWithButtons.spec.js
+++ b/tests/FieldArrayWithButtons.spec.js
@@ -246,11 +246,14 @@ describe('FieldArrayWithButtons', () => {
     const validTypes = ['select', 'input', 'textarea']
     const component = FieldArrayWithButtons
     const validator = component.props.fieldType.validator
-    
+
     validTypes.forEach(type => {
       expect(validator(type)).toBe(true)
     })
-    
+
+    // also allows component objects
+    expect(validator({})).toBe(true)
+
     expect(validator('invalid')).toBe(false)
   })
 


### PR DESCRIPTION
## Summary
- add reusable FeacnCodeInput with inline search
- allow FieldArrayWithButtons to render custom components
- introduce Feacn prefix views with exception list editing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5e6418b7c832182756912fe588e58