### PR TITLE
Add notifications management UI and tests

### DIFF
--- a/src/dialogs/Notification_Settings.vue
+++ b/src/dialogs/Notification_Settings.vue
@@ -1,0 +1,180 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { ref, computed } from 'vue'
+import router from '@/router'
+import { Form, Field } from 'vee-validate'
+import * as Yup from 'yup'
+import { useNotificationsStore } from '@/stores/notifications.store.js'
+
+const props = defineProps({
+  mode: {
+    type: String,
+    required: true,
+    validator: (value) => ['create', 'edit'].includes(value)
+  },
+  notificationId: {
+    type: Number,
+    required: false
+  }
+})
+
+const notificationsStore = useNotificationsStore()
+
+const isCreate = computed(() => props.mode === 'create')
+
+const notificationForm = ref({
+  model: '',
+  number: '',
+  terminationDate: ''
+})
+
+if (!isCreate.value) {
+  const loaded = await notificationsStore.getById(props.notificationId)
+  if (loaded) {
+    notificationForm.value = {
+      model: loaded.model || '',
+      number: loaded.number || '',
+      terminationDate: formatDateForInput(loaded.terminationDate)
+    }
+  } else {
+    router.push('/notifications')
+  }
+}
+
+function formatDateForInput(value) {
+  if (!value) {
+    return ''
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10)
+  }
+
+  if (typeof value === 'string') {
+    if (value.includes('T')) {
+      return value.slice(0, 10)
+    }
+    return value
+  }
+
+  if (typeof value === 'object' && value.year && value.month && value.day) {
+    const month = String(value.month).padStart(2, '0')
+    const day = String(value.day).padStart(2, '0')
+    return `${value.year}-${month}-${day}`
+  }
+
+  return ''
+}
+
+function getTitle() {
+  return isCreate.value ? 'Регистрация нотификации' : 'Изменить информацию о нотификации'
+}
+
+function getButtonText() {
+  return isCreate.value ? 'Создать' : 'Сохранить'
+}
+
+const schema = Yup.object({
+  model: Yup.string().required('Модель обязательна'),
+  number: Yup.string(),
+  terminationDate: Yup.string().required('Дата окончания обязательна')
+})
+
+function onSubmit(values, { setErrors }) {
+  const payload = {
+    model: values.model?.trim() || '',
+    number: values.number?.trim() || '',
+    terminationDate: values.terminationDate
+  }
+
+  if (isCreate.value) {
+    return notificationsStore
+      .create(payload)
+      .then(() => {
+        router.push('/notifications')
+      })
+      .catch((error) => {
+        setErrors({ apiError: error.message || 'Ошибка при создании нотификации' })
+      })
+  }
+
+  return notificationsStore
+    .update(props.notificationId, payload)
+    .then(() => {
+      router.push('/notifications')
+    })
+    .catch((error) => {
+      setErrors({ apiError: error.message || 'Ошибка при сохранении нотификации' })
+    })
+}
+
+defineExpose({
+  formatDateForInput,
+  getTitle,
+  getButtonText,
+  onSubmit
+})
+
+</script>
+
+<template>
+  <div class="settings form-2">
+    <h1 class="primary-heading">{{ getTitle() }}</h1>
+    <hr class="hr" />
+    <Form
+      @submit="onSubmit"
+      :initial-values="notificationForm"
+      :validation-schema="schema"
+      v-slot="{ errors, isSubmitting }"
+    >
+      <div class="form-group">
+        <label for="model" class="label">Модель:</label>
+        <Field
+          name="model"
+          id="model"
+          type="text"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.model }"
+          placeholder="Модель"
+        />
+        <div v-if="errors.model" class="invalid-feedback">{{ errors.model }}</div>
+      </div>
+
+      <div class="form-group">
+        <label for="number" class="label">Номер:</label>
+        <Field
+          name="number"
+          id="number"
+          type="text"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.number }"
+          placeholder="Номер"
+        />
+        <div v-if="errors.number" class="invalid-feedback">{{ errors.number }}</div>
+      </div>
+
+      <div class="form-group">
+        <label for="terminationDate" class="label">Дата окончания:</label>
+        <Field
+          name="terminationDate"
+          id="terminationDate"
+          type="date"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.terminationDate }"
+        />
+        <div v-if="errors.terminationDate" class="invalid-feedback">{{ errors.terminationDate }}</div>
+      </div>
+
+      <div v-if="errors.apiError" class="alert alert-danger">{{ errors.apiError }}</div>
+
+      <div class="form-actions">
+        <button type="submit" class="btn btn-primary" :disabled="isSubmitting">
+          {{ getButtonText() }}
+        </button>
+      </div>
+    </Form>
+  </div>
+</template>

