### PR TITLE
Add airports management views and tests

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -134,14 +134,17 @@ function getUserName() {
             <RouterLink to="/keywords" class="link">Подбор ТН ВЭД</RouterLink>
           </v-list-item>
           <v-list-item>
-            <RouterLink to="/feacn/insertitems" class="link">До и После</RouterLink>
-          </v-list-item>
-          <v-list-item>
-            <RouterLink to="/companies" class="link">Компании</RouterLink>
-          </v-list-item>
-          <v-list-item>
-            <RouterLink to="/parcelstatuses" class="link">Статусы посылок</RouterLink>
-          </v-list-item>
+          <RouterLink to="/feacn/insertitems" class="link">До и После</RouterLink>
+        </v-list-item>
+        <v-list-item>
+          <RouterLink to="/companies" class="link">Компании</RouterLink>
+        </v-list-item>
+        <v-list-item>
+          <RouterLink to="/airports" class="link">Аэропорты</RouterLink>
+        </v-list-item>
+        <v-list-item>
+          <RouterLink to="/parcelstatuses" class="link">Статусы посылок</RouterLink>
+        </v-list-item>
           <v-list-item>
             <RouterLink to="/stopwords" class="link">Стоп-слова</RouterLink>
           </v-list-item>

--- a/src/dialogs/Airport_Settings.vue
+++ b/src/dialogs/Airport_Settings.vue
@@ -1,0 +1,164 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { ref, computed } from 'vue'
+import router from '@/router'
+import { storeToRefs } from 'pinia'
+import { Form, Field } from 'vee-validate'
+import * as Yup from 'yup'
+import { useAirportsStore } from '@/stores/airports.store.js'
+
+const props = defineProps({
+  mode: {
+    type: String,
+    required: true,
+    validator: (value) => ['create', 'edit'].includes(value)
+  },
+  airportId: {
+    type: Number,
+    required: false
+  }
+})
+
+const airportsStore = useAirportsStore()
+
+const isCreate = computed(() => props.mode === 'create')
+
+let airport = ref({
+  iata: '',
+  icao: '',
+  name: '',
+  country: ''
+})
+
+if (!isCreate.value) {
+  ;({ airport } = storeToRefs(airportsStore))
+  await airportsStore.getById(props.airportId)
+}
+
+function getTitle() {
+  return isCreate.value ? 'Регистрация аэропорта' : 'Изменить информацию об аэропорте'
+}
+
+function getButtonText() {
+  return isCreate.value ? 'Создать' : 'Сохранить'
+}
+
+const schema = Yup.object({
+  iata: Yup.string().required('IATA код обязателен'),
+  icao: Yup.string(),
+  name: Yup.string().required('Название обязательно'),
+  country: Yup.string().required('Страна обязательна')
+})
+
+function onSubmit(values, { setErrors }) {
+  if (isCreate.value) {
+    return airportsStore
+      .create(values)
+      .then(() => {
+        router.push('/airports')
+      })
+      .catch((error) => {
+        if (error.message?.includes('409')) {
+          setErrors({ apiError: 'Аэропорт с таким IATA кодом уже существует' })
+        } else {
+          setErrors({ apiError: error.message || 'Ошибка при регистрации аэропорта' })
+        }
+      })
+  }
+
+  return airportsStore
+    .update(props.airportId, values)
+    .then(() => {
+      router.push('/airports')
+    })
+    .catch((error) => {
+      setErrors({ apiError: error.message || 'Ошибка при сохранении информации об аэропорте' })
+    })
+}
+</script>
+
+<template>
+  <div class="settings form-2">
+    <h1 class="primary-heading">{{ getTitle() }}</h1>
+    <hr class="hr" />
+    <Form
+      @submit="onSubmit"
+      :initial-values="airport"
+      :validation-schema="schema"
+      v-slot="{ errors, isSubmitting }"
+    >
+      <div class="form-group">
+        <label for="iata" class="label">IATA:</label>
+        <Field
+          name="iata"
+          id="iata"
+          type="text"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.iata }"
+          placeholder="IATA код"
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="icao" class="label">ICAO:</label>
+        <Field
+          name="icao"
+          id="icao"
+          type="text"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.icao }"
+          placeholder="ICAO код"
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="name" class="label">Название:</label>
+        <Field
+          name="name"
+          id="name"
+          type="text"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.name }"
+          placeholder="Название аэропорта"
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="country" class="label">Страна:</label>
+        <Field
+          name="country"
+          id="country"
+          type="text"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.country }"
+          placeholder="Страна"
+        />
+      </div>
+
+      <div class="form-group mt-8">
+        <button class="button primary" type="submit" :disabled="isSubmitting">
+          <span v-show="isSubmitting" class="spinner-border spinner-border-sm mr-1"></span>
+          <font-awesome-icon size="1x" icon="fa-solid fa-check-double" class="mr-1" />
+          {{ getButtonText() }}
+        </button>
+        <button
+          class="button secondary"
+          type="button"
+          @click="$router.push('/airports')"
+        >
+          <font-awesome-icon size="1x" icon="fa-solid fa-xmark" class="mr-1" />
+          Отменить
+        </button>
+      </div>
+
+      <div v-if="errors.iata" class="alert alert-danger mt-3 mb-0">{{ errors.iata }}</div>
+      <div v-if="errors.icao" class="alert alert-danger mt-3 mb-0">{{ errors.icao }}</div>
+      <div v-if="errors.name" class="alert alert-danger mt-3 mb-0">{{ errors.name }}</div>
+      <div v-if="errors.country" class="alert alert-danger mt-3 mb-0">{{ errors.country }}</div>
+      <div v-if="errors.apiError" class="alert alert-danger mt-3 mb-0">{{ errors.apiError }}</div>
+    </Form>
+  </div>
+</template>

