### PR TITLE
feat: add FEACN prefix editing views

### DIFF
--- a/src/components/FeacnInsertItem_Settings.vue
+++ b/src/components/FeacnInsertItem_Settings.vue
@@ -201,7 +201,7 @@ function cancel() {
                 :item="null"
                 @click="toggleSearch"
                 class="ml-2 mr-2"
-                tooltip-text="Выбрать код"
+                :tooltip-text="searchActive ? 'Скрыть дерево кодов' : 'Выбрать код'"
                 :disabled="false"
             />
             <div v-if="errors.code" class="invalid-feedback">{{ errors.code }}</div>

--- a/src/components/FeacnPrefix_Settings.vue
+++ b/src/components/FeacnPrefix_Settings.vue
@@ -1,0 +1,173 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import router from '@/router'
+import { storeToRefs } from 'pinia'
+import { useForm, useField } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/yup'
+import * as Yup from 'yup'
+import FieldArrayWithButtons from '@/components/FieldArrayWithButtons.vue'
+import { useFeacnPrefixesStore } from '@/stores/feacn.prefix.store.js'
+import { useAlertStore } from '@/stores/alert.store.js'
+
+const props = defineProps({
+  mode: {
+    type: String,
+    required: true,
+    validator: (value) => ['create', 'edit'].includes(value)
+  },
+  prefixId: {
+    type: [String, Number],
+    required: false
+  }
+})
+
+const prefixesStore = useFeacnPrefixesStore()
+const alertStore = useAlertStore()
+const { alert } = storeToRefs(alertStore)
+
+const isCreate = computed(() => props.mode === 'create')
+const saving = ref(false)
+const loading = ref(false)
+
+const schema = toTypedSchema(
+  Yup.object({
+    code: Yup.string().required('Префикс обязателен'),
+    exceptions: Yup.array().of(Yup.string())
+  })
+)
+
+const { errors, handleSubmit, resetForm, setFieldValue } = useForm({
+  validationSchema: schema,
+  initialValues: {
+    code: '',
+    exceptions: ['']
+  }
+})
+
+const { value: code } = useField('code')
+
+onMounted(async () => {
+  if (!isCreate.value) {
+    loading.value = true
+    try {
+      const item = await prefixesStore.getById(props.prefixId)
+      if (item) {
+        resetForm({
+          values: {
+            code: item.code || '',
+            exceptions: item.exceptions && item.exceptions.length ? item.exceptions : ['']
+          }
+        })
+      }
+    } catch {
+      alertStore.error('Ошибка при загрузке данных префикса')
+      router.push('/feacn/prefixes')
+    } finally {
+      loading.value = false
+    }
+  }
+})
+
+const onSubmit = handleSubmit(async (values, { setErrors }) => {
+  saving.value = true
+  try {
+    if (isCreate.value) {
+      await prefixesStore.create(values)
+    } else {
+      await prefixesStore.update(props.prefixId, values)
+    }
+    router.push('/feacn/prefixes')
+  } catch (error) {
+    setErrors({ apiError: error.message || 'Ошибка при сохранении префикса' })
+  } finally {
+    saving.value = false
+  }
+})
+
+function cancel() {
+  router.push('/feacn/prefixes')
+}
+</script>
+
+<template>
+  <div class="settings form-3">
+    <h1 class="primary-heading">{{ isCreate ? 'Создание префикса ТН ВЭД' : 'Редактирование префикса ТН ВЭД' }}</h1>
+    <hr class="hr" />
+
+    <div v-if="loading" class="text-center m-5">
+      <span class="spinner-border spinner-border-lg align-center"></span>
+    </div>
+
+    <form v-else @submit.prevent="onSubmit">
+      <div class="form-group">
+        <label for="code" class="label">Префикс:</label>
+        <input
+          name="code"
+          id="code"
+          type="text"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.code }"
+          v-model="code"
+          placeholder="Введите префикс ТН ВЭД"
+        />
+        <div v-if="errors.code" class="invalid-feedback">{{ errors.code }}</div>
+      </div>
+
+      <FieldArrayWithButtons
+        name="exceptions"
+        label="Исключения"
+        field-type="input"
+        placeholder="Код-исключение"
+        add-tooltip="Добавить исключение"
+        remove-tooltip="Удалить исключение"
+        :has-error="!!errors.exceptions"
+      />
+      <div v-if="errors.exceptions" class="invalid-feedback">{{ errors.exceptions }}</div>
+
+      <div class="form-group mt-8">
+        <button class="button primary" type="submit" :disabled="saving">
+          <span v-show="saving" class="spinner-border spinner-border-sm mr-1"></span>
+          <font-awesome-icon size="1x" icon="fa-solid fa-check-double" class="mr-1" />
+          {{ isCreate ? 'Создать' : 'Сохранить' }}
+        </button>
+        <button class="button secondary" type="button" @click="cancel">
+          <font-awesome-icon size="1x" icon="fa-solid fa-xmark" class="mr-1" />
+          Отменить
+        </button>
+      </div>
+
+      <div v-if="errors.apiError" class="alert alert-danger mt-3 mb-0">{{ errors.apiError }}</div>
+    </form>
+
+    <div v-if="alert" class="alert alert-dismissable mt-3 mb-0" :class="alert.type">
+      <button @click="alertStore.clear()" class="btn btn-link close">×</button>
+      {{ alert.message }}
+    </div>
+  </div>
+</template>
+

