### PR TITLE
Remove airport caching in register dialog

### DIFF
--- a/src/components/AirportSelectField.vue
+++ b/src/components/AirportSelectField.vue
@@ -1,0 +1,48 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { computed } from 'vue'
+import { Field } from 'vee-validate'
+
+const props = defineProps({
+  label: { type: String, required: true },
+  name: { type: String, required: true },
+  airports: { type: Array, default: () => [] },
+  disabled: { type: Boolean, default: false }
+})
+
+const airportOptions = computed(() => {
+  if (!Array.isArray(props.airports)) {
+    return []
+  }
+  return props.airports
+})
+
+function formatAirport(airport) {
+  if (!airport) return ''
+  const name = airport.name || '—'
+  const code = airport.codeIata || ''
+  return code ? `${name} (${code})` : name
+}
+</script>
+
+<template>
+  <div class="form-group">
+    <label class="label" :for="name">{{ label }}</label>
+    <Field
+      :name="name"
+      :id="name"
+      as="select"
+      class="form-control input"
+      :disabled="disabled"
+      :value-as-number="true"
+    >
+      <option :value="0">Не выбрано</option>
+      <option v-for="airport in airportOptions" :key="airport.id" :value="airport.id">
+        {{ formatAirport(airport) }}
+      </option>
+    </Field>
+  </div>
+</template>

--- a/tests/Register_EditDialog.spec.js
+++ b/tests/Register_EditDialog.spec.js
@@ -14,16 +14,20 @@ import { resolveAll } from './helpers/test-utils'
 
 // No need to mock vuetify-use-dialog anymore since we use custom ErrorDialog
 
-const mockItem = ref({
+const baseRegisterItem = {
   id: 1,
   fileName: 'r.csv',
   companyId: 2,
   dealNumber: 'D1',
   customsProcedureId: 1,
+  transportationTypeId: 1,
   theOtherCompanyId: null,
   theOtherCountryCode: null,
+  departureAirportId: 0,
+  arrivalAirportId: 0,
   date: '2024-01-01'
-})
+}
+const mockItem = ref({ ...baseRegisterItem })
 const getById = vi.fn(() => Promise.resolve())
 const update = vi.fn(() => Promise.resolve())
 const upload = vi.fn(() => Promise.resolve())
@@ -47,7 +51,10 @@ const countriesStore = createMockStore({
   ensureLoaded: vi.fn()
 })
 const transStore = createMockStore({
-  types: [{ id: 1, name: 'Авто' }],
+  types: [
+    { id: 1, name: 'Авто', code: 1 },
+    { id: 2, name: 'Авиа', code: 0 }
+  ],
   ensureLoaded: vi.fn()
 })
 const procStore = createMockStore({
@@ -62,6 +69,14 @@ const companiesStore = createMockStore({
     { id: 2, shortName: 'My Company' },
     { id: 3, shortName: 'Partner' }
   ]),
+  getAll: vi.fn(() => Promise.resolve())
+})
+const baseAirports = [
+  { id: 1, name: 'Шереметьево', codeIata: 'SVO' },
+  { id: 2, name: 'Домодедово', codeIata: 'DME' }
+]
+const airportsStore = createMockStore({
+  airports: ref([...baseAirports]),
   getAll: vi.fn(() => Promise.resolve())
 })
 
@@ -79,6 +94,7 @@ vi.mock('pinia', async () => {
       }
       if (store === countriesStore) return { countries: countriesStore.countries }
       if (store === companiesStore) return { companies: companiesStore.companies }
+      if (store === airportsStore) return { airports: airportsStore.airports }
       return {}
     }
   }
@@ -93,6 +109,7 @@ vi.mock('@/stores/customs.procedures.store.js', () => ({
   useCustomsProceduresStore: () => procStore
 }))
 vi.mock('@/stores/companies.store.js', () => ({ useCompaniesStore: () => companiesStore }))
+vi.mock('@/stores/airports.store.js', () => ({ useAirportsStore: () => airportsStore }))
 vi.mock('@/router', () => ({ default: { push: vi.fn(() => Promise.resolve()) } }))
 
 // Simple stubs for vee-validate components
