### PR TITLE
Improve error dialog missing item layout

### DIFF
--- a/src/components/ErrorDialog.vue
+++ b/src/components/ErrorDialog.vue
@@ -14,6 +14,10 @@ const emit = defineEmits(['close'])
 
 const dialogVisible = computed(() => props.show)
 
+const hasMissingItems = computed(
+  () => props.missingHeaders.length > 0 || props.missingColumns.length > 0
+)
+
 function closeDialog() {
   emit('close')
 }
@@ -46,10 +50,34 @@ onUnmounted(() => {
       <v-card-title class="primary-heading">
         {{ title }}
       </v-card-title>
-      <v-card-text class="text-left"  >
-        {{ missingHeaders.length == 0 && missingColumns.length == 0 ? message : '' }}
-        {{ missingHeaders.length > 0 ? 'Не найдены параметры посылок для столбцов реестра: ' + missingHeaders.join(', ') : '' }}
-        {{ missingColumns.length > 0 ? 'Не найдены столбцы реестра для параметров посылок: ' + missingColumns.join(', ') : '' }}
+      <v-card-text class="text-left">
+        <template v-if="hasMissingItems">
+          <div class="error-dialog__lists">
+            <div v-if="missingHeaders.length" class="error-dialog__list">
+              <p class="error-dialog__list-title">
+                Не найдены параметры посылок для столбцов реестра:
+              </p>
+              <ul>
+                <li v-for="header in missingHeaders" :key="`header-${header}`">
+                  {{ header }}
+                </li>
+              </ul>
+            </div>
+            <div v-if="missingColumns.length" class="error-dialog__list">
+              <p class="error-dialog__list-title">
+                Не найдены столбцы реестра для параметров посылок:
+              </p>
+              <ul>
+                <li v-for="column in missingColumns" :key="`column-${column}`">
+                  {{ column }}
+                </li>
+              </ul>
+            </div>
+          </div>
+        </template>
+        <template v-else>
+          {{ message }}
+        </template>
       </v-card-text>
       <v-card-actions class="justify-center">
         <v-btn color="primary" @click="closeDialog">
@@ -59,3 +87,30 @@ onUnmounted(() => {
     </v-card>
   </v-dialog>
 </template>
+
+<style scoped>
+.error-dialog__lists {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.error-dialog__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.error-dialog__list-title {
+  font-weight: 600;
+}
+
+.error-dialog__list ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.error-dialog__list li + li {
+  margin-top: 4px;
+}
+</style>


### PR DESCRIPTION
## Summary
- display missing headers and columns in dedicated two-column lists
- add computed helper and scoped styles for the error dialog content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2bab0f68083218939ef30497a7e00