### PR TITLE
Remove notifications unread count and mark-as-read

### DIFF
--- a/src/stores/airports.store.js
+++ b/src/stores/airports.store.js
@@ -1,0 +1,105 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/airports`
+
+export const useAirportsStore = defineStore('airports', () => {
+  const airports = ref([])
+  const airport = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function getAll() {
+    loading.value = true
+    error.value = null
+    try {
+      airports.value = await fetchWrapper.get(baseUrl)
+    } catch (err) {
+      error.value = err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getById(id) {
+    airport.value = { loading: true }
+    loading.value = true
+    error.value = null
+    try {
+      airport.value = await fetchWrapper.get(`${baseUrl}/${id}`)
+      return airport.value
+    } catch (err) {
+      error.value = err
+      airport.value = { error: err }
+      return null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function create(airportData) {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await fetchWrapper.post(baseUrl, airportData)
+      airports.value.push(result)
+      return result
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function update(id, airportData) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.put(`${baseUrl}/${id}`, airportData)
+      const index = airports.value.findIndex(a => a.id === id)
+      if (index !== -1) {
+        airports.value[index] = { ...airports.value[index], ...airportData }
+      }
+      return true
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function remove(id) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.delete(`${baseUrl}/${id}`)
+      airports.value = airports.value.filter(a => a.id !== id)
+      return true
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    airports,
+    airport,
+    loading,
+    error,
+    getAll,
+    getById,
+    create,
+    update,
+    remove
+  }
+})

--- a/src/stores/notifications.store.js
+++ b/src/stores/notifications.store.js
@@ -1,0 +1,105 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/notifications`
+
+export const useNotificationsStore = defineStore('notifications', () => {
+  const notifications = ref([])
+  const notification = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function getAll() {
+    loading.value = true
+    error.value = null
+    try {
+      notifications.value = await fetchWrapper.get(baseUrl)
+    } catch (err) {
+      error.value = err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getById(id) {
+    notification.value = { loading: true }
+    loading.value = true
+    error.value = null
+    try {
+      notification.value = await fetchWrapper.get(`${baseUrl}/${id}`)
+      return notification.value
+    } catch (err) {
+      error.value = err
+      notification.value = { error: err }
+      return null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function create(notificationData) {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await fetchWrapper.post(baseUrl, notificationData)
+      notifications.value.push(result)
+      return result
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function update(id, notificationData) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.put(`${baseUrl}/${id}`, notificationData)
+      const index = notifications.value.findIndex(n => n.id === id)
+      if (index !== -1) {
+        notifications.value[index] = { ...notifications.value[index], ...notificationData }
+      }
+      return true
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function remove(id) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.delete(`${baseUrl}/${id}`)
+      notifications.value = notifications.value.filter(n => n.id !== id)
+      return true
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    notifications,
+    notification,
+    loading,
+    error,
+    getAll,
+    getById,
+    create,
+    update,
+    remove
+  }
+})

--- a/tests/airports.store.spec.js
+++ b/tests/airports.store.spec.js
@@ -1,0 +1,194 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAirportsStore } from '@/stores/airports.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn()
+  }
+}))
+
+vi.mock('@/helpers/config.js', () => ({
+  apiUrl: 'http://localhost:8080/api'
+}))
+
+const mockAirports = [
+  {
+    id: 1,
+    iata: 'SVO',
+    icao: 'UUEE',
+    name: 'Sheremetyevo International Airport',
+    country: 'Russia'
+  },
+  {
+    id: 2,
+    iata: 'DME',
+    icao: 'UUDD',
+    name: 'Domodedovo International Airport',
+    country: 'Russia'
+  }
+]
+
+const mockAirport = mockAirports[0]
+
+describe('airports store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('initializes with default values', () => {
+    const store = useAirportsStore()
+    expect(store.airports).toEqual([])
+    expect(store.airport).toBeNull()
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  describe('getAll', () => {
+    it('fetches airports successfully', async () => {
+      fetchWrapper.get.mockResolvedValue(mockAirports)
+      const store = useAirportsStore()
+
+      await store.getAll()
+
+      expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/airports`)
+      expect(store.airports).toEqual(mockAirports)
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('handles fetch error', async () => {
+      const error = new Error('Network error')
+      fetchWrapper.get.mockRejectedValue(error)
+      const store = useAirportsStore()
+
+      await store.getAll()
+
+      expect(store.airports).toEqual([])
+      expect(store.loading).toBe(false)
+      expect(store.error).toBe(error)
+    })
+  })
+
+  describe('getById', () => {
+    it('fetches airport by id successfully', async () => {
+      fetchWrapper.get.mockResolvedValue(mockAirport)
+      const store = useAirportsStore()
+
+      const result = await store.getById(1)
+
+      expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/airports/1`)
+      expect(store.airport).toEqual(mockAirport)
+      expect(result).toEqual(mockAirport)
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('handles fetch error and returns null', async () => {
+      const error = new Error('Not found')
+      fetchWrapper.get.mockRejectedValue(error)
+      const store = useAirportsStore()
+
+      const result = await store.getById(999)
+
+      expect(result).toBeNull()
+      expect(store.loading).toBe(false)
+      expect(store.error).toBe(error)
+    })
+  })
+
+  describe('create', () => {
+    it('creates airport successfully', async () => {
+      const newAirport = { ...mockAirport, id: 3 }
+      fetchWrapper.post.mockResolvedValue(newAirport)
+      const store = useAirportsStore()
+      store.airports = [...mockAirports]
+
+      const result = await store.create(mockAirport)
+
+      expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/airports`, mockAirport)
+      expect(store.airports).toHaveLength(3)
+      expect(store.airports[2]).toEqual(newAirport)
+      expect(result).toEqual(newAirport)
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('handles create error', async () => {
+      const error = new Error('Conflict')
+      fetchWrapper.post.mockRejectedValue(error)
+      const store = useAirportsStore()
+
+      await expect(store.create(mockAirport)).rejects.toThrow('Conflict')
+
+      expect(store.loading).toBe(false)
+      expect(store.error).toBe(error)
+    })
+  })
+
+  describe('update', () => {
+    it('updates airport successfully', async () => {
+      fetchWrapper.put.mockResolvedValue({})
+      const store = useAirportsStore()
+      store.airports = [...mockAirports]
+
+      const updateData = { name: 'Updated Airport' }
+      const result = await store.update(1, updateData)
+
+      expect(fetchWrapper.put).toHaveBeenCalledWith(`${apiUrl}/airports/1`, updateData)
+      expect(store.airports[0]).toEqual({ ...mockAirports[0], ...updateData })
+      expect(result).toBe(true)
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('handles update error', async () => {
+      const error = new Error('Not found')
+      fetchWrapper.put.mockRejectedValue(error)
+      const store = useAirportsStore()
+
+      await expect(store.update(999, {})).rejects.toThrow('Not found')
+
+      expect(store.loading).toBe(false)
+      expect(store.error).toBe(error)
+    })
+  })
+
+  describe('remove', () => {
+    it('removes airport successfully', async () => {
+      fetchWrapper.delete.mockResolvedValue({})
+      const store = useAirportsStore()
+      store.airports = [...mockAirports]
+
+      const result = await store.remove(1)
+
+      expect(fetchWrapper.delete).toHaveBeenCalledWith(`${apiUrl}/airports/1`)
+      expect(store.airports).not.toContain(mockAirports[0])
+      expect(store.airports.length).toBe(1)
+      expect(result).toBe(true)
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('handles remove error', async () => {
+      const error = new Error('Conflict')
+      fetchWrapper.delete.mockRejectedValue(error)
+      const store = useAirportsStore()
+
+      await expect(store.remove(1)).rejects.toThrow('Conflict')
+
+      expect(store.loading).toBe(false)
+      expect(store.error).toBe(error)
+    })
+  })
+})

--- a/tests/notifications.store.spec.js
+++ b/tests/notifications.store.spec.js
@@ -1,0 +1,195 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useNotificationsStore } from '@/stores/notifications.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn()
+  }
+}))
+
+vi.mock('@/helpers/config.js', () => ({
+  apiUrl: 'http://localhost:8080/api'
+}))
+
+const mockNotifications = [
+  {
+    id: 1,
+    title: 'New parcel registered',
+    message: 'Parcel 12345 has been registered',
+    isRead: false,
+    createdAt: '2024-05-01T10:00:00Z'
+  },
+  {
+    id: 2,
+    title: 'Parcel departed',
+    message: 'Parcel 67890 has departed the warehouse',
+    isRead: true,
+    createdAt: '2024-05-02T12:00:00Z'
+  }
+]
+
+const mockNotification = mockNotifications[0]
+
+describe('notifications store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('initializes with default values', () => {
+    const store = useNotificationsStore()
+    expect(store.notifications).toEqual([])
+    expect(store.notification).toBeNull()
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  describe('getAll', () => {
+    it('fetches notifications successfully', async () => {
+      fetchWrapper.get.mockResolvedValue(mockNotifications)
+      const store = useNotificationsStore()
+
+      await store.getAll()
+
+      expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/notifications`)
+      expect(store.notifications).toEqual(mockNotifications)
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('handles fetch error', async () => {
+      const error = new Error('Network error')
+      fetchWrapper.get.mockRejectedValue(error)
+      const store = useNotificationsStore()
+
+      await store.getAll()
+
+      expect(store.notifications).toEqual([])
+      expect(store.loading).toBe(false)
+      expect(store.error).toBe(error)
+    })
+  })
+
+  describe('getById', () => {
+    it('fetches notification by id successfully', async () => {
+      fetchWrapper.get.mockResolvedValue(mockNotification)
+      const store = useNotificationsStore()
+
+      const result = await store.getById(1)
+
+      expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/notifications/1`)
+      expect(store.notification).toEqual(mockNotification)
+      expect(result).toEqual(mockNotification)
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('handles fetch error and returns null', async () => {
+      const error = new Error('Not found')
+      fetchWrapper.get.mockRejectedValue(error)
+      const store = useNotificationsStore()
+
+      const result = await store.getById(999)
+
+      expect(result).toBeNull()
+      expect(store.loading).toBe(false)
+      expect(store.error).toBe(error)
+    })
+  })
+
+  describe('create', () => {
+    it('creates notification successfully', async () => {
+      const newNotification = { ...mockNotification, id: 3 }
+      fetchWrapper.post.mockResolvedValue(newNotification)
+      const store = useNotificationsStore()
+      store.notifications = [...mockNotifications]
+
+      const result = await store.create(mockNotification)
+
+      expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/notifications`, mockNotification)
+      expect(store.notifications).toHaveLength(3)
+      expect(store.notifications[2]).toEqual(newNotification)
+      expect(result).toEqual(newNotification)
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('handles create error', async () => {
+      const error = new Error('Conflict')
+      fetchWrapper.post.mockRejectedValue(error)
+      const store = useNotificationsStore()
+
+      await expect(store.create(mockNotification)).rejects.toThrow('Conflict')
+
+      expect(store.loading).toBe(false)
+      expect(store.error).toBe(error)
+    })
+  })
+
+  describe('update', () => {
+    it('updates notification successfully', async () => {
+      fetchWrapper.put.mockResolvedValue({})
+      const store = useNotificationsStore()
+      store.notifications = [...mockNotifications]
+
+      const updateData = { title: 'Updated notification', isRead: true }
+      const result = await store.update(1, updateData)
+
+      expect(fetchWrapper.put).toHaveBeenCalledWith(`${apiUrl}/notifications/1`, updateData)
+      expect(store.notifications[0]).toEqual({ ...mockNotifications[0], ...updateData })
+      expect(result).toBe(true)
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('handles update error', async () => {
+      const error = new Error('Not found')
+      fetchWrapper.put.mockRejectedValue(error)
+      const store = useNotificationsStore()
+
+      await expect(store.update(999, {})).rejects.toThrow('Not found')
+
+      expect(store.loading).toBe(false)
+      expect(store.error).toBe(error)
+    })
+  })
+
+  describe('remove', () => {
+    it('removes notification successfully', async () => {
+      fetchWrapper.delete.mockResolvedValue({})
+      const store = useNotificationsStore()
+      store.notifications = [...mockNotifications]
+
+      const result = await store.remove(1)
+
+      expect(fetchWrapper.delete).toHaveBeenCalledWith(`${apiUrl}/notifications/1`)
+      expect(store.notifications).not.toContain(mockNotifications[0])
+      expect(store.notifications.length).toBe(1)
+      expect(result).toBe(true)
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('handles remove error', async () => {
+      const error = new Error('Conflict')
+      fetchWrapper.delete.mockRejectedValue(error)
+      const store = useNotificationsStore()
+
+      await expect(store.remove(1)).rejects.toThrow('Conflict')
+
+      expect(store.loading).toBe(false)
+      expect(store.error).toBe(error)
+    })
+  })
+
+})


### PR DESCRIPTION
## Summary
- remove the unread count computed property and mark-as-read helper from the notifications store
- update the notifications store unit tests to match the revised API surface

## Testing
- npm run test -- tests/notifications.store.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68e214ad7b2c8321af58c1bcc8df60c3