### PR TITLE
Add operation spinner dialog for register actions

### DIFF
--- a/src/components/RegisterActionsDialogs.vue
+++ b/src/components/RegisterActionsDialogs.vue
@@ -1,0 +1,49 @@
+<script setup>
+import { computed, unref } from 'vue'
+
+const props = defineProps({
+  validationState: { type: Object, required: true },
+  progressPercent: { type: [Number, Object], required: true },
+  cancelValidation: { type: Function, required: true },
+  actionDialog: { type: Object, required: true }
+})
+
+const validationTitle = computed(() =>
+  props.validationState?.operation === 'lookup-feacn-codes'
+    ? 'Подбор кодов ТН ВЭД'
+    : 'Проверка реестра'
+)
+
+const progressValue = computed(() => unref(props.progressPercent) ?? 0)
+
+const actionDialogTitle = computed(() => props.actionDialog?.title ?? 'Пожалуйста, подождите')
+</script>
+
+<template>
+  <v-dialog v-model="validationState.show" width="300">
+    <v-card>
+      <v-card-title class="primary-heading">
+        {{ validationTitle }}
+      </v-card-title>
+      <v-card-text class="text-center">
+        <v-progress-circular :model-value="progressValue" :size="70" :width="7" color="primary">
+          {{ progressValue }}%
+        </v-progress-circular>
+      </v-card-text>
+      <v-card-actions class="justify-end">
+        <v-btn variant="text" @click="cancelValidation">Отменить</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+
+  <v-dialog v-model="actionDialog.show" width="300">
+    <v-card>
+      <v-card-title class="primary-heading">
+        {{ actionDialogTitle }}
+      </v-card-title>
+      <v-card-text class="text-center">
+        <v-progress-circular :model-value="0" indeterminate :size="70" :width="7" color="primary" />
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>

--- a/src/lists/OzonParcels_List.vue
+++ b/src/lists/OzonParcels_List.vue
@@ -39,6 +39,7 @@ import ActionButton from '@/components/ActionButton.vue'
 import FeacnCodeSelector from '@/components/FeacnCodeSelector.vue'
 import FeacnCodeCurrent from '@/components/FeacnCodeCurrent.vue'
 import ParcelNumberExt from '@/components/ParcelNumberExt.vue'