--- a/src/lists/Notifications_List.vue
+++ b/src/lists/Notifications_List.vue
@@ -1,0 +1,206 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { onMounted, ref } from 'vue'
+import router from '@/router'
+import { storeToRefs } from 'pinia'
+import { useNotificationsStore } from '@/stores/notifications.store.js'
+import { useAuthStore } from '@/stores/auth.store.js'
+import { useAlertStore } from '@/stores/alert.store.js'
+import { useConfirm } from 'vuetify-use-dialog'
+import ActionButton from '@/components/ActionButton.vue'
+import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
+import { mdiMagnify } from '@mdi/js'
+
+const notificationsStore = useNotificationsStore()
+const authStore = useAuthStore()
+const alertStore = useAlertStore()
+const confirm = useConfirm()
+
+const { notifications, loading } = storeToRefs(notificationsStore)
+const { alert } = storeToRefs(alertStore)
+const runningAction = ref(false)
+
+function filterNotifications(value, query, item) {
+  if (query === null || item === null) {
+    return false
+  }
+
+  const notification = item.raw
+  if (!notification) {
+    return false
+  }
+
+  const q = query.toLocaleUpperCase()
+
+  return [notification.model, notification.number, formatTerminationDate(notification.terminationDate)]
+    .some((field) => (field || '').toLocaleUpperCase().includes(q))
+}
+
+const headers = [
+  ...(authStore.isAdminOrSrLogist ? [{ title: '', align: 'center', key: 'actions', sortable: false, width: '120px' }] : []),
+  { title: 'Модель', key: 'model', sortable: true },
+  { title: 'Номер', key: 'number', sortable: true },
+  { title: 'Дата окончания', key: 'terminationDate', sortable: true }
+]
+
+function formatTerminationDate(value) {
+  if (!value) {
+    return ''
+  }
+
+  if (value instanceof Date) {
+    return value.toLocaleDateString('ru-RU')
+  }
+
+  if (typeof value === 'string') {
+    const date = new Date(value)
+    if (!Number.isNaN(date.getTime())) {
+      return date.toLocaleDateString('ru-RU')
+    }
+    return value
+  }
+
+  if (typeof value === 'object' && value.year && value.month && value.day) {
+    const date = new Date(value.year, value.month - 1, value.day)
+    if (!Number.isNaN(date.getTime())) {
+      return date.toLocaleDateString('ru-RU')
+    }
+  }
+
+  return ''
+}
+
+function openEditDialog(notification) {
+  router.push(`/notification/edit/${notification.id}`)
+}
+
+function openCreateDialog() {
+  router.push('/notification/create')
+}
+
+async function deleteNotification(notification) {
+  if (runningAction.value) return
+  runningAction.value = true
+
+  try {
+    const confirmed = await confirm({
+      title: 'Подтверждение',
+      confirmationText: 'Удалить',
+      cancellationText: 'Не удалять',
+      dialogProps: {
+        width: '30%',
+        minWidth: '250px'
+      },
+      confirmationButtonProps: {
+        color: 'orange-darken-3'
+      },
+      content: `Удалить нотификацию "${notification.model}"?`
+    })
+
+    if (confirmed) {
+      try {
+        await notificationsStore.remove(notification.id)
+      } catch (error) {
+        alertStore.error(error.message || 'Ошибка при удалении нотификации')
+      }
+    }
+  } finally {
+    runningAction.value = false
+  }
+}
+
+onMounted(async () => {
+  await notificationsStore.getAll()
+})
+
+defineExpose({
+  openCreateDialog,
+  openEditDialog,
+  deleteNotification,
+  formatTerminationDate
+})
+</script>
+
+<template>
+  <div class="settings table-2">
+    <h1 class="primary-heading">Нотификации</h1>
+    <hr class="hr" />
+
+    <div class="link-crt" v-if="authStore.isAdminOrSrLogist">
+      <router-link to="/notification/create" class="link">
+        <font-awesome-icon
+          size="1x"
+          icon="fa-solid fa-bell"
+          class="link"
+        />&nbsp;&nbsp;&nbsp;Создать нотификацию
+      </router-link>
+    </div>
+
+    <div v-if="notifications?.length">
+      <v-text-field
+        v-model="authStore.notifications_search"
+        :append-inner-icon="mdiMagnify"
+        label="Поиск по информации о нотификациях"
+        variant="solo"
+        hide-details
+      />
+    </div>
+
+    <v-card>
+      <v-data-table
+        v-if="notifications?.length"
+        v-model:items-per-page="authStore.notifications_per_page"
+        items-per-page-text="Нотификаций на странице"
+        :items-per-page-options="itemsPerPageOptions"
+        page-text="{0}-{1} из {2}"
+        v-model:page="authStore.notifications_page"
+        :headers="headers"
+        :items="notifications"
+        :search="authStore.notifications_search"
+        v-model:sort-by="authStore.notifications_sort_by"
+        :custom-filter="filterNotifications"
+        :loading="loading"
+        item-value="id"
+        density="compact"
+        class="elevation-1 interlaced-table"
+      >
+        <template #item.terminationDate="{ item }">
+          {{ formatTerminationDate(item.terminationDate) }}
+        </template>
+
+        <template #item.actions="{ item }">
+          <div v-if="authStore.isAdminOrSrLogist" class="actions-container">
+            <ActionButton
+              :item="item"
+              icon="fa-solid fa-pen"
+              tooltip-text="Редактировать нотификацию"
+              @click="openEditDialog"
+              :disabled="runningAction || loading"
+            />
+            <ActionButton
+              :item="item"
+              icon="fa-solid fa-trash-can"
+              tooltip-text="Удалить нотификацию"
+              @click="deleteNotification"
+              :disabled="runningAction || loading"
+            />
+          </div>
+        </template>
+      </v-data-table>
+
+      <div v-if="!notifications?.length" class="text-center m-5">Список нотификаций пуст</div>
+    </v-card>
+
+    <div v-if="loading" class="text-center m-5">
+      <span class="spinner-border spinner-border-lg align-center"></span>
+    </div>
+
+    <div v-if="alert" class="alert alert-dismissable mt-3 mb-0" :class="alert.type">
+      <button @click="alertStore.clear()" class="btn btn-link close">×</button>
+      {{ alert.message }}
+    </div>
+  </div>
+</template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -56,6 +56,12 @@ const router = createRouter({
       meta: { reqAnyRole: true }
     },
     {
+      path: '/notifications',
+      name: 'Нотификации',
+      component: () => import('@/views/Notifications_View.vue'),
+      meta: { reqAnyRole: true }
+    },
+    {
       path: '/airports',
       name: 'Коды аэропортов',
       component: () => import('@/views/Airports_View.vue'),
@@ -71,6 +77,21 @@ const router = createRouter({
       path: '/company/edit/:id',
       name: 'Изменить информацию о компании',
       component: () => import('@/views/Company_EditView.vue'),
+      props: (route) => ({
+        id: Number(route.params.id)
+      }),
+      meta: { reqAdminOrSrLogist: true }
+    },
+    {
+      path: '/notification/create',
+      name: 'Создание нотификации',
+      component: () => import('@/views/Notification_CreateView.vue'),
+      meta: { reqAdminOrSrLogist: true }
+    },
+    {
+      path: '/notification/edit/:id',
+      name: 'Редактирование нотификации',
+      component: () => import('@/views/Notification_EditView.vue'),
       props: (route) => ({
         id: Number(route.params.id)
       }),

--- a/src/stores/auth.store.js
+++ b/src/stores/auth.store.js
@@ -42,6 +42,10 @@ export const useAuthStore = defineStore('auth', () => {
   const companies_search = ref('')
   const companies_sort_by = ref(['id'])
   const companies_page = ref(1)
+  const notifications_per_page = ref(10)
+  const notifications_search = ref('')
+  const notifications_sort_by = ref(['id'])
+  const notifications_page = ref(1)
   const airports_per_page = ref(10)
   const airports_search = ref('')
   const airports_sort_by = ref(['id'])
@@ -180,6 +184,10 @@ export const useAuthStore = defineStore('auth', () => {
     companies_search,
     companies_sort_by,
     companies_page,
+    notifications_per_page,
+    notifications_search,
+    notifications_sort_by,
+    notifications_page,
     airports_per_page,
     airports_search,
     airports_sort_by,

--- a/src/views/Notification_CreateView.vue
+++ b/src/views/Notification_CreateView.vue
@@ -1,0 +1,13 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import NotificationSettings from '@/dialogs/Notification_Settings.vue'
+</script>
+
+<template>
+  <Suspense>
+    <NotificationSettings :mode="'create'" />
+  </Suspense>
+</template>

--- a/src/views/Notification_EditView.vue
+++ b/src/views/Notification_EditView.vue
@@ -1,0 +1,20 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import NotificationSettings from '@/dialogs/Notification_Settings.vue'
+
+const props = defineProps({
+  id: {
+    type: Number,
+    required: true
+  }
+})
+</script>
+
+<template>
+  <Suspense>
+    <NotificationSettings :mode="'edit'" :notification-id="props.id" />
+  </Suspense>
+</template>

--- a/src/views/Notifications_View.vue
+++ b/src/views/Notifications_View.vue
@@ -1,0 +1,11 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import Notifications from '@/lists/Notifications_List.vue'
+</script>
+
+<template>
+  <Notifications />
+</template>

--- a/tests/Notification_CreateView.spec.js
+++ b/tests/Notification_CreateView.spec.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import NotificationCreateView from '@/views/Notification_CreateView.vue'
+import NotificationSettings from '@/dialogs/Notification_Settings.vue'
+
+const vuetify = createVuetify()
+
+vi.mock('@/dialogs/Notification_Settings.vue', () => ({
+  default: {
+    name: 'Notification_Settings',
+    props: ['mode', 'notificationId'],
+    template: '<div data-test="notification-settings">Notification Settings Component</div>'
+  }
+}))
+
+describe('Notification_CreateView.vue', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(NotificationCreateView, {
+      global: {
+        plugins: [vuetify]
+      }
+    })
+  })
+
+  it('renders Notification_Settings component', () => {
+    const settings = wrapper.findComponent(NotificationSettings)
+    expect(settings.exists()).toBe(true)
+  })
+
+  it('passes create mode to Notification_Settings', () => {
+    const settings = wrapper.findComponent(NotificationSettings)
+    expect(settings.props('mode')).toBe('create')
+    expect(settings.props('notificationId')).toBeUndefined()
+  })
+
+  it('renders placeholder content', () => {
+    expect(wrapper.find('[data-test="notification-settings"]').exists()).toBe(true)
+  })
+})

--- a/tests/Notification_EditView.spec.js
+++ b/tests/Notification_EditView.spec.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import NotificationEditView from '@/views/Notification_EditView.vue'
+import NotificationSettings from '@/dialogs/Notification_Settings.vue'
+
+const vuetify = createVuetify()
+
+vi.mock('@/dialogs/Notification_Settings.vue', () => ({
+  default: {
+    name: 'Notification_Settings',
+    props: ['mode', 'notificationId'],
+    template: '<div data-test="notification-settings">Notification Settings Component</div>'
+  }
+}))
+
+describe('Notification_EditView.vue', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(NotificationEditView, {
+      props: { id: 5 },
+      global: {
+        plugins: [vuetify]
+      }
+    })
+  })
+
+  it('renders Notification_Settings component', () => {
+    const settings = wrapper.findComponent(NotificationSettings)
+    expect(settings.exists()).toBe(true)
+  })
+
+  it('passes edit mode and id to Notification_Settings', () => {
+    const settings = wrapper.findComponent(NotificationSettings)
+    expect(settings.props('mode')).toBe('edit')
+    expect(settings.props('notificationId')).toBe(5)
+  })
+
+  it('renders placeholder content', () => {
+    expect(wrapper.find('[data-test="notification-settings"]').exists()).toBe(true)
+  })
+})

--- a/tests/Notification_Settings.spec.js
+++ b/tests/Notification_Settings.spec.js
@@ -1,0 +1,171 @@
+/* @vitest-environment jsdom */
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { Suspense } from 'vue'
+import NotificationSettings from '@/dialogs/Notification_Settings.vue'
+import { defaultGlobalStubs, createMockStore, resolveAll } from './helpers/test-utils.js'
+
+const mockRouter = vi.hoisted(() => ({ push: vi.fn() }))
+const mockNotification = {
+  id: 1,
+  model: 'Test Model',
+  number: 'ABC-123',
+  terminationDate: '2025-12-31'
+}
+
+let mockNotificationsStore
+
+vi.mock('@/stores/notifications.store.js', () => ({
+  useNotificationsStore: () => mockNotificationsStore
+}))
+
+vi.mock('@/router', () => ({
+  default: mockRouter
+}))
+
+vi.mock('vee-validate', () => ({
+  Form: {
+    name: 'Form',
+    props: ['initialValues', 'validationSchema'],
+    emits: ['submit'],
+    data() {
+      return {
+        errors: {},
+        isSubmitting: false
+      }
+    },
+    methods: {
+      handleSubmit() {
+        const values = this.initialValues?.value ?? this.initialValues ?? {}
+        const actions = {
+          setErrors: this.setErrors.bind(this)
+        }
+        this.$emit('submit', values, actions)
+      },
+      setErrors(newErrors) {
+        this.errors = { ...this.errors, ...newErrors }
+      }
+    },
+    template: `
+      <form @submit.prevent="handleSubmit">
+        <slot :errors="errors" :isSubmitting="isSubmitting" />
+      </form>
+    `
+  },
+  Field: {
+    name: 'Field',
+    props: ['name', 'id', 'type', 'class', 'placeholder'],
+    template: '<input v-bind="$props" />'
+  }
+}))
+
+const AsyncWrapper = {
+  components: { NotificationSettings, Suspense },
+  props: ['mode', 'notificationId'],
+  template: `
+    <Suspense>
+      <NotificationSettings :mode="mode" :notification-id="notificationId" />
+      <template #fallback>
+        <div>Loading...</div>
+      </template>
+    </Suspense>
+  `
+}
+
+describe('Notification_Settings.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRouter.push.mockClear()
+    mockNotificationsStore = createMockStore({
+      notification: mockNotification,
+      getById: vi.fn().mockResolvedValue(mockNotification),
+      create: vi.fn().mockResolvedValue(mockNotification),
+      update: vi.fn().mockResolvedValue()
+    })
+  })
+
+  it('renders create mode correctly', async () => {
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'create' },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    expect(wrapper.find('h1').text()).toBe('Регистрация нотификации')
+    expect(wrapper.find('button[type="submit"]').text()).toContain('Создать')
+    expect(mockNotificationsStore.getById).not.toHaveBeenCalled()
+  })
+
+  it('renders edit mode and loads data', async () => {
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'edit', notificationId: 1 },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    expect(wrapper.find('h1').text()).toBe('Изменить информацию о нотификации')
+    expect(wrapper.find('button[type="submit"]').text()).toContain('Сохранить')
+    expect(mockNotificationsStore.getById).toHaveBeenCalledWith(1)
+  })
+
+  it('submits create form and redirects', async () => {
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'create' },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    await wrapper.find('form').trigger('submit')
+    await resolveAll()
+
+    expect(mockNotificationsStore.create).toHaveBeenCalled()
+    expect(mockRouter.push).toHaveBeenCalledWith('/notifications')
+  })
+
+  it('submits edit form and redirects', async () => {
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'edit', notificationId: 1 },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    await wrapper.find('form').trigger('submit')
+    await resolveAll()
+
+    expect(mockNotificationsStore.update).toHaveBeenCalledWith(1, expect.any(Object))
+    expect(mockRouter.push).toHaveBeenCalledWith('/notifications')
+  })
+
+  it('formats date values for input fields', async () => {
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'create' },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    const vm = wrapper.findComponent(NotificationSettings).vm
+
+    expect(vm.formatDateForInput('2025-01-15')).toBe('2025-01-15')
+    expect(vm.formatDateForInput(new Date('2025-01-15'))).toBe('2025-01-15')
+    expect(vm.formatDateForInput({ year: 2025, month: 1, day: 15 })).toBe('2025-01-15')
+  })
+})