@@ -102,7 +119,7 @@ const FormStub = {
 }
 const FieldStub = {
   name: 'Field',
-  props: ['name', 'id', 'type', 'as', 'readonly', 'disabled'],
+  props: ['name', 'id', 'type', 'as', 'readonly', 'disabled', 'valueAsNumber'],
   template: `
     <input :id="id || name" :type="type" :readonly="readonly" :disabled="disabled" v-if="as !== 'select'" />
     <select :id="id || name" :disabled="disabled" v-else><slot /></select>
@@ -147,7 +164,9 @@ describe('Register_EditDialog', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    mockItem.value = { ...baseRegisterItem }
     registerItems.value = []
+    airportsStore.airports.value = [...baseAirports]
   })
 
   it('loads data and renders fields', async () => {
@@ -165,8 +184,42 @@ describe('Register_EditDialog', () => {
     expect(countriesStore.ensureLoaded).toHaveBeenCalled()
     expect(transStore.ensureLoaded).toHaveBeenCalled()
     expect(procStore.ensureLoaded).toHaveBeenCalled()
+    expect(airportsStore.getAll).toHaveBeenCalled()
     expect(wrapper.find('#invoiceNumber').exists()).toBe(true)
     expect(wrapper.find('#customsProcedureId').exists()).toBe(true)
+    const departureSelect = wrapper.find('select#departureAirportId')
+    expect(departureSelect.exists()).toBe(true)
+    expect(departureSelect.element.disabled).toBe(true)
+    const optionTexts = departureSelect.findAll('option').map((option) => option.text())
+    expect(optionTexts).toContain('Не выбрано')
+    expect(optionTexts).toContain('Шереметьево (SVO)')
+    const arrivalSelect = wrapper.find('select#arrivalAirportId')
+    expect(arrivalSelect.exists()).toBe(true)
+  })
+
+  it('enables airport selectors when aviation transport is selected', async () => {
+    mockItem.value = {
+      ...baseRegisterItem,
+      transportationTypeId: 2,
+      departureAirportId: 1,
+      arrivalAirportId: 2
+    }
+
+    const Parent = {
+      template: '<Suspense><RegisterEditDialog :id="1" :create="false" /></Suspense>',
+      components: { RegisterEditDialog }
+    }
+    const wrapper = mount(Parent, {
+      global: {
+        stubs: { ...defaultGlobalStubs, Form: FormStub, Field: FieldStub, ErrorDialog: ErrorDialogStub }
+      }
+    })
+    await resolveAll()
+
+    const departureSelect = wrapper.find('select#departureAirportId')
+    const arrivalSelect = wrapper.find('select#arrivalAirportId')
+    expect(departureSelect.element.disabled).toBe(false)
+    expect(arrivalSelect.element.disabled).toBe(false)
   })
 
   it('switches recipient field on customs procedure change', async () => {
@@ -193,9 +246,46 @@ describe('Register_EditDialog', () => {
     expect(recipientGroup.find('select#theOtherCompanyId').exists()).toBe(true)
   })
 
+  it('submits airport ids when aviation transport is chosen', async () => {
+    mockItem.value = {
+      ...baseRegisterItem,
+      transportationTypeId: 2,
+      departureAirportId: 1,
+      arrivalAirportId: 2
+    }
+
+    const Parent = {
+      template: '<Suspense><RegisterEditDialog :id="1" :create="false" /></Suspense>',
+      components: { RegisterEditDialog }
+    }
+    const wrapper = mount(Parent, {
+      global: {
+        stubs: { ...defaultGlobalStubs, Form: FormStub, Field: FieldStub, ErrorDialog: ErrorDialogStub }
+      }
+    })
+    await resolveAll()
+
+    const dialog = wrapper.findComponent(RegisterEditDialog)
+    await dialog.vm.onSubmit(
+      {
+        transportationTypeId: '2',
+        departureAirportId: '1',
+        arrivalAirportId: '2'
+      },
+      { setErrors: vi.fn() }
+    )
+    await resolveAll()
+
+    expect(update).toHaveBeenCalledWith(1, expect.objectContaining({
+      transportationTypeId: 2,
+      departureAirportId: 1,
+      arrivalAirportId: 2
+    }))
+  })
+
   it('handles create mode with upload', async () => {
     registersStore.uploadFile.value = new File(['data'], 'test.xlsx')
-    mockItem.value = { fileName: 'test.xlsx', companyId: 2 }
+    mockItem.value = { ...baseRegisterItem, fileName: 'test.xlsx', companyId: 2 }
     registerItems.value = []
 
     const Parent = {
@@ -275,7 +365,7 @@ describe('Register_EditDialog', () => {
       { id: 20, dealNumber: 'D-200', fileName: 'reg-200.xlsx', companyId: 3 }
     ]
     registersStore.uploadFile.value = new File(['data'], 'test.xlsx')
-    mockItem.value = { fileName: 'test.xlsx', companyId: 3 }
+    mockItem.value = { ...baseRegisterItem, fileName: 'test.xlsx', companyId: 3 }
 
     const Parent = {
       template: '<Suspense><RegisterEditDialog :create="true" /></Suspense>',
@@ -298,9 +388,9 @@ describe('Register_EditDialog', () => {
   })
 
   it('handles create mode with upload result object', async () => {
-  upload.mockResolvedValueOnce({ success: true, registerId: 42, ErrMsg: '' })
+    upload.mockResolvedValueOnce({ success: true, registerId: 42, ErrMsg: '' })
     registersStore.uploadFile.value = new File(['data'], 'test.xlsx')
-    mockItem.value = { fileName: 'test.xlsx', companyId: 2 }
+    mockItem.value = { ...baseRegisterItem, fileName: 'test.xlsx', companyId: 2 }
     registerItems.value = []
     const formValues = { dealNumber: 'D42', invoiceNumber: 'INV42' }
 
@@ -320,8 +410,14 @@ describe('Register_EditDialog', () => {
     // Verify upload was called
     expect(upload).toHaveBeenCalledWith(registersStore.uploadFile.value, mockItem.value.companyId, null)
     
-    // Verify update was called with the Id from the Reference object and the form values
-    expect(update).toHaveBeenCalledWith(42, formValues)
+    // Verify update was called with the Id from the Reference object and the sanitized form values
+    expect(update).toHaveBeenCalledWith(42, expect.objectContaining({
+      dealNumber: 'D42',
+      invoiceNumber: 'INV42',
+      transportationTypeId: 1,
+      departureAirportId: 0,
+      arrivalAirportId: 0
+    }))
     
     // Verify navigation occurred
     expect(router.push).toHaveBeenCalledWith('/registers')
@@ -331,7 +427,7 @@ describe('Register_EditDialog', () => {
     const deferred = createDeferred()
     upload.mockReturnValueOnce(deferred.promise)
     registersStore.uploadFile.value = new File(['data'], 'upload.xlsx')
-    mockItem.value = { fileName: 'upload.xlsx', companyId: 5 }
+    mockItem.value = { ...baseRegisterItem, fileName: 'upload.xlsx', companyId: 5 }
 
     const Parent = {
       template: '<Suspense><RegisterEditDialog :create="true" /></Suspense>',
@@ -363,7 +459,7 @@ describe('Register_EditDialog', () => {
     update.mockRejectedValueOnce(new Error('Update failed'))
 
     registersStore.uploadFile.value = new File(['data'], 'test.xlsx')
-    mockItem.value = { fileName: 'test.xlsx', companyId: 2 }
+    mockItem.value = { ...baseRegisterItem, fileName: 'test.xlsx', companyId: 2 }
     const formValues = { dealNumber: 'D42', invoiceNumber: 'INV42' }
     const setErrors = vi.fn()
 


### PR DESCRIPTION
## Summary
- always fetch airports when opening the register edit dialog instead of relying on cached ensureLoaded state
- simplify the airports store by removing the ensureLoaded helper and its associated unit coverage
- update register dialog tests to expect airports to be refreshed on each mount

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4cfee95288321ba274f90c5feb409