--- a/src/components/FeacnPrefix_Settings.vue
+++ b/src/components/FeacnPrefix_Settings.vue
@@ -77,10 +77,15 @@ onMounted(async () => {
     try {
       const item = await prefixesStore.getById(props.prefixId)
       if (item) {
+        // Convert FeacnPrefixExceptionDto[] to string[] for UI display
+        const exceptionCodes = item.exceptions && item.exceptions.length 
+          ? item.exceptions.map(exc => typeof exc === 'string' ? exc : exc.code)
+          : ['']
+        
         resetForm({
           values: {
             code: item.code || '',
-            exceptions: item.exceptions && item.exceptions.length ? item.exceptions : ['']
+            exceptions: exceptionCodes
           }
         })
       }
@@ -96,10 +101,17 @@ onMounted(async () => {
 const onSubmit = handleSubmit(async (values, { setErrors }) => {
   saving.value = true
   try {
+    // Prepare data for API - convert UI format to DTO format
+    const submitData = {
+      code: values.code,
+      // Filter out empty strings and convert to the format expected by CreateDto
+      exceptions: values.exceptions.filter(exc => exc && exc.trim() !== '')
+    }
+
     if (isCreate.value) {
-      await prefixesStore.create(values)
+      await prefixesStore.create(submitData)
     } else {
-      await prefixesStore.update(props.prefixId, values)
+      await prefixesStore.update(props.prefixId, submitData)
     }
     router.push('/feacn/prefixes')
   } catch (error) {

--- a/src/components/FeacnPrefixes_List.vue
+++ b/src/components/FeacnPrefixes_List.vue
@@ -26,10 +26,12 @@
 <script setup>
 import { onMounted, computed } from 'vue'
 import { storeToRefs } from 'pinia'
+import router from '@/router'
 import { useFeacnPrefixesStore } from '@/stores/feacn.prefix.store.js'
 import { useAuthStore } from '@/stores/auth.store.js'
 import { useAlertStore } from '@/stores/alert.store.js'
 import ActionButton from '@/components/ActionButton.vue'
+import { useConfirm } from 'vuetify-use-dialog'
 import {
   preloadFeacnInfo,
   loadFeacnTooltipOnHover,
@@ -39,6 +41,7 @@ import {
 const prefixesStore = useFeacnPrefixesStore()
 const authStore = useAuthStore()
 const alertStore = useAlertStore()
+const confirm = useConfirm()
 
 const { prefixes, loading } = storeToRefs(prefixesStore)
 const { alert } = storeToRefs(alertStore)
@@ -67,15 +70,35 @@ onMounted(async () => {
 })
 
 function openCreateDialog() {
-  console.log('openCreateDialog stub')
+  router.push('/feacn/prefix/create')
 }
 
 function openEditDialog(item) {
-  console.log('openEditDialog stub', item)
+  router.push(`/feacn/prefix/edit/${item.id}`)
 }
 
-function deletePrefix(item) {
-  console.log('deletePrefix stub', item)
+async function deletePrefix(item) {
+  const confirmed = await confirm({
+    title: 'Подтверждение',
+    confirmationText: 'Удалить',
+    cancellationText: 'Не удалять',
+    dialogProps: {
+      width: '30%',
+      minWidth: '250px'
+    },
+    confirmationButtonProps: {
+      color: 'orange-darken-3'
+    },
+    content: 'Удалить префикс?'
+  })
+
+  if (confirmed) {
+    try {
+      await prefixesStore.remove(item.id)
+    } catch {
+      alertStore.error('Ошибка при удалении префикса')
+    }
+  }
 }
 
 // Expose for testing

--- a/src/components/KeyWord_Settings.vue
+++ b/src/components/KeyWord_Settings.vue
@@ -267,11 +267,11 @@ defineExpose({
         >
           <template #extra="{ index }">
             <ActionButton
-              :icon="searchIndex === index ? 'fa-solid fa-arrow-up' : 'fa-solid fa-arrow-down'"
+              :icon="searchActive && searchIndex === index ? 'fa-solid fa-arrow-up' : 'fa-solid fa-arrow-down'"
               :item="index"
               @click="toggleSearch(index)"
               class="button-o-c ml-2"
-              tooltip-text="Выбрать код"
+              :tooltip-text="searchActive && searchIndex === index ? 'Скрыть дерево кодов' : 'Выбрать код'"
               :disabled="searchActive && searchIndex !== index"
             />
           </template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -154,6 +154,21 @@ const router = createRouter({
       component: () => import('@/views/FeacnPrefixes_View.vue')
     },
     {
+      path: '/feacn/prefix/create',
+      name: 'Создание префикса ТН ВЭД',
+      component: () => import('@/views/FeacnPrefix_CreateView.vue'),
+      meta: { requiresAdmin: true }
+    },
+    {
+      path: '/feacn/prefix/edit/:id',
+      name: 'Редактирование префикса ТН ВЭД',
+      component: () => import('@/views/FeacnPrefix_EditView.vue'),
+      props: (route) => ({
+        id: Number(route.params.id)
+      }),
+      meta: { requiresAdmin: true }
+    },
+    {
       path: '/feacn/codes',
       name: 'Коды ТН ВЭД',
       component: () => import('@/views/FeacnCodes_View.vue')

--- a/src/views/FeacnInsertItem_EditView.vue
+++ b/src/views/FeacnInsertItem_EditView.vue
@@ -24,7 +24,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 <script setup>
-import { useRoute } from 'vue-router'
 import FeacnInsertItem_Settings from '@/components/FeacnInsertItem_Settings.vue'
 
 const props = defineProps({

--- a/src/views/FeacnPrefix_CreateView.vue
+++ b/src/views/FeacnPrefix_CreateView.vue
@@ -1,0 +1,33 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import FeacnPrefix_Settings from '@/components/FeacnPrefix_Settings.vue'
+</script>
+
+<template>
+  <FeacnPrefix_Settings :mode="'create'" />
+</template>
+

--- a/src/views/FeacnPrefix_EditView.vue
+++ b/src/views/FeacnPrefix_EditView.vue
@@ -24,7 +24,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 <script setup>
-import { useRoute } from 'vue-router'
 import FeacnPrefix_Settings from '@/components/FeacnPrefix_Settings.vue'
 
 const props = defineProps({

--- a/src/views/FeacnPrefix_EditView.vue
+++ b/src/views/FeacnPrefix_EditView.vue
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks frontend application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+<script setup>
+import { useRoute } from 'vue-router'
+import FeacnPrefix_Settings from '@/components/FeacnPrefix_Settings.vue'
+
+const route = useRoute()
+</script>
+
+<template>
+  <FeacnPrefix_Settings :mode="'edit'" :prefix-id="route.params.id" />
+</template>
+

--- a/src/views/FeacnPrefix_EditView.vue
+++ b/src/views/FeacnPrefix_EditView.vue
@@ -27,10 +27,15 @@
 import { useRoute } from 'vue-router'
 import FeacnPrefix_Settings from '@/components/FeacnPrefix_Settings.vue'
 
-const route = useRoute()
+const props = defineProps({
+  id: {
+    type: Number,
+    required: true
+  }
+})
 </script>
 
 <template>
-  <FeacnPrefix_Settings :mode="'edit'" :prefix-id="route.params.id" />
+  <FeacnPrefix_Settings :mode="'edit'" :prefix-id="props.id" />
 </template>
 

--- a/src/views/KeyWord_EditView.vue
+++ b/src/views/KeyWord_EditView.vue
@@ -24,7 +24,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 <script setup>
-import { useRoute } from 'vue-router'
 import KeyWord_Settings from '@/components/KeyWord_Settings.vue'
 
 const props = defineProps({

--- a/src/views/StopWord_EditView.vue
+++ b/src/views/StopWord_EditView.vue
@@ -24,7 +24,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 <script setup>
-import { useRoute } from 'vue-router'
 import StopWord_Settings from '@/components/StopWord_Settings.vue'
 
 const props = defineProps({

--- a/tests/FeacnInsertItem_EditView.spec.js
+++ b/tests/FeacnInsertItem_EditView.spec.js
@@ -6,16 +6,6 @@ import FeacnInsertItem_Settings from '@/components/FeacnInsertItem_Settings.vue'
 
 const vuetify = createVuetify()
 
-const mockRoute = {
-  params: {
-    id: '123'
-  }
-}
-
-vi.mock('vue-router', () => ({
-  useRoute: () => mockRoute
-}))
-
 vi.mock('@/components/FeacnInsertItem_Settings.vue', () => ({
   default: {
     name: 'FeacnInsertItem_Settings',
@@ -29,6 +19,9 @@ describe('FeacnInsertItem_EditView.vue', () => {
 
   beforeEach(() => {
     wrapper = mount(FeacnInsertItem_EditView, {
+      props: {
+        id: 123
+      },
       global: { plugins: [vuetify] }
     })
   })
@@ -40,7 +33,7 @@ describe('FeacnInsertItem_EditView.vue', () => {
 
   it('passes route id to FeacnInsertItem_Settings', () => {
     const comp = wrapper.findComponent(FeacnInsertItem_Settings)
-    expect(comp.props('insertItemId')).toBe('123')
+    expect(comp.props('insertItemId')).toBe(123)
   })
 
   it('renders stub content', () => {

--- a/tests/FeacnPrefix_CreateView.spec.js
+++ b/tests/FeacnPrefix_CreateView.spec.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import FeacnPrefix_CreateView from '@/views/FeacnPrefix_CreateView.vue'
+import FeacnPrefix_Settings from '@/components/FeacnPrefix_Settings.vue'
+
+const vuetify = createVuetify()
+
+vi.mock('@/components/FeacnPrefix_Settings.vue', () => ({
+  default: {
+    name: 'FeacnPrefix_Settings',
+    template: '<div data-test="fp-settings">FeacnPrefix_Settings Component</div>'
+  }
+}))
+
+describe('FeacnPrefix_CreateView.vue', () => {
+  it('renders FeacnPrefix_Settings component', () => {
+    const wrapper = mount(FeacnPrefix_CreateView, {
+      global: { plugins: [vuetify] }
+    })
+    const comp = wrapper.findComponent(FeacnPrefix_Settings)
+    expect(comp.exists()).toBe(true)
+    expect(wrapper.html()).toContain('FeacnPrefix_Settings Component')
+  })
+})
+

--- a/tests/FeacnPrefix_EditView.spec.js
+++ b/tests/FeacnPrefix_EditView.spec.js
@@ -6,16 +6,6 @@ import FeacnPrefix_Settings from '@/components/FeacnPrefix_Settings.vue'
 
 const vuetify = createVuetify()
 
-const mockRoute = {
-  params: {
-    id: '123'
-  }
-}
-
-vi.mock('vue-router', () => ({
-  useRoute: () => mockRoute
-}))
-
 vi.mock('@/components/FeacnPrefix_Settings.vue', () => ({
   default: {
     name: 'FeacnPrefix_Settings',
@@ -29,6 +19,9 @@ describe('FeacnPrefix_EditView.vue', () => {
 
   beforeEach(() => {
     wrapper = mount(FeacnPrefix_EditView, {
+      props: {
+        id: 123
+      },
       global: { plugins: [vuetify] }
     })
   })
@@ -40,7 +33,7 @@ describe('FeacnPrefix_EditView.vue', () => {
 
   it('passes route id to FeacnPrefix_Settings', () => {
     const comp = wrapper.findComponent(FeacnPrefix_Settings)
-    expect(comp.props('prefixId')).toBe('123')
+    expect(comp.props('prefixId')).toBe(123)
   })
 
   it('renders stub content', () => {

--- a/tests/FeacnPrefix_EditView.spec.js
+++ b/tests/FeacnPrefix_EditView.spec.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import FeacnPrefix_EditView from '@/views/FeacnPrefix_EditView.vue'
+import FeacnPrefix_Settings from '@/components/FeacnPrefix_Settings.vue'
+
+const vuetify = createVuetify()
+
+const mockRoute = {
+  params: {
+    id: '123'
+  }
+}
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute
+}))
+
+vi.mock('@/components/FeacnPrefix_Settings.vue', () => ({
+  default: {
+    name: 'FeacnPrefix_Settings',
+    props: ['mode', 'prefixId'],
+    template: '<div data-test="fp-settings">Fp Settings {{ prefixId }}</div>'
+  }
+}))
+
+describe('FeacnPrefix_EditView.vue', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(FeacnPrefix_EditView, {
+      global: { plugins: [vuetify] }
+    })
+  })
+
+  it('renders FeacnPrefix_Settings component', () => {
+    const comp = wrapper.findComponent(FeacnPrefix_Settings)
+    expect(comp.exists()).toBe(true)
+  })
+
+  it('passes route id to FeacnPrefix_Settings', () => {
+    const comp = wrapper.findComponent(FeacnPrefix_Settings)
+    expect(comp.props('prefixId')).toBe('123')
+  })
+
+  it('renders stub content', () => {
+    expect(wrapper.html()).toContain('Fp Settings 123')
+  })
+})
+

--- a/tests/FeacnPrefix_Settings.spec.js
+++ b/tests/FeacnPrefix_Settings.spec.js
@@ -71,19 +71,46 @@ describe('FeacnPrefix_Settings.vue', () => {
     create.mockResolvedValue({})
     const wrapper = mountComponent()
     wrapper.vm.setFieldValue('code', '0101')
-    wrapper.vm.setFieldValue('exceptions', ['111'])
+    wrapper.vm.setFieldValue('exceptions', ['111', ''])
     await wrapper.vm.onSubmit()
     expect(create).toHaveBeenCalledWith({ code: '0101', exceptions: ['111'] })
   })
 
   it('loads data in edit mode and updates', async () => {
-    getById.mockResolvedValue({ code: '0202', exceptions: ['222'] })
+    // Mock backend response with FeacnPrefixExceptionDto structure
+    getById.mockResolvedValue({ 
+      code: '0202', 
+      exceptions: [{ id: 1, code: '222', feacnPrefixId: 1 }] 
+    })
     update.mockResolvedValue({})
     const wrapper = mountComponent({ mode: 'edit', prefixId: 1 })
     await flushPromises()
     await wrapper.vm.onSubmit()
     expect(getById).toHaveBeenCalledWith(1)
     expect(update).toHaveBeenCalledWith(1, { code: '0202', exceptions: ['222'] })
+  })
+
+  it('handles mixed exception formats in edit mode', async () => {
+    // Mock backend response with mixed string and object formats for backward compatibility
+    getById.mockResolvedValue({ 
+      code: '0303', 
+      exceptions: ['333', { id: 2, code: '444', feacnPrefixId: 1 }] 
+    })
+    update.mockResolvedValue({})
+    const wrapper = mountComponent({ mode: 'edit', prefixId: 1 })
+    await flushPromises()
+    await wrapper.vm.onSubmit()
+    expect(getById).toHaveBeenCalledWith(1)
+    expect(update).toHaveBeenCalledWith(1, { code: '0303', exceptions: ['333', '444'] })
+  })
+
+  it('filters out empty exception strings on submit', async () => {
+    create.mockResolvedValue({})
+    const wrapper = mountComponent()
+    wrapper.vm.setFieldValue('code', '0404')
+    wrapper.vm.setFieldValue('exceptions', ['555', '', '666', '   '])
+    await wrapper.vm.onSubmit()
+    expect(create).toHaveBeenCalledWith({ code: '0404', exceptions: ['555', '666'] })
   })
 
   it('renders FieldArrayWithButtons', () => {

--- a/tests/FeacnPrefix_Settings.spec.js
+++ b/tests/FeacnPrefix_Settings.spec.js
@@ -14,6 +14,26 @@ vi.mock('@/components/FieldArrayWithButtons.vue', () => ({
   }
 }))
 
+// Mock FeacnCodeSearch
+vi.mock('@/components/FeacnCodeSearch.vue', () => ({
+  default: {
+    name: 'FeacnCodeSearch',
+    props: [],
+    emits: ['select'],
+    template: '<div data-test="feacn-code-search"></div>'
+  }
+}))
+
+// Mock ActionButton
+vi.mock('@/components/ActionButton.vue', () => ({
+  default: {
+    name: 'ActionButton',
+    props: ['icon', 'item', 'tooltipText', 'disabled'],
+    emits: ['click'],
+    template: '<button data-test="action-button" @click="$emit(\'click\')">{{ icon }}</button>'
+  }
+}))
+
 // Mock stores
 const getById = vi.fn()
 const create = vi.fn()
@@ -116,6 +136,42 @@ describe('FeacnPrefix_Settings.vue', () => {
   it('renders FieldArrayWithButtons', () => {
     const wrapper = mountComponent()
     expect(wrapper.find('[data-test="fab-stub"]').exists()).toBe(true)
+  })
+
+  it('renders ActionButton and FeacnCodeSearch when search is toggled', async () => {
+    const wrapper = mountComponent()
+    
+    // Should render ActionButton
+    expect(wrapper.find('[data-test="action-button"]').exists()).toBe(true)
+    
+    // Should not show search initially
+    expect(wrapper.find('[data-test="feacn-code-search"]').exists()).toBe(false)
+    
+    // Click the action button to toggle search
+    await wrapper.find('[data-test="action-button"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    
+    // Should show search now
+    expect(wrapper.find('[data-test="feacn-code-search"]').exists()).toBe(true)
+  })
+
+  it('handles code selection from FeacnCodeSearch', async () => {
+    const wrapper = mountComponent()
+    
+    // Toggle search on
+    await wrapper.find('[data-test="action-button"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    
+    // Simulate code selection
+    const feacnCodeSearch = wrapper.findComponent({ name: 'FeacnCodeSearch' })
+    await feacnCodeSearch.vm.$emit('select', '123456')
+    
+    // Check that code field is updated
+    expect(wrapper.vm.code).toBe('123456')
+    
+    // Search should be closed
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-test="feacn-code-search"]').exists()).toBe(false)
   })
 })
 

--- a/tests/FeacnPrefix_Settings.spec.js
+++ b/tests/FeacnPrefix_Settings.spec.js
@@ -1,0 +1,94 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { ref } from 'vue'
+import FeacnPrefix_Settings from '@/components/FeacnPrefix_Settings.vue'
+
+// Stub FieldArrayWithButtons
+vi.mock('@/components/FieldArrayWithButtons.vue', () => ({
+  default: {
+    name: 'FieldArrayWithButtons',
+    props: ['name', 'label'],
+    template: '<div data-test="fab-stub"></div>'
+  }
+}))
+
+// Mock stores
+const getById = vi.fn()
+const create = vi.fn()
+const update = vi.fn()
+
+vi.mock('@/stores/feacn.prefix.store.js', () => ({
+  useFeacnPrefixesStore: () => ({
+    getById,
+    create,
+    update
+  })
+}))
+
+const alertError = vi.fn()
+const alertClear = vi.fn()
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => ({
+    error: alertError,
+    clear: alertClear
+  })
+}))
+
+vi.mock('@/router', () => ({
+  default: {
+    push: vi.fn()
+  }
+}))
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return {
+    ...actual,
+    storeToRefs: () => ({
+      alert: ref(null)
+    })
+  }
+})
+
+describe('FeacnPrefix_Settings.vue', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  const mountComponent = (props = { mode: 'create' }) =>
+    mount(FeacnPrefix_Settings, {
+      props,
+      global: {
+        stubs: { 'font-awesome-icon': true }
+      }
+    })
+
+  it('renders create mode and submits', async () => {
+    create.mockResolvedValue({})
+    const wrapper = mountComponent()
+    wrapper.vm.setFieldValue('code', '0101')
+    wrapper.vm.setFieldValue('exceptions', ['111'])
+    await wrapper.vm.onSubmit()
+    expect(create).toHaveBeenCalledWith({ code: '0101', exceptions: ['111'] })
+  })
+
+  it('loads data in edit mode and updates', async () => {
+    getById.mockResolvedValue({ code: '0202', exceptions: ['222'] })
+    update.mockResolvedValue({})
+    const wrapper = mountComponent({ mode: 'edit', prefixId: 1 })
+    await flushPromises()
+    await wrapper.vm.onSubmit()
+    expect(getById).toHaveBeenCalledWith(1)
+    expect(update).toHaveBeenCalledWith(1, { code: '0202', exceptions: ['222'] })
+  })
+
+  it('renders FieldArrayWithButtons', () => {
+    const wrapper = mountComponent()
+    expect(wrapper.find('[data-test="fab-stub"]').exists()).toBe(true)
+  })
+})
+

--- a/tests/FeacnPrefixes_List.spec.js
+++ b/tests/FeacnPrefixes_List.spec.js
@@ -159,5 +159,3 @@ describe('FeacnPrefixes_List.vue', () => {
     expect(wrapper.vm.getExceptionKey(exception, 2)).toBe('2-789')
   })
 })
-
-

--- a/tests/FeacnPrefixes_List.spec.js
+++ b/tests/FeacnPrefixes_List.spec.js
@@ -15,8 +15,18 @@ const mockPush = vi.hoisted(() => vi.fn())
 const mockConfirm = vi.hoisted(() => vi.fn())
 
 const mockPrefixes = ref([
-  { id: 1, code: '0101', description: 'd1', exceptions: ['111'] },
-  { id: 2, code: '0202', description: 'd2', exceptions: [] }
+  { 
+    id: 1, 
+    code: '0101', 
+    description: 'd1', 
+    exceptions: [{ id: 1, code: '111', feacnPrefixId: 1 }] 
+  },
+  { 
+    id: 2, 
+    code: '0202', 
+    description: 'd2', 
+    exceptions: []
+  }
 ])
 
 const mockFeacnInfo = ref({
@@ -75,7 +85,7 @@ describe('FeacnPrefixes_List.vue', () => {
 
   it('fetches prefixes and preloads FEACN info on mount', () => {
     expect(getAllPrefixes).toHaveBeenCalled()
-    expect(preloadFeacnInfo).toHaveBeenCalledWith(['0101', '0202'])
+    expect(preloadFeacnInfo).toHaveBeenCalledWith(['0101', '0202', '111'])
   })
 
   it('renders prefixes using derived description', () => {
@@ -124,6 +134,29 @@ describe('FeacnPrefixes_List.vue', () => {
     mockConfirm.mockResolvedValue(false)
     await wrapper.vm.deletePrefix(mockPrefixes.value[0])
     expect(removePrefix).not.toHaveBeenCalled()
+  })
+
+  it('getExceptionCode handles string exceptions', () => {
+    expect(wrapper.vm.getExceptionCode('123')).toBe('123')
+  })
+
+  it('getExceptionCode handles object exceptions', () => {
+    const exception = { id: 1, code: '456', feacnPrefixId: 1 }
+    expect(wrapper.vm.getExceptionCode(exception)).toBe('456')
+  })
+
+  it('getExceptionKey generates keys for string exceptions', () => {
+    expect(wrapper.vm.getExceptionKey('123', 0)).toBe('123')
+  })
+
+  it('getExceptionKey generates keys for object exceptions', () => {
+    const exception = { id: 1, code: '456', feacnPrefixId: 1 }
+    expect(wrapper.vm.getExceptionKey(exception, 0)).toBe('1-456')
+  })
+
+  it('getExceptionKey handles object exceptions without id', () => {
+    const exception = { code: '789', feacnPrefixId: 1 }
+    expect(wrapper.vm.getExceptionKey(exception, 2)).toBe('2-789')
   })
 })
 

--- a/tests/KeyWord_EditView.spec.js
+++ b/tests/KeyWord_EditView.spec.js
@@ -31,18 +31,6 @@ import KeyWord_Settings from '@/components/KeyWord_Settings.vue'
 
 const vuetify = createVuetify()
 
-// Mock the route
-const mockRoute = {
-  params: {
-    id: '123'
-  }
-}
-
-// Mock useRoute
-vi.mock('vue-router', () => ({
-  useRoute: () => mockRoute
-}))
-
 // Mock the KeyWord_Settings component
 vi.mock('@/components/KeyWord_Settings.vue', () => ({
   default: {
@@ -57,6 +45,9 @@ describe('KeyWord_EditView', () => {
 
   beforeEach(() => {
     wrapper = mount(KeyWord_EditView, {
+      props: {
+        id: 123
+      },
       global: {
         plugins: [vuetify]
       }
@@ -64,13 +55,13 @@ describe('KeyWord_EditView', () => {
   })
 
   it('should render KeyWord_Settings component', () => {
-    const stopWordSettings = wrapper.findComponent(KeyWord_Settings)
-    expect(stopWordSettings.exists()).toBe(true)
+    const keyWordSettings = wrapper.findComponent(KeyWord_Settings)
+    expect(keyWordSettings.exists()).toBe(true)
   })
 
   it('should pass route id to KeyWord_Settings component', () => {
-    const stopWordSettings = wrapper.findComponent(KeyWord_Settings)
-    expect(stopWordSettings.props('id')).toBe('123')
+    const keyWordSettings = wrapper.findComponent(KeyWord_Settings)
+    expect(keyWordSettings.props('id')).toBe(123)
   })
 
   it('should have correct component structure', () => {
@@ -79,9 +70,5 @@ describe('KeyWord_EditView', () => {
 
   it('should be a simple wrapper component for edit mode', () => {
     expect(wrapper.html()).toContain('KeyWord_Settings Component with ID: 123')
-  })
-
-  it('should get route parameter correctly', () => {
-    expect(wrapper.vm.route.params.id).toBe('123')
   })
 })

--- a/tests/StopWord_EditView.spec.js
+++ b/tests/StopWord_EditView.spec.js
@@ -31,18 +31,6 @@ import StopWord_Settings from '@/components/StopWord_Settings.vue'
 
 const vuetify = createVuetify()
 
-// Mock the route
-const mockRoute = {
-  params: {
-    id: '123'
-  }
-}
-
-// Mock useRoute
-vi.mock('vue-router', () => ({
-  useRoute: () => mockRoute
-}))
-
 // Mock the StopWord_Settings component
 vi.mock('@/components/StopWord_Settings.vue', () => ({
   default: {
@@ -57,6 +45,9 @@ describe('StopWord_EditView', () => {
 
   beforeEach(() => {
     wrapper = mount(StopWord_EditView, {
+      props: {
+        id: 123
+      },
       global: {
         plugins: [vuetify]
       }
@@ -70,7 +61,7 @@ describe('StopWord_EditView', () => {
 
   it('should pass route id to StopWord_Settings component', () => {
     const stopWordSettings = wrapper.findComponent(StopWord_Settings)
-    expect(stopWordSettings.props('id')).toBe('123')
+    expect(stopWordSettings.props('id')).toBe(123)
   })
 
   it('should have correct component structure', () => {
@@ -79,9 +70,5 @@ describe('StopWord_EditView', () => {
 
   it('should be a simple wrapper component for edit mode', () => {
     expect(wrapper.html()).toContain('StopWord_Settings Component with ID: 123')
-  })
-
-  it('should get route parameter correctly', () => {
-    expect(wrapper.vm.route.params.id).toBe('123')
   })
 })

--- a/tests/feacn.prefix.store.spec.js
+++ b/tests/feacn.prefix.store.spec.js
@@ -20,11 +20,35 @@ describe('feacn.prefix.store.js', () => {
   let pinia
 
   const mockPrefixes = [
-    { id: 1, code: '0101', intervalCode: '0', description: 'd1', comment: 'c1', exceptions: ['111'] },
-    { id: 2, code: '0202', intervalCode: '0', description: 'd2', comment: 'c2', exceptions: ['222', '333'] }
+    { 
+      id: 1, 
+      code: '0101', 
+      intervalCode: '0', 
+      description: 'd1', 
+      comment: 'c1', 
+      exceptions: [{ id: 1, code: '111', feacnPrefixId: 1 }] 
+    },
+    { 
+      id: 2, 
+      code: '0202', 
+      intervalCode: '0', 
+      description: 'd2', 
+      comment: 'c2', 
+      exceptions: [
+        { id: 2, code: '222', feacnPrefixId: 2 }, 
+        { id: 3, code: '333', feacnPrefixId: 2 }
+      ] 
+    }
   ]
 
-  const mockPrefix = { id: 1, code: '0101', intervalCode: '0', description: 'd1', comment: 'c1', exceptions: ['111'] }
+  const mockPrefix = { 
+    id: 1, 
+    code: '0101', 
+    intervalCode: '0', 
+    description: 'd1', 
+    comment: 'c1', 
+    exceptions: [{ id: 1, code: '111', feacnPrefixId: 1 }] 
+  }
 
   beforeEach(() => {
     pinia = createPinia()
@@ -102,6 +126,22 @@ describe('feacn.prefix.store.js', () => {
       expect(store.prefix).toEqual({ id: 99, loading: true })
       await promise
       expect(store.prefix).toEqual(mockPrefix)
+    })
+
+    it('handles create DTO format with string exceptions', async () => {
+      const createDto = { code: '0404', exceptions: ['444', '555'] }
+      fetchWrapper.post.mockResolvedValue({})
+      fetchWrapper.get.mockResolvedValue(mockPrefixes)
+      await store.create(createDto)
+      expect(fetchWrapper.post).toHaveBeenCalledWith('http://localhost:3000/api/feacnprefixes', createDto)
+    })
+
+    it('handles update DTO format with string exceptions', async () => {
+      const updateDto = { code: '0505', exceptions: ['666'] }
+      fetchWrapper.put.mockResolvedValue({})
+      fetchWrapper.get.mockResolvedValue(mockPrefixes)
+      await store.update(1, updateDto)
+      expect(fetchWrapper.put).toHaveBeenCalledWith('http://localhost:3000/api/feacnprefixes/1', updateDto)
     })
 
     it('ensureLoaded fetches prefixes when not initialized', async () => {


### PR DESCRIPTION
## Summary
- add FeacnPrefix_Settings component with prefix and exception fields
- introduce FeacnPrefix create and edit views and routes
- cover new FEACN prefix components with tests
- fix FEACN prefix routes and implement list actions

## Testing
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b609304d7c8321a0df3910de01e012