+import RegisterActionsDialogs from '@/components/RegisterActionsDialogs.vue'
 
 const props = defineProps({
   registerId: { type: Number, required: true }
@@ -173,6 +174,7 @@ provide('loadOrders', loadOrdersWrapper)
 const {
   validationState,
   progressPercent,
+  actionDialog: actionDialogState,
   generalActionsDisabled,
   validateRegisterSw: validateRegisterSwHeader,
   validateRegisterFc: validateRegisterFcHeader,
@@ -674,21 +676,12 @@ function getGenericTemplateHeaders() {
       {{ alert.message }}
     </div>
 
-    <v-dialog v-model="validationState.show" width="300">
-      <v-card>
-        <v-card-title class="primary-heading">
-          {{ validationState.operation === 'lookup-feacn-codes' ? 'Подбор кодов ТН ВЭД' : 'Проверка реестра' }}
-        </v-card-title>
-        <v-card-text class="text-center">
-          <v-progress-circular :model-value="progressPercent" :size="70" :width="7" color="primary">
-            {{ progressPercent }}%
-          </v-progress-circular>
-        </v-card-text>
-        <v-card-actions class="justify-end">
-          <v-btn variant="text" @click="cancelRegisterValidation">Отменить</v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
+    <RegisterActionsDialogs
+      :validation-state="validationState"
+      :progress-percent="progressPercent"
+      :cancel-validation="cancelRegisterValidation"
+      :action-dialog="actionDialogState"
+    />
   </div>
 </template>
 

--- a/src/lists/Registers_List.vue
+++ b/src/lists/Registers_List.vue
@@ -12,6 +12,7 @@ import {
   isBulkStatusEditMode,
   getBulkStatusSelectedId,
   setBulkStatusSelectedId,
+  createRegisterActionHandlers
 } from '@/helpers/registers.list.helpers.js'
 
 import { useRegistersStore } from '@/stores/registers.store.js'
@@ -55,6 +56,12 @@ const customsProceduresStore = useCustomsProceduresStore()
 const alertStore = useAlertStore()
 const { alert } = storeToRefs(alertStore)
 const confirm = useConfirm()
+
+const {
+  validationState,
+  progressPercent,
+  stopPolling
+} = createRegisterActionHandlers(registersStore, alertStore)
 
 const authStore = useAuthStore()
 const { registers_per_page, registers_search, registers_sort_by, registers_page, isAdmin, isAdminOrSrLogist } = storeToRefs(authStore)
@@ -165,6 +172,7 @@ onUnmounted(() => {
   if (watcherStop) {
     watcherStop()
   }
+  stopPolling()
 })
 
 function openFileDialog() {
@@ -280,6 +288,11 @@ const headers = [
   { title: 'Товаров/Посылок', key: 'parcelsTotal', align: 'center' },
   { title: 'Дата загрузки', key: 'date', align: 'center' }
 ]
+
+defineExpose({
+  validationState,
+  progressPercent
+})
 
 </script>
 

--- a/src/lists/WbrParcels_List.vue
+++ b/src/lists/WbrParcels_List.vue
@@ -39,6 +39,7 @@ import ActionButton from '@/components/ActionButton.vue'
 import FeacnCodeSelector from '@/components/FeacnCodeSelector.vue'
 import FeacnCodeCurrent from '@/components/FeacnCodeCurrent.vue'
 import ParcelNumberExt from '@/components/ParcelNumberExt.vue'
+import RegisterActionsDialogs from '@/components/RegisterActionsDialogs.vue'
 
 const props = defineProps({
   registerId: { type: Number, required: true }
@@ -174,6 +175,7 @@ provide('loadOrders', loadOrdersWrapper)
 const {
   validationState,
   progressPercent,
+  actionDialog: actionDialogState,
   generalActionsDisabled,
   validateRegisterSw: validateRegisterSwHeader,
   validateRegisterFc: validateRegisterFcHeader,
@@ -682,21 +684,12 @@ function getGenericTemplateHeaders() {
       {{ alert.message }}
     </div>
 
-    <v-dialog v-model="validationState.show" width="300">
-      <v-card>
-        <v-card-title class="primary-heading">
-          {{ validationState.operation === 'lookup-feacn-codes' ? 'Подбор кодов ТН ВЭД' : 'Проверка реестра' }}
-        </v-card-title>
-        <v-card-text class="text-center">
-          <v-progress-circular :model-value="progressPercent" :size="70" :width="7" color="primary">
-            {{ progressPercent }}%
-          </v-progress-circular>
-        </v-card-text>
-        <v-card-actions class="justify-end">
-          <v-btn variant="text" @click="cancelRegisterValidation">Отменить</v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
+    <RegisterActionsDialogs
+      :validation-state="validationState"
+      :progress-percent="progressPercent"
+      :cancel-validation="cancelRegisterValidation"
+      :action-dialog="actionDialogState"
+    />
 
   </div>
 </template>

--- a/tests/Parcels_HeaderActions.spec.js
+++ b/tests/Parcels_HeaderActions.spec.js
@@ -18,6 +18,7 @@ function createRegisterHeaderActionsMock() {
   return {
     validationState: reactive({ show: false, operation: null, total: 0, processed: 0 }),
     progressPercent: ref(0),
+    actionDialog: reactive({ show: false, title: '' }),
     generalActionsDisabled: ref(false),
     validateRegisterSw: vi.fn(),
     validateRegisterFc: vi.fn(),

--- a/tests/register.header.actions.spec.js
+++ b/tests/register.header.actions.spec.js
@@ -1,0 +1,114 @@
+/* @vitest-environment jsdom */
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref, reactive } from 'vue'
+import { useRegisterHeaderActions } from '@/helpers/register.header.actions.js'
+
+function createDeferred() {
+  let resolve
+  let reject
+  const promise = new Promise((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, resolve, reject }
+}
+
+describe('useRegisterHeaderActions', () => {
+  let registersStore
+  let alertStore
+  let runningAction
+  let tableLoading
+  let registerLoading
+  let loadOrders
+  let isComponentMounted
+
+  beforeEach(() => {
+    registersStore = {
+      item: reactive({
+        id: 1,
+        invoiceNumber: 'INV-1',
+        fileName: 'register.xlsx',
+        loading: false,
+        error: null
+      }),
+      validate: vi.fn(),
+      getValidationProgress: vi.fn(),
+      cancelValidation: vi.fn(),
+      lookupFeacnCodes: vi.fn(),
+      getLookupFeacnCodesProgress: vi.fn(),
+      cancelLookupFeacnCodes: vi.fn(),
+      generate: vi.fn().mockResolvedValue(),
+      generateWithoutExcise: vi.fn().mockResolvedValue(),
+      generateExcise: vi.fn().mockResolvedValue(),
+      download: vi.fn().mockResolvedValue(),
+      getAll: vi.fn().mockResolvedValue()
+    }
+
+    alertStore = { error: vi.fn() }
+    runningAction = ref(false)
+    tableLoading = ref(false)
+    registerLoading = ref(false)
+    loadOrders = vi.fn().mockResolvedValue()
+    isComponentMounted = ref(true)
+  })
+
+  it('shows action dialog while export without excise runs', async () => {
+    const deferred = createDeferred()
+    registersStore.generateWithoutExcise.mockReturnValueOnce(deferred.promise)
+
+    const actions = useRegisterHeaderActions({
+      registersStore,
+      alertStore,
+      runningAction,
+      tableLoading,
+      registerLoading,
+      loadOrders,
+      isComponentMounted
+    })
+
+    const { actionDialog, exportAllXmlWithoutExcise } = actions
+
+    const promise = exportAllXmlWithoutExcise()
+
+    expect(actionDialog.show).toBe(true)
+    expect(actionDialog.title).toBe('Подготовка XML накладных (без акциза)')
+    expect(registersStore.generateWithoutExcise).toHaveBeenCalledWith(1, 'INV-1')
+
+    deferred.resolve()
+    await promise
+
+    expect(actionDialog.show).toBe(false)
+    expect(actionDialog.title).toBe('')
+  })
+
+  it('hides action dialog when download fails', async () => {
+    const error = new Error('Download failed')
+    registersStore.download.mockRejectedValueOnce(error)
+
+    const actions = useRegisterHeaderActions({
+      registersStore,
+      alertStore,
+      runningAction,
+      tableLoading,
+      registerLoading,
+      loadOrders,
+      isComponentMounted
+    })
+
+    const { actionDialog, downloadRegister } = actions
+
+    const promise = downloadRegister()
+
+    expect(actionDialog.show).toBe(true)
+
+    await expect(promise).rejects.toThrow(error)
+
+    expect(actionDialog.show).toBe(false)
+    expect(actionDialog.title).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
- add a reusable RegisterActionsDialogs component that can show validation progress or a spinner-only dialog for long running register actions
- update OzonParcels_List and WbrParcels_List to use the shared dialog and surface actionDialog state returned by useRegisterHeaderActions
- extend useRegisterHeaderActions with spinner handling for export/download actions and wire Registers_List into createRegisterActionHandlers, adding targeted tests for the new behaviour

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d3d8e230f08321b57b290ef56c8843