### PR TITLE
Support stop-word and FEACN register validation

### DIFF
--- a/src/helpers/registers.list.helpers.js
+++ b/src/helpers/registers.list.helpers.js
@@ -233,12 +233,13 @@ export async function pollValidation(validationState, registersStore, alertStore
  * @param {Object} alertStore - The alert store instance
  * @param {Function} stopPollingFn - Function to stop polling
  * @param {Function} startPollingFn - Function to start polling
+ * @param {boolean} sw - Whether to validate against Stopwords (true) or FEACN codes (false)
  * @returns {Promise<void>}
  */
-export async function validateRegister(item, validationState, registersStore, alertStore, stopPollingFn, startPollingFn) {
+export async function validateRegister(item, validationState, registersStore, alertStore, stopPollingFn, startPollingFn, sw) {
   try {
     stopPollingFn()
-    const res = await registersStore.validate(item.id)
+    const res = await registersStore.validate(item.id, sw)
     validationState.handleId = res.id
     validationState.total = 0
     validationState.processed = 0

--- a/src/lists/Registers_List.vue
+++ b/src/lists/Registers_List.vue
@@ -290,7 +290,7 @@ async function deleteRegister(item) {
   }
 }
 
-async function validateRegisterWrapper(item) {
+async function validateRegisterSw(item) {
   try {
     validationState.operation = 'validation'
     pollingFunction = () =>
@@ -301,7 +301,27 @@ async function validateRegisterWrapper(item) {
       registersStore,
       alertStore,
       () => pollingTimer.stop(),
-      () => pollingTimer.start()
+      () => pollingTimer.start(),
+      true
+    )
+  } catch (err) {
+    alertStore.error(err.message || String(err))
+  }
+}
+
+async function validateRegisterFc(item) {
+  try {
+    validationState.operation = 'validation'
+    pollingFunction = () =>
+      pollValidation(validationState, registersStore, alertStore, () => pollingTimer.stop())
+    await validateRegister(
+      item,
+      validationState,
+      registersStore,
+      alertStore,
+      () => pollingTimer.stop(),
+      () => pollingTimer.start(),
+      false
     )
   } catch (err) {
     alertStore.error(err.message || String(err))
@@ -562,7 +582,8 @@ const headers = [
               />
             </div>
 
-            <ActionButton :item="item" icon="fa-solid fa-clipboard-check" tooltip-text="Проверить реестр" @click="validateRegisterWrapper" :disabled="runningAction || loading" />
+            <ActionButton :item="item" icon="fa-solid fa-spell-check" tooltip-text="Проверить по стоп-словам" @click="validateRegisterSw" :disabled="runningAction || loading" />
+            <ActionButton :item="item" icon="fa-solid fa-anchor-circle-check" tooltip-text="Проверить по кодам ТН ВЭД" @click="validateRegisterFc" :disabled="runningAction || loading" />
             <ActionButton :item="item" icon="fa-solid fa-magnifying-glass" tooltip-text="Подбор кодов ТН ВЭД" @click="lookupFeacnCodes" :disabled="runningAction || loading" />
             <ActionButton :item="item" icon="fa-solid fa-upload" tooltip-text="Выгрузить XML накладные для всех посылок в реестре" @click="exportAllXml" :disabled="runningAction || loading" />
             <ActionButton :item="item" icon="fa-solid fa-file-export" tooltip-text="Экспортировать реестр" @click="downloadRegister" :disabled="runningAction || loading" />

--- a/src/stores/registers.store.js
+++ b/src/stores/registers.store.js
@@ -143,12 +143,9 @@ export const useRegistersStore = defineStore('registers', () => {
 
   async function validate(registerId, sw) {
     try {
-      let url
-      if (sw) {
-        url = `${baseUrl}/${registerId}/validate-sw`
-      } else {
-        url = `${baseUrl}/${registerId}/validate-fc`
-      }
+      const url = sw
+        ? `${baseUrl}/${registerId}/validate-sw`
+        : `${baseUrl}/${registerId}/validate-fc`
       const result = await fetchWrapper.post(url)
       return result
     } catch (err) {

--- a/src/stores/registers.store.js
+++ b/src/stores/registers.store.js
@@ -141,9 +141,15 @@ export const useRegistersStore = defineStore('registers', () => {
     }
   }
 
-  async function validate(registerId) {
+  async function validate(registerId, sw) {
     try {
-      const result = await fetchWrapper.post(`${baseUrl}/${registerId}/validate`)
+      let url
+      if (sw) {
+        url = `${baseUrl}/${registerId}/validate-sw`
+      } else {
+        url = `${baseUrl}/${registerId}/validate-fc`
+      }
+      const result = await fetchWrapper.post(url)
       return result
     } catch (err) {
       error.value = err

--- a/tests/registers.list.helpers.spec.js
+++ b/tests/registers.list.helpers.spec.js
@@ -584,10 +584,10 @@ describe('registers.list.helpers', () => {
           finished: false
         })
         
-        await validateRegister(item, validationState, mockRegistersStore, mockAlertStore, stopPollingFn, startPollingFn)
-        
+        await validateRegister(item, validationState, mockRegistersStore, mockAlertStore, stopPollingFn, startPollingFn, true)
+
         expect(stopPollingFn).toHaveBeenCalled()
-        expect(mockRegistersStore.validate).toHaveBeenCalledWith(123)
+        expect(mockRegistersStore.validate).toHaveBeenCalledWith(123, true)
         expect(validationState.handleId).toBe('validation-handle-123')
         expect(validationState.total).toBe(100)
         expect(validationState.processed).toBe(0)
@@ -599,10 +599,10 @@ describe('registers.list.helpers', () => {
         const errorMessage = 'Validation failed to start'
         mockRegistersStore.validate.mockRejectedValueOnce(new Error(errorMessage))
         
-        await validateRegister(item, validationState, mockRegistersStore, mockAlertStore, stopPollingFn, startPollingFn)
-        
+        await validateRegister(item, validationState, mockRegistersStore, mockAlertStore, stopPollingFn, startPollingFn, false)
+
         expect(stopPollingFn).toHaveBeenCalled()
-        expect(mockRegistersStore.validate).toHaveBeenCalledWith(123)
+        expect(mockRegistersStore.validate).toHaveBeenCalledWith(123, false)
         expect(mockAlertStore.error).toHaveBeenCalledWith(errorMessage)
         expect(validationState.show).toBe(false)
         expect(startPollingFn).not.toHaveBeenCalled()

--- a/tests/registers.store.spec.js
+++ b/tests/registers.store.spec.js
@@ -730,24 +730,25 @@ describe('registers store', () => {
   })
 
   describe('validation API', () => {
-    it('starts validation and returns handle', async () => {
+    it('starts validation for stop-words and returns handle', async () => {
       const handle = { id: '1234' }
       fetchWrapper.post.mockResolvedValue(handle)
 
       const store = useRegistersStore()
-      const result = await store.validate(1)
+      const result = await store.validate(1, true)
 
-      expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/registers/1/validate`)
+      expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/registers/1/validate-sw`)
       expect(result).toEqual(handle)
     })
 
-    it('handles validation error', async () => {
+    it('starts validation for FEACN and handles error', async () => {
       const error = new Error('Validation failed')
       fetchWrapper.post.mockRejectedValue(error)
 
       const store = useRegistersStore()
-      
-      await expect(store.validate(1)).rejects.toThrow('Validation failed')
+
+      await expect(store.validate(1, false)).rejects.toThrow('Validation failed')
+      expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/registers/1/validate-fc`)
       expect(store.error).toBe(error)
     })
 


### PR DESCRIPTION
## Summary
- add `sw` parameter to register validation store with separate stop-word and FEACN endpoints
- split register validation UI into two buttons mirroring parcel list behavior
- adjust helper logic and tests for new validation modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc6c6048e883218481d5fcdd1fff4f