### PR TITLE
Remove duplicate validation actions disabled flag

### DIFF
--- a/src/helpers/register.header.actions.js
+++ b/src/helpers/register.header.actions.js
@@ -54,10 +54,6 @@ export function useRegisterHeaderActions({
 
   const registerReady = computed(() => !!currentRegister.value && !registerLoadingRef.value)
 
-  const validationActionsDisabled = computed(() =>
-    !registerReady.value || tableLoadingRef.value || runningActionRef.value
-  )
-
   const generalActionsDisabled = computed(() =>
     !registerReady.value || tableLoadingRef.value || runningActionRef.value
   )
@@ -81,17 +77,17 @@ export function useRegisterHeaderActions({
   }
 
   const runValidateRegisterSw = async () => {
-    if (validationActionsDisabled.value) return
+    if (generalActionsDisabled.value) return
     await runWithLock(validateRegisterSw, false)
   }
 
   const runValidateRegisterFc = async () => {
-    if (validationActionsDisabled.value) return
+    if (generalActionsDisabled.value) return
     await runWithLock(validateRegisterFc, false)
   }
 
   const runLookupFeacnCodes = async () => {
-    if (validationActionsDisabled.value) return
+    if (generalActionsDisabled.value) return
     await runWithLock(lookupFeacnCodes, false)
   }
 
@@ -127,7 +123,6 @@ export function useRegisterHeaderActions({
   return {
     validationState,
     progressPercent,
-    validationActionsDisabled,
     generalActionsDisabled,
     validateRegisterSw: runValidateRegisterSw,
     validateRegisterFc: runValidateRegisterFc,

--- a/src/lists/OzonParcels_List.vue
+++ b/src/lists/OzonParcels_List.vue
@@ -173,7 +173,6 @@ provide('loadOrders', loadOrdersWrapper)
 const {
   validationState,
   progressPercent,
-  validationActionsDisabled,
   generalActionsDisabled,
   validateRegisterSw: validateRegisterSwHeader,
   validateRegisterFc: validateRegisterFcHeader,
@@ -378,7 +377,7 @@ function getGenericTemplateHeaders() {
           tooltip-text="Проверить по стоп-словам"
           :iconSize="'2x'"
           @click="validateRegisterSwHeader"
-          :disabled="validationActionsDisabled"
+          :disabled="generalActionsDisabled"
         />
         <ActionButton
           :item="registersStore.item"
@@ -386,7 +385,7 @@ function getGenericTemplateHeaders() {
           tooltip-text="Проверить по кодам ТН ВЭД"
           :iconSize="'2x'"
           @click="validateRegisterFcHeader"
-          :disabled="validationActionsDisabled"
+          :disabled="generalActionsDisabled"
         />
         <ActionButton
           :item="registersStore.item"
@@ -394,7 +393,7 @@ function getGenericTemplateHeaders() {
           tooltip-text="Подбор кодов ТН ВЭД"
           :iconSize="'2x'"
           @click="lookupRegisterFeacnCodes"
-          :disabled="validationActionsDisabled"
+          :disabled="generalActionsDisabled"
         />
         <ActionButton
           :item="registersStore.item"

--- a/src/lists/WbrParcels_List.vue
+++ b/src/lists/WbrParcels_List.vue
@@ -174,7 +174,6 @@ provide('loadOrders', loadOrdersWrapper)
 const {
   validationState,
   progressPercent,
-  validationActionsDisabled,
   generalActionsDisabled,
   validateRegisterSw: validateRegisterSwHeader,
   validateRegisterFc: validateRegisterFcHeader,
@@ -385,7 +384,7 @@ function getGenericTemplateHeaders() {
           tooltip-text="Проверить по стоп-словам"
           :iconSize="'2x'"
           @click="validateRegisterSwHeader"
-          :disabled="validationActionsDisabled"
+          :disabled="generalActionsDisabled"
         />
         <ActionButton
           :item="registersStore.item"
@@ -393,7 +392,7 @@ function getGenericTemplateHeaders() {
           tooltip-text="Проверить по кодам ТН ВЭД"
           :iconSize="'2x'"
           @click="validateRegisterFcHeader"
-          :disabled="validationActionsDisabled"
+          :disabled="generalActionsDisabled"
         />
         <ActionButton
           :item="registersStore.item"
@@ -401,7 +400,7 @@ function getGenericTemplateHeaders() {
           tooltip-text="Подбор кодов ТН ВЭД"
           :iconSize="'2x'"
           @click="lookupRegisterFeacnCodes"
-          :disabled="validationActionsDisabled"
+          :disabled="generalActionsDisabled"
         />
         <ActionButton
           :item="registersStore.item"

--- a/tests/Parcels_HeaderActions.spec.js
+++ b/tests/Parcels_HeaderActions.spec.js
@@ -18,7 +18,6 @@ function createRegisterHeaderActionsMock() {
   return {
     validationState: reactive({ show: false, operation: null, total: 0, processed: 0 }),
     progressPercent: ref(0),
-    validationActionsDisabled: ref(false),
     generalActionsDisabled: ref(false),
     validateRegisterSw: vi.fn(),
     validateRegisterFc: vi.fn(),


### PR DESCRIPTION
## Summary
- remove the redundant `validationActionsDisabled` computed state from `useRegisterHeaderActions`
- update parcel list components to rely on `generalActionsDisabled` for all header action buttons
- adjust tests to reflect the consolidated action disable state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d2fcecf2e08321bb7ff2279ee99049