### PR TITLE
Display exchange rates in app bar and update status store

### DIFF
--- a/src/stores/status.store.js
+++ b/src/stores/status.store.js
@@ -12,14 +12,17 @@ const baseUrl = `${apiUrl}/status`
 export const useStatusStore = defineStore('status', () => {
   const coreVersion = ref('')
   const dbVersion = ref('')
+  const exchangeRates = ref([])
 
   async function fetchStatus() {
     coreVersion.value = undefined
     dbVersion.value = undefined
+    exchangeRates.value = []
     const res = await fetchWrapper.get(`${baseUrl}/status`)
     coreVersion.value = res.appVersion
     dbVersion.value = res.dbVersion
+    exchangeRates.value = Array.isArray(res.exchangeRates) ? res.exchangeRates : []
   }
 
-  return { coreVersion, dbVersion, fetchStatus }
+  return { coreVersion, dbVersion, exchangeRates, fetchStatus }
 })

--- a/tests/App.exchangeRates.spec.js
+++ b/tests/App.exchangeRates.spec.js
@@ -1,0 +1,112 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createRouter, createWebHistory } from 'vue-router'
+import { createPinia, setActivePinia } from 'pinia'
+import App from '@/App.vue'
+import { useStatusStore } from '@/stores/status.store.js'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+
+// Mock ResizeObserver
+if (!global.ResizeObserver) {
+  global.ResizeObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }))
+}
+
+// Mock Vuetify display composable
+vi.mock('vuetify', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useDisplay: () => ({
+      height: { value: 600 },
+    }),
+  }
+})
+
+const vuetify = createVuetify({
+  components,
+  directives,
+})
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: '/', component: { template: '<div>Home</div>' } },
+    { path: '/login', component: { template: '<div>Login</div>' } },
+  ],
+})
+
+describe('App exchange rates display', () => {
+  let statusStore
+
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    statusStore = useStatusStore()
+    statusStore.fetchStatus = vi.fn().mockResolvedValue({})
+
+    await router.push('/')
+    await router.isReady()
+  })
+
+  function mountApp() {
+    return mount(App, {
+      global: {
+        plugins: [router, vuetify],
+        stubs: {
+          RouterView: true,
+          'v-app': { template: '<div class="v-app"><slot /></div>' },
+          'v-app-bar': { template: '<div class="v-app-bar"><slot name="prepend" /><slot /></div>' },
+          'v-app-bar-nav-icon': { template: '<button class="nav-icon" />' },
+          'v-app-bar-title': { template: '<div class="primary-heading"><slot /></div>' },
+          'v-spacer': { template: '<div class="spacer" />' },
+          'v-navigation-drawer': {
+            template: '<div class="nav-drawer"><slot name="prepend" /><slot /><slot name="append" /></div>',
+          },
+          'v-list': { template: '<ul><slot /></ul>' },
+          'v-list-item': { template: '<li><slot /></li>' },
+          'v-list-group': { template: '<div class="list-group"><slot name="activator" :props="{}" /><slot /></div>' },
+          'v-main': { template: '<main><slot /></main>' },
+        },
+      },
+    })
+  }
+
+  it('displays USD and EUR exchange rates when available', async () => {
+    statusStore.exchangeRates = [
+      { currencyCode: 'USD', rate: 92.1234, rateDate: '2024-06-29T00:00:00.000Z' },
+      { currencyCode: 'EUR', rate: 101.9876, rateDate: '2024-06-30T00:00:00.000Z' },
+    ]
+
+    const wrapper = mountApp()
+    await wrapper.vm.$nextTick()
+
+    const rateItems = wrapper.findAll('.exchange-rates span')
+    expect(rateItems).toHaveLength(2)
+    expect(rateItems[0].text()).toBe('29.06.2024 USD/RUB 92,1234')
+    expect(rateItems[1].text()).toBe('30.06.2024 EUR/RUB 101,9876')
+  })
+
+  it('renders only available exchange rates', async () => {
+    statusStore.exchangeRates = [
+      { currencyCode: 'USD', rate: 95.5, rateDate: '2024-07-01' },
+    ]
+
+    const wrapper = mountApp()
+    await wrapper.vm.$nextTick()
+
+    const rateItems = wrapper.findAll('.exchange-rates span')
+    expect(rateItems).toHaveLength(1)
+    expect(rateItems[0].text()).toBe('01.07.2024 USD/RUB 95,50')
+    expect(wrapper.text()).not.toContain('EUR/RUB')
+  })
+})

--- a/tests/status.store.spec.js
+++ b/tests/status.store.spec.js
@@ -24,10 +24,14 @@ describe('status store', () => {
     vi.clearAllMocks()
   })
 
-  it('fetchStatus sets versions from API', async () => {
+  it('fetchStatus sets versions and exchange rates from API', async () => {
     fetchWrapper.get.mockResolvedValue({
       appVersion: '1.2.3',
-      dbVersion: '20240624'
+      dbVersion: '20240624',
+      exchangeRates: [
+        { currencyCode: 'USD', rate: 92.12, rateDate: '2024-06-24' },
+        { currencyCode: 'EUR', rate: 101.98, rateDate: '2024-06-24' },
+      ],
     })
 
     const store = useStatusStore()
@@ -38,5 +42,25 @@ describe('status store', () => {
     )
     expect(store.coreVersion).toBe('1.2.3')
     expect(store.dbVersion).toBe('20240624')
+    expect(store.exchangeRates).toEqual([
+      { currencyCode: 'USD', rate: 92.12, rateDate: '2024-06-24' },
+      { currencyCode: 'EUR', rate: 101.98, rateDate: '2024-06-24' },
+    ])
+  })
+
+  it('fetchStatus resets exchange rates when API does not return them', async () => {
+    fetchWrapper.get.mockResolvedValue({
+      appVersion: '2.0.0',
+      dbVersion: '20240630',
+    })
+
+    const store = useStatusStore()
+    store.exchangeRates = [
+      { currencyCode: 'USD', rate: 91.1, rateDate: '2024-06-01' },
+    ]
+
+    await store.fetchStatus()
+
+    expect(store.exchangeRates).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- extend the status store to persist backend exchange rates alongside version info
- render USD and EUR rates in the app bar using Russian locale formatting when available
- add unit coverage for the store and the new exchange-rate UI output

## Testing
- npm run test
- npx vitest run tests/App.exchangeRates.spec.js tests/status.store.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68dba17d8434832186c0bce363f5c751