--- a/src/lists/Airports_List.vue
+++ b/src/lists/Airports_List.vue
@@ -1,0 +1,181 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { onMounted, ref } from 'vue'
+import router from '@/router'
+import { storeToRefs } from 'pinia'
+import { useAirportsStore } from '@/stores/airports.store.js'
+import { useAuthStore } from '@/stores/auth.store.js'
+import { useAlertStore } from '@/stores/alert.store.js'
+import ActionButton from '@/components/ActionButton.vue'
+import { useConfirm } from 'vuetify-use-dialog'
+import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
+import { mdiMagnify } from '@mdi/js'
+
+const airportsStore = useAirportsStore()
+const authStore = useAuthStore()
+const alertStore = useAlertStore()
+const confirm = useConfirm()
+
+const { airports, loading } = storeToRefs(airportsStore)
+const { alert } = storeToRefs(alertStore)
+
+const runningAction = ref(false)
+
+function filterAirports(value, query, item) {
+  if (query === null || item === null) {
+    return false
+  }
+  const airport = item.raw
+  if (airport === null) {
+    return false
+  }
+
+  const q = query.toLocaleUpperCase()
+
+  return [airport.name, airport.iata, airport.icao, airport.country]
+    .filter(Boolean)
+    .some((field) => field.toLocaleUpperCase().includes(q))
+}
+
+const headers = [
+  ...(authStore.isAdminOrSrLogist
+    ? [{ title: '', align: 'center', key: 'actions', sortable: false, width: '120px' }]
+    : []),
+  { title: 'Название', key: 'name', sortable: true },
+  { title: 'IATA', key: 'iata', sortable: true },
+  { title: 'ICAO', key: 'icao', sortable: true },
+  { title: 'Страна', key: 'country', sortable: true }
+]
+
+function openEditDialog(airport) {
+  router.push(`/airport/edit/${airport.id}`)
+}
+
+function openCreateDialog() {
+  router.push('/airport/create')
+}
+
+async function deleteAirport(airport) {
+  if (runningAction.value) return
+  runningAction.value = true
+  try {
+    const confirmed = await confirm({
+      title: 'Подтверждение',
+      confirmationText: 'Удалить',
+      cancellationText: 'Не удалять',
+      dialogProps: {
+        width: '30%',
+        minWidth: '250px'
+      },
+      confirmationButtonProps: {
+        color: 'orange-darken-3'
+      },
+      content: `Удалить аэропорт "${airport.name}"?`
+    })
+
+    if (confirmed) {
+      try {
+        await airportsStore.remove(airport.id)
+      } catch (error) {
+        if (error.message?.includes('409')) {
+          alertStore.error('Нельзя удалить аэропорт, у которого есть связанные записи')
+        } else {
+          alertStore.error('Ошибка при удалении аэропорта')
+        }
+      }
+    }
+  } finally {
+    runningAction.value = false
+  }
+}
+
+onMounted(async () => {
+  await airportsStore.getAll()
+})
+
+defineExpose({
+  openCreateDialog,
+  openEditDialog,
+  deleteAirport
+})
+</script>
+
+<template>
+  <div class="settings table-2">
+    <h1 class="primary-heading">Аэропорты</h1>
+    <hr class="hr" />
+
+    <div class="link-crt" v-if="authStore.isAdminOrSrLogist">
+      <router-link to="/airport/create" class="link">
+        <font-awesome-icon
+          size="1x"
+          icon="fa-solid fa-plane"
+          class="link"
+        />&nbsp;&nbsp;&nbsp;Добавить аэропорт
+      </router-link>
+    </div>
+
+    <div v-if="airports?.length">
+      <v-text-field
+        v-model="authStore.airports_search"
+        :append-inner-icon="mdiMagnify"
+        label="Поиск по любой информации об аэропорте"
+        variant="solo"
+        hide-details
+      />
+    </div>
+
+    <v-card>
+      <v-data-table
+        v-if="airports?.length"
+        v-model:items-per-page="authStore.airports_per_page"
+        items-per-page-text="Аэропортов на странице"
+        :items-per-page-options="itemsPerPageOptions"
+        page-text="{0}-{1} из {2}"
+        v-model:page="authStore.airports_page"
+        :headers="headers"
+        :items="airports"
+        :search="authStore.airports_search"
+        v-model:sort-by="authStore.airports_sort_by"
+        :custom-filter="filterAirports"
+        :loading="loading"
+        item-value="name"
+        density="compact"
+        class="elevation-1 interlaced-table"
+      >
+        <template v-slot:[`item.actions`]="{ item }">
+          <div v-if="authStore.isAdminOrSrLogist" class="actions-container">
+            <ActionButton
+              :item="item"
+              icon="fa-solid fa-pen"
+              tooltip-text="Редактировать аэропорт"
+              @click="openEditDialog"
+              :disabled="runningAction || loading"
+            />
+            <ActionButton
+              :item="item"
+              icon="fa-solid fa-trash-can"
+              tooltip-text="Удалить аэропорт"
+              @click="deleteAirport"
+              :disabled="runningAction || loading"
+            />
+          </div>
+        </template>
+      </v-data-table>
+
+      <div v-if="!airports?.length" class="text-center m-5">Список аэропортов пуст</div>
+    </v-card>
+
+    <div v-if="loading" class="text-center m-5">
+      <span class="spinner-border spinner-border-lg align-center"></span>
+    </div>
+
+    <div v-if="alert" class="alert alert-dismissable mt-3 mb-0" :class="alert.type">
+      <button @click="alertStore.clear()" class="btn btn-link close">×</button>
+      {{ alert.message }}
+    </div>
+  </div>
+</template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -56,6 +56,12 @@ const router = createRouter({
       meta: { reqAnyRole: true }
     },
     {
+      path: '/airports',
+      name: 'Аэропорты',
+      component: () => import('@/views/Airports_View.vue'),
+      meta: { reqAnyRole: true }
+    },
+    {
       path: '/company/create',
       name: 'Регистрация компании',
       component: () => import('@/views/Company_CreateView.vue'),
@@ -65,6 +71,21 @@ const router = createRouter({
       path: '/company/edit/:id',
       name: 'Изменить информацию о компании',
       component: () => import('@/views/Company_EditView.vue'),
+      props: (route) => ({
+        id: Number(route.params.id)
+      }),
+      meta: { reqAdminOrSrLogist: true }
+    },
+    {
+      path: '/airport/create',
+      name: 'Регистрация аэропорта',
+      component: () => import('@/views/Airport_CreateView.vue'),
+      meta: { reqAdminOrSrLogist: true }
+    },
+    {
+      path: '/airport/edit/:id',
+      name: 'Изменить информацию об аэропорте',
+      component: () => import('@/views/Airport_EditView.vue'),
       props: (route) => ({
         id: Number(route.params.id)
       }),

--- a/src/stores/auth.store.js
+++ b/src/stores/auth.store.js
@@ -42,6 +42,10 @@ export const useAuthStore = defineStore('auth', () => {
   const companies_search = ref('')
   const companies_sort_by = ref(['id'])
   const companies_page = ref(1)
+  const airports_per_page = ref(10)
+  const airports_search = ref('')
+  const airports_sort_by = ref(['id'])
+  const airports_page = ref(1)
   const registers_per_page = ref(10)
   const registers_search = ref('')
   const registers_sort_by = ref([{ key: 'id', order: 'desc' }])
@@ -176,6 +180,10 @@ export const useAuthStore = defineStore('auth', () => {
     companies_search,
     companies_sort_by,
     companies_page,
+    airports_per_page,
+    airports_search,
+    airports_sort_by,
+    airports_page,
     registers_per_page,
     registers_search,
     registers_sort_by,

--- a/src/views/Airport_CreateView.vue
+++ b/src/views/Airport_CreateView.vue
@@ -1,0 +1,13 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import AirportSettings from '@/dialogs/Airport_Settings.vue'
+</script>
+
+<template>
+  <Suspense>
+    <AirportSettings :mode="'create'" />
+  </Suspense>
+</template>

--- a/src/views/Airport_EditView.vue
+++ b/src/views/Airport_EditView.vue
@@ -1,0 +1,20 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import AirportSettings from '@/dialogs/Airport_Settings.vue'
+
+const props = defineProps({
+  id: {
+    type: Number,
+    required: true
+  }
+})
+</script>
+
+<template>
+  <Suspense>
+    <AirportSettings :mode="'edit'" :airport-id="props.id" />
+  </Suspense>
+</template>

--- a/src/views/Airports_View.vue
+++ b/src/views/Airports_View.vue
@@ -1,0 +1,11 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import Airports from '@/lists/Airports_List.vue'
+</script>
+
+<template>
+  <Airports />
+</template>

--- a/tests/Airport_CreateView.spec.js
+++ b/tests/Airport_CreateView.spec.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import AirportCreateView from '@/views/Airport_CreateView.vue'
+
+vi.mock('@/dialogs/Airport_Settings.vue', () => ({
+  default: {
+    name: 'Airport_Settings',
+    props: ['mode'],
+    template: '<div data-testid="airport-settings">Airport Settings (mode: {{ mode }})</div>'
+  }
+}))
+
+describe('Airport_CreateView.vue', () => {
+  let vuetify
+  let pinia
+
+  beforeEach(() => {
+    vuetify = createVuetify({ components, directives })
+    pinia = createPinia()
+  })
+
+  it('renders Airport_Settings in create mode', () => {
+    const wrapper = mount(AirportCreateView, {
+      global: {
+        plugins: [vuetify, pinia]
+      }
+    })
+
+    const settings = wrapper.find('[data-testid="airport-settings"]')
+    expect(settings.exists()).toBe(true)
+    expect(settings.text()).toContain('mode: create')
+  })
+})

--- a/tests/Airport_EditView.spec.js
+++ b/tests/Airport_EditView.spec.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import AirportEditView from '@/views/Airport_EditView.vue'
+
+vi.mock('@/dialogs/Airport_Settings.vue', () => ({
+  default: {
+    name: 'Airport_Settings',
+    props: ['mode', 'airportId'],
+    template: '<div data-testid="airport-settings">Airport Settings (mode: {{ mode }}, id: {{ airportId }})</div>'
+  }
+}))
+
+describe('Airport_EditView.vue', () => {
+  let vuetify
+  let pinia
+
+  beforeEach(() => {
+    vuetify = createVuetify({ components, directives })
+    pinia = createPinia()
+  })
+
+  it('renders Airport_Settings in edit mode with passed id', () => {
+    const wrapper = mount(AirportEditView, {
+      props: { id: 42 },
+      global: {
+        plugins: [vuetify, pinia]
+      }
+    })
+
+    const settings = wrapper.find('[data-testid="airport-settings"]')
+    expect(settings.exists()).toBe(true)
+    expect(settings.text()).toContain('mode: edit')
+    expect(settings.text()).toContain('id: 42')
+  })
+})

--- a/tests/Airport_Settings.spec.js
+++ b/tests/Airport_Settings.spec.js
@@ -1,0 +1,187 @@
+/* @vitest-environment jsdom */
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { Suspense, ref } from 'vue'
+import AirportSettings from '@/dialogs/Airport_Settings.vue'
+import { defaultGlobalStubs, createMockStore, resolveAll } from './helpers/test-utils.js'
+
+const mockAirportData = {
+  id: 1,
+  iata: 'SVO',
+  icao: 'UUEE',
+  name: 'Sheremetyevo International Airport',
+  country: 'Russia'
+}
+
+const airportRef = ref({ ...mockAirportData })
+
+const mockAirportsStore = createMockStore({
+  airport: airportRef,
+  getById: vi.fn().mockImplementation(async () => mockAirportData),
+  create: vi.fn().mockResolvedValue(mockAirportData),
+  update: vi.fn().mockResolvedValue()
+})
+
+vi.mock('@/stores/airports.store.js', () => ({
+  useAirportsStore: () => mockAirportsStore
+}))
+
+const mockRouter = vi.hoisted(() => ({
+  push: vi.fn()
+}))
+
+vi.mock('@/router', () => ({
+  default: mockRouter
+}))
+
+vi.mock('pinia', () => ({
+  storeToRefs: (store) => {
+    if (store.airport) {
+      return { airport: store.airport }
+    }
+    return {}
+  }
+}))
+
+vi.mock('vee-validate', () => ({
+  Form: {
+    name: 'Form',
+    props: ['initialValues', 'validationSchema'],
+    emits: ['submit'],
+    data() {
+      return {
+        errors: {},
+        isSubmitting: false
+      }
+    },
+    methods: {
+      handleSubmit() {
+        const actions = {
+          setErrors: this.setErrors.bind(this)
+        }
+        this.$emit('submit', this.initialValues || {}, actions)
+      },
+      setErrors(newErrors) {
+        this.errors = { ...this.errors, ...newErrors }
+      }
+    },
+    template: `
+      <form @submit.prevent="handleSubmit">
+        <slot :errors="errors" :isSubmitting="isSubmitting" />
+      </form>
+    `
+  },
+  Field: {
+    name: 'Field',
+    props: ['name', 'id', 'type', 'class', 'placeholder'],
+    template: '<input :name="name" :id="id" :type="type" :placeholder="placeholder" />'
+  }
+}))
+
+const AsyncWrapper = {
+  components: { AirportSettings, Suspense },
+  props: ['mode', 'airportId'],
+  template: `
+    <Suspense>
+      <AirportSettings :mode="mode" :airport-id="airportId" />
+      <template #fallback>
+        <div>Loading...</div>
+      </template>
+    </Suspense>
+  `
+}
+
+beforeEach(async () => {
+  airportRef.value = { ...mockAirportData }
+  vi.clearAllMocks()
+  await import('@/router')
+})
+
+describe('Airport_Settings.vue', () => {
+  it('renders create mode correctly', async () => {
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'create' },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    expect(wrapper.find('h1').text()).toBe('Регистрация аэропорта')
+    expect(wrapper.find('button[type="submit"]').text()).toContain('Создать')
+    expect(mockAirportsStore.getById).not.toHaveBeenCalled()
+  })
+
+  it('renders edit mode correctly', async () => {
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'edit', airportId: 1 },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    expect(mockAirportsStore.getById).toHaveBeenCalledWith(1)
+    expect(wrapper.find('h1').text()).toBe('Изменить информацию об аэропорте')
+    expect(wrapper.find('button[type="submit"]').text()).toContain('Сохранить')
+  })
+
+  it('submits create form successfully', async () => {
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'create' },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    await wrapper.find('form').trigger('submit.prevent')
+    await resolveAll()
+
+    expect(mockAirportsStore.create).toHaveBeenCalled()
+    expect(mockRouter.push).toHaveBeenCalledWith('/airports')
+  })
+
+  it('submits edit form successfully', async () => {
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'edit', airportId: 1 },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    await wrapper.find('form').trigger('submit.prevent')
+    await resolveAll()
+
+    expect(mockAirportsStore.update).toHaveBeenCalledWith(1, expect.any(Object))
+    expect(mockRouter.push).toHaveBeenCalledWith('/airports')
+  })
+
+  it('shows api error message on create conflict', async () => {
+    mockAirportsStore.create.mockRejectedValueOnce(new Error('409 Conflict'))
+
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'create' },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    await wrapper.find('form').trigger('submit.prevent')
+    await resolveAll()
+
+    const alerts = wrapper.findAll('.alert-danger')
+    expect(alerts.at(-1)?.text()).toBe('Аэропорт с таким IATA кодом уже существует')
+  })
+})

--- a/tests/Airports_List.spec.js
+++ b/tests/Airports_List.spec.js
@@ -1,0 +1,170 @@
+/* @vitest-environment jsdom */
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import AirportsList from '@/lists/Airports_List.vue'
+import { defaultGlobalStubs } from './helpers/test-utils.js'
+
+const mockAirports = ref([
+  { id: 1, name: 'Sheremetyevo', iata: 'SVO', icao: 'UUEE', country: 'Russia' },
+  { id: 2, name: 'Domodedovo', iata: 'DME', icao: 'UUDD', country: 'Russia' }
+])
+
+const getAllAirports = vi.hoisted(() => vi.fn().mockResolvedValue())
+const removeAirport = vi.hoisted(() => vi.fn().mockResolvedValue())
+const alertError = vi.hoisted(() => vi.fn())
+const alertClear = vi.hoisted(() => vi.fn())
+const confirmMock = vi.hoisted(() => vi.fn().mockResolvedValue(true))
+const mockPush = vi.hoisted(() => vi.fn())
+
+const loadingRef = ref(false)
+const alertRef = ref(null)
+
+const mockAirportsStore = {
+  airports: mockAirports,
+  loading: loadingRef,
+  getAll: getAllAirports,
+  remove: removeAirport
+}
+
+const mockAlertStore = {
+  alert: alertRef,
+  error: alertError,
+  clear: alertClear
+}
+
+const mockAuthStore = {
+  isAdminOrSrLogist: true,
+  airports_per_page: ref(10),
+  airports_search: ref(''),
+  airports_sort_by: ref(['id']),
+  airports_page: ref(1)
+}
+
+vi.mock('pinia', () => ({
+  storeToRefs: (store) => {
+    if (store === mockAirportsStore) {
+      return { airports: mockAirportsStore.airports, loading: mockAirportsStore.loading }
+    }
+    if (store === mockAlertStore) {
+      return { alert: mockAlertStore.alert }
+    }
+    return {}
+  }
+}))
+
+vi.mock('@/stores/airports.store.js', () => ({
+  useAirportsStore: () => mockAirportsStore
+}))
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => mockAlertStore
+}))
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: () => mockAuthStore
+}))
+
+vi.mock('vuetify-use-dialog', () => ({
+  useConfirm: () => confirmMock
+}))
+
+vi.mock('@/router', () => ({
+  default: { push: mockPush }
+}))
+
+vi.mock('@mdi/js', () => ({
+  mdiMagnify: 'mdi-magnify'
+}))
+
+vi.mock('@/helpers/items.per.page.js', () => ({
+  itemsPerPageOptions: [10, 25, 50]
+}))
+
+vi.mock('@/components/ActionButton.vue', () => ({
+  default: {
+    name: 'ActionButton',
+    props: ['item', 'icon', 'tooltipText', 'disabled'],
+    emits: ['click'],
+    template: '<button data-testid="action-button" @click="$emit(\'click\', item)"></button>'
+  }
+}))
+
+const testStubs = {
+  ...defaultGlobalStubs,
+  'router-link': {
+    template: '<a data-testid="router-link"><slot></slot></a>',
+    props: ['to']
+  }
+}
+
+beforeEach(() => {
+  mockAirports.value = [
+    { id: 1, name: 'Sheremetyevo', iata: 'SVO', icao: 'UUEE', country: 'Russia' },
+    { id: 2, name: 'Domodedovo', iata: 'DME', icao: 'UUDD', country: 'Russia' }
+  ]
+  alertRef.value = null
+  loadingRef.value = false
+  vi.clearAllMocks()
+})
+
+describe('Airports_List.vue', () => {
+  it('calls getAll on mount', async () => {
+    const wrapper = mount(AirportsList, {
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(getAllAirports).toHaveBeenCalled()
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('navigates to create view via exposed method', async () => {
+    const wrapper = mount(AirportsList, {
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    await wrapper.vm.$nextTick()
+
+    wrapper.vm.openCreateDialog()
+    expect(mockPush).toHaveBeenCalledWith('/airport/create')
+  })
+
+  it('deletes airport when confirmed', async () => {
+    const wrapper = mount(AirportsList, {
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    await wrapper.vm.$nextTick()
+
+    await wrapper.vm.deleteAirport(mockAirports.value[0])
+
+    expect(confirmMock).toHaveBeenCalled()
+    expect(removeAirport).toHaveBeenCalledWith(1)
+  })
+
+  it('shows empty list message when no airports available', async () => {
+    mockAirports.value = []
+
+    const wrapper = mount(AirportsList, {
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('Список аэропортов пуст')
+  })
+})

--- a/tests/Airports_View.spec.js
+++ b/tests/Airports_View.spec.js
@@ -1,0 +1,60 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import AirportsView from '@/views/Airports_View.vue'
+
+vi.mock('@/lists/Airports_List.vue', () => ({
+  default: {
+    name: 'Airports_List',
+    template: '<div data-testid="airports-list">Airports List Component</div>'
+  }
+}))
+
+describe('Airports_View.vue', () => {
+  let vuetify
+  let pinia
+
+  beforeEach(() => {
+    vuetify = createVuetify({ components, directives })
+    pinia = createPinia()
+  })
+
+  it('mounts successfully', () => {
+    const wrapper = mount(AirportsView, {
+      global: {
+        plugins: [vuetify, pinia]
+      }
+    })
+
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('renders Airports_List component', () => {
+    const wrapper = mount(AirportsView, {
+      global: {
+        plugins: [vuetify, pinia]
+      }
+    })
+
+    const list = wrapper.find('[data-testid="airports-list"]')
+    expect(list.exists()).toBe(true)
+    expect(list.text()).toBe('Airports List Component')
+  })
+
+  it('wraps Airports_List component correctly', () => {
+    const wrapper = mount(AirportsView, {
+      global: {
+        plugins: [vuetify, pinia]
+      }
+    })
+
+    expect(wrapper.html()).toContain('Airports List Component')
+  })
+})


### PR DESCRIPTION
## Summary
- add Airport_Settings dialog with create and edit flows backed by the airports store
- implement Airports_List with CRUD navigation plus register new routes, navigation link, and auth store preferences
- create airports views and accompanying unit tests mirroring the companies feature set

## Testing
- npx vitest run tests/Airport_Settings.spec.js tests/Airports_List.spec.js tests/Airports_View.spec.js tests/Airport_CreateView.spec.js tests/Airport_EditView.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68e21a5bae7c8321ab5ebd5ab10c983a