--- a/tests/Notifications_List.spec.js
+++ b/tests/Notifications_List.spec.js
@@ -1,0 +1,189 @@
+/* @vitest-environment jsdom */
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import NotificationsList from '@/lists/Notifications_List.vue'
+import { defaultGlobalStubs } from './helpers/test-utils.js'
+
+const notificationsRef = ref([])
+const loadingRef = ref(false)
+const alertRef = ref(null)
+const getAllMock = vi.hoisted(() => vi.fn())
+const removeMock = vi.hoisted(() => vi.fn())
+const errorMock = vi.hoisted(() => vi.fn())
+const clearMock = vi.hoisted(() => vi.fn())
+const confirmMock = vi.hoisted(() => vi.fn().mockResolvedValue(true))
+const pushMock = vi.hoisted(() => vi.fn())
+
+let notificationsStoreMock
+let authStoreMock
+let alertStoreMock
+
+const testStubs = {
+  ...defaultGlobalStubs,
+  'font-awesome-icon': {
+    template: '<i class="fa-icon-stub" />',
+    props: ['size', 'icon', 'class']
+  },
+  'router-link': {
+    template: '<a class="router-link-stub"><slot></slot></a>',
+    props: ['to']
+  }
+}
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return {
+    ...actual,
+    storeToRefs: (store) => {
+      const refs = {}
+      Object.keys(store).forEach((key) => {
+        const value = store[key]
+        if (value && typeof value === 'object' && 'value' in value) {
+          refs[key] = value
+        }
+      })
+      return refs
+    }
+  }
+})
+
+vi.mock('@/stores/notifications.store.js', () => ({
+  useNotificationsStore: () => notificationsStoreMock
+}))
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: () => authStoreMock
+}))
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => alertStoreMock
+}))
+
+vi.mock('vuetify-use-dialog', () => ({
+  useConfirm: () => confirmMock
+}))
+
+vi.mock('@/router', () => ({
+  default: { push: pushMock }
+}), { virtual: true })
+
+vi.mock('@/helpers/items.per.page.js', () => ({
+  itemsPerPageOptions: [10, 25, 50]
+}))
+
+vi.mock('@mdi/js', () => ({
+  mdiMagnify: 'mdi-magnify'
+}))
+
+describe('Notifications_List.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    pushMock.mockClear()
+    confirmMock.mockClear()
+    confirmMock.mockResolvedValue(true)
+
+    notificationsRef.value = [
+      { id: 1, model: 'Model A', number: 'N-001', terminationDate: '2025-01-31' }
+    ]
+    loadingRef.value = false
+    alertRef.value = null
+
+    notificationsStoreMock = {
+      notifications: notificationsRef,
+      loading: loadingRef,
+      getAll: getAllMock,
+      remove: removeMock
+    }
+
+    authStoreMock = {
+      isAdminOrSrLogist: true,
+      notifications_per_page: ref(10),
+      notifications_search: ref(''),
+      notifications_sort_by: ref(['id']),
+      notifications_page: ref(1)
+    }
+
+    alertStoreMock = {
+      alert: alertRef,
+      error: errorMock,
+      clear: clearMock
+    }
+  })
+
+  it('loads notifications on mount', async () => {
+    mount(NotificationsList, {
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    await Promise.resolve()
+
+    expect(getAllMock).toHaveBeenCalled()
+  })
+
+  it('navigates to create view when openCreateDialog is called', async () => {
+    const wrapper = mount(NotificationsList, {
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    await wrapper.vm.openCreateDialog()
+
+    expect(pushMock).toHaveBeenCalledWith('/notification/create')
+  })
+
+  it('navigates to edit view when openEditDialog is called', async () => {
+    const wrapper = mount(NotificationsList, {
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    await wrapper.vm.openEditDialog({ id: 2 })
+
+    expect(pushMock).toHaveBeenCalledWith('/notification/edit/2')
+  })
+
+  it('deletes notification after confirmation', async () => {
+    const wrapper = mount(NotificationsList, {
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    await wrapper.vm.deleteNotification(notificationsRef.value[0])
+
+    expect(confirmMock).toHaveBeenCalled()
+    expect(removeMock).toHaveBeenCalledWith(1)
+  })
+
+  it('formats termination dates correctly', async () => {
+    const wrapper = mount(NotificationsList, {
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    expect(wrapper.vm.formatTerminationDate('2025-02-15')).toBe('15.02.2025')
+    expect(wrapper.vm.formatTerminationDate({ year: 2025, month: 2, day: 15 })).toBe('15.02.2025')
+  })
+
+  it('shows empty state message when there are no notifications', async () => {
+    notificationsRef.value = []
+
+    const wrapper = mount(NotificationsList, {
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    expect(wrapper.text()).toContain('Список нотификаций пуст')
+  })
+})

--- a/tests/Notifications_View.spec.js
+++ b/tests/Notifications_View.spec.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import { createPinia } from 'pinia'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import NotificationsView from '@/views/Notifications_View.vue'
+
+vi.mock('@/lists/Notifications_List.vue', () => ({
+  default: {
+    name: 'Notifications_List',
+    template: '<div data-testid="notifications-list">Notifications List</div>'
+  }
+}))
+
+describe('Notifications_View.vue', () => {
+  let vuetify
+  let pinia
+
+  beforeEach(() => {
+    vuetify = createVuetify({
+      components,
+      directives
+    })
+    pinia = createPinia()
+  })
+
+  it('renders without errors', () => {
+    const wrapper = mount(NotificationsView, {
+      global: {
+        plugins: [vuetify, pinia]
+      }
+    })
+
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('renders Notifications_List component', () => {
+    const wrapper = mount(NotificationsView, {
+      global: {
+        plugins: [vuetify, pinia]
+      }
+    })
+
+    const list = wrapper.find('[data-testid="notifications-list"]')
+    expect(list.exists()).toBe(true)
+    expect(list.text()).toBe('Notifications List')
+  })
+})


### PR DESCRIPTION
## Summary
- add notification settings dialog, list, and views wired to the notifications store
- extend the router and auth store to support notifications navigation and paging state
- add unit tests covering the new notification components and views

## Testing
- npx vitest run tests/Notification_Settings.spec.js tests/Notifications_List.spec.js tests/Notifications_View.spec.js tests/Notification_CreateView.spec.js tests/Notification_EditView.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68e2396acf808321a65549b904bb2c9b