### PR TITLE
Update register export buttons to call new store actions

### DIFF
--- a/src/helpers/register.header.actions.js
+++ b/src/helpers/register.header.actions.js
@@ -35,6 +35,8 @@ export function useRegisterHeaderActions({
     validateRegisterFc,
     lookupFeacnCodes,
     exportAllXml,
+    exportAllXmlWithoutExcise,
+    exportAllXmlExcise,
     downloadRegister,
     cancelValidation,
     stopPolling
@@ -96,6 +98,16 @@ export function useRegisterHeaderActions({
     await runWithLock(exportAllXml, true)
   }
 
+  const runExportAllXmlWithoutExcise = async () => {
+    if (generalActionsDisabled.value) return
+    await runWithLock(exportAllXmlWithoutExcise, true)
+  }
+
+  const runExportAllXmlExcise = async () => {
+    if (generalActionsDisabled.value) return
+    await runWithLock(exportAllXmlExcise, true)
+  }
+
   const runDownloadRegister = async () => {
     if (generalActionsDisabled.value) return
     await runWithLock(downloadRegister, true)
@@ -128,6 +140,8 @@ export function useRegisterHeaderActions({
     validateRegisterFc: runValidateRegisterFc,
     lookupFeacnCodes: runLookupFeacnCodes,
     exportAllXml: runExportAllXml,
+    exportAllXmlWithoutExcise: runExportAllXmlWithoutExcise,
+    exportAllXmlExcise: runExportAllXmlExcise,
     downloadRegister: runDownloadRegister,
     cancelValidation,
     stop

--- a/src/helpers/registers.list.helpers.js
+++ b/src/helpers/registers.list.helpers.js
@@ -391,6 +391,14 @@ export function createRegisterActionHandlers(registersStore, alertStore) {
     await registersStore.generate(item.id, item.invoiceNumber)
   }
 
+  async function exportAllXmlWithoutExcise(item) {
+    await registersStore.generateWithoutExcise(item.id, item.invoiceNumber)
+  }
+
+  async function exportAllXmlExcise(item) {
+    await registersStore.generateExcise(item.id, item.invoiceNumber)
+  }
+
   async function downloadRegister(item) {
     await registersStore.download(item.id, item.fileName)
   }
@@ -420,6 +428,8 @@ export function createRegisterActionHandlers(registersStore, alertStore) {
     validateRegisterFc,
     lookupFeacnCodes,
     exportAllXml,
+    exportAllXmlWithoutExcise,
+    exportAllXmlExcise,
     downloadRegister,
     cancelValidation: cancelValidationWrapper,
     stopPolling

--- a/src/lists/OzonParcels_List.vue
+++ b/src/lists/OzonParcels_List.vue
@@ -177,7 +177,8 @@ const {
   validateRegisterSw: validateRegisterSwHeader,
   validateRegisterFc: validateRegisterFcHeader,
   lookupFeacnCodes: lookupRegisterFeacnCodes,
-  exportAllXml: exportRegisterXml,
+  exportAllXmlWithoutExcise: exportRegisterXmlWithoutExcise,
+  exportAllXmlExcise: exportRegisterXmlExcise,
   downloadRegister: downloadRegisterFile,
   cancelValidation: cancelRegisterValidation,
   stop: stopRegisterHeaderActions
@@ -401,7 +402,7 @@ function getGenericTemplateHeaders() {
           tooltip-text="Выгрузить XML накладные для реестра (без акциза)"
           :iconSize="'2x'"
           variant="green"
-          @click="exportRegisterXml"
+          @click="exportRegisterXmlWithoutExcise"
           :disabled="generalActionsDisabled"
         />
         <ActionButton
@@ -410,7 +411,7 @@ function getGenericTemplateHeaders() {
           tooltip-text="Выгрузить XML накладные для реестра (акциз)"
           :iconSize="'2x'"
           variant="orange"
-          @click="exportRegisterXml"
+          @click="exportRegisterXmlExcise"
           :disabled="generalActionsDisabled"
         />
         <ActionButton

--- a/src/lists/WbrParcels_List.vue
+++ b/src/lists/WbrParcels_List.vue
@@ -178,7 +178,8 @@ const {
   validateRegisterSw: validateRegisterSwHeader,
   validateRegisterFc: validateRegisterFcHeader,
   lookupFeacnCodes: lookupRegisterFeacnCodes,
-  exportAllXml: exportRegisterXml,
+  exportAllXmlWithoutExcise: exportRegisterXmlWithoutExcise,
+  exportAllXmlExcise: exportRegisterXmlExcise,
   downloadRegister: downloadRegisterFile,
   cancelValidation: cancelRegisterValidation,
   stop: stopRegisterHeaderActions
@@ -408,7 +409,7 @@ function getGenericTemplateHeaders() {
           tooltip-text="Выгрузить XML накладные для реестра (без акциза)"
           :iconSize="'2x'"
           variant="green"
-          @click="exportRegisterXml"
+          @click="exportRegisterXmlWithoutExcise"
           :disabled="generalActionsDisabled"
         />
         <ActionButton
@@ -417,7 +418,7 @@ function getGenericTemplateHeaders() {
           tooltip-text="Выгрузить XML накладные для реестра (акциз)"
           :iconSize="'2x'"
           variant="orange"
-          @click="exportRegisterXml"
+          @click="exportRegisterXmlExcise"
           :disabled="generalActionsDisabled"
         />
         <ActionButton

--- a/tests/Parcels_HeaderActions.spec.js
+++ b/tests/Parcels_HeaderActions.spec.js
@@ -23,6 +23,8 @@ function createRegisterHeaderActionsMock() {
     validateRegisterFc: vi.fn(),
     lookupFeacnCodes: vi.fn(),
     exportAllXml: vi.fn(),
+    exportAllXmlWithoutExcise: vi.fn(),
+    exportAllXmlExcise: vi.fn(),
     downloadRegister: vi.fn(),
     cancelValidation: vi.fn(),
     stop: vi.fn()
@@ -272,10 +274,10 @@ describe.each([
     expect(registerHeaderActionsMock.lookupFeacnCodes).toHaveBeenCalled()
 
     await buttons[3].trigger('click')
-    expect(registerHeaderActionsMock.exportAllXml).toHaveBeenCalled()
+    expect(registerHeaderActionsMock.exportAllXmlWithoutExcise).toHaveBeenCalled()
 
     await buttons[4].trigger('click')
-    expect(registerHeaderActionsMock.exportAllXml).toHaveBeenCalled()
+    expect(registerHeaderActionsMock.exportAllXmlExcise).toHaveBeenCalled()
 
     await buttons[5].trigger('click')
     expect(registerHeaderActionsMock.downloadRegister).toHaveBeenCalled()

--- a/tests/registers.list.helpers.spec.js
+++ b/tests/registers.list.helpers.spec.js
@@ -732,6 +732,8 @@ describe('registers.list.helpers', () => {
 
         registersStore = {
           generate: vi.fn().mockResolvedValue(),
+          generateExcise: vi.fn().mockResolvedValue(),
+          generateWithoutExcise: vi.fn().mockResolvedValue(),
           download: vi.fn().mockResolvedValue(),
           validate: vi.fn().mockResolvedValue({ id: 1 }),
           lookupFeacnCodes: vi.fn().mockResolvedValue({ id: 2 }),
@@ -762,9 +764,15 @@ describe('registers.list.helpers', () => {
         expect(handlers.validationState.handleId).toBe(2)
       })
 
-      it('exports XML and downloads register files', async () => {
+      it('exports XML variants and downloads register files', async () => {
         await handlers.exportAllXml({ id: 3, invoiceNumber: 'INV-3' })
         expect(registersStore.generate).toHaveBeenCalledWith(3, 'INV-3')
+
+        await handlers.exportAllXmlWithoutExcise({ id: 8, invoiceNumber: 'INV-8' })
+        expect(registersStore.generateWithoutExcise).toHaveBeenCalledWith(8, 'INV-8')
+
+        await handlers.exportAllXmlExcise({ id: 9, invoiceNumber: 'INV-9' })
+        expect(registersStore.generateExcise).toHaveBeenCalledWith(9, 'INV-9')
 
         await handlers.downloadRegister({ id: 4, fileName: 'file.xlsx' })
         expect(registersStore.download).toHaveBeenCalledWith(4, 'file.xlsx')


### PR DESCRIPTION
## Summary
- route Ozon and WBR parcel header export buttons to the appropriate register store generators
- expose excise-specific export helpers through register header actions and cover them with updated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2ff684f4c8321bc8d92939a35c4d5