### PR TITLE
Load airports for register list and show IATA codes

### DIFF
--- a/src/lists/Registers_List.vue
+++ b/src/lists/Registers_List.vue
@@ -21,6 +21,7 @@ import { useParcelCheckStatusStore } from '@/stores/parcel.checkstatuses.store.j
 import { useCompaniesStore } from '@/stores/companies.store.js'
 import { useCountriesStore } from '@/stores/countries.store.js'
 import { useTransportationTypesStore } from '@/stores/transportation.types.store.js'
+import { useAirportsStore } from '@/stores/airports.store.js'
 import { useCustomsProceduresStore } from '@/stores/customs.procedures.store.js'
 import { useAuthStore } from '@/stores/auth.store.js'
 import { useAlertStore } from '@/stores/alert.store.js'
@@ -50,6 +51,9 @@ const { countries } = storeToRefs(countriesStore)
 
 const transportationTypesStore = useTransportationTypesStore()
 const { types: transportationTypes } = storeToRefs(transportationTypesStore)
+
+const airportsStore = useAirportsStore()
+const { airports } = storeToRefs(airportsStore)
 
 const customsProceduresStore = useCustomsProceduresStore()
 
@@ -135,6 +139,46 @@ function getParcelsByCheckStatusTooltip(item) {
     .join('\n')
 }
 
+const transportationTypesById = computed(() => {
+  if (!Array.isArray(transportationTypes.value)) return new Map()
+  return new Map(transportationTypes.value.map(type => [type.id, type]))
+})
+
+const airportsById = computed(() => {
+  if (!Array.isArray(airports.value)) return new Map()
+  return new Map(airports.value.map(airport => [airport.id, airport]))
+})
+
+const AVIA_TRANSPORT_CODE = 0
+
+function isAviaTransportation(item) {
+  const typeId = Number(item?.transportationTypeId)
+  if (!typeId) return false
+  const type = transportationTypesById.value.get(typeId)
+  return type?.code === AVIA_TRANSPORT_CODE
+}
+
+function getAirportIata(airportId) {
+  const id = Number(airportId)
+  if (!id) return null
+  const airport = airportsById.value.get(id)
+  return airport?.codeIata || null
+}
+
+function getCountryDisplayName(item, countryCode, airportId) {
+  const countryName = getCountryShortName(countryCode)
+  if (!isAviaTransportation(item)) {
+    return countryName
+  }
+
+  const airportCode = getAirportIata(airportId)
+  if (!airportCode) {
+    return countryName
+  }
+
+  return `${countryName} (${airportCode})`
+}
+
 // Load companies and parcel statuses on component mount
 onMounted(async () => {
   try {
@@ -154,8 +198,11 @@ onMounted(async () => {
     
     await customsProceduresStore.ensureLoaded()
     if (!isComponentMounted.value) return
-    
+
     await companiesStore.getAll()
+    if (!isComponentMounted.value) return
+
+    await airportsStore.ensureLoaded()
   } catch (error) {
     if (isComponentMounted.value) {
       registersStore.error = error?.message || 'Ошибка при загрузке данных'
@@ -388,9 +435,9 @@ defineExpose({
           >
             <template #default>
               <span>{{ customsProceduresStore.getName(item.customsProcedureId) }}: </span>
-              <span>{{ getCountryShortName(item.origCountryCode) }}</span>
+              <span>{{ getCountryDisplayName(item, item.origCountryCode, item.departureAirportId) }}</span>
               <font-awesome-icon icon="fa-solid fa-arrow-right" class="mx-1 arrow-icon" />
-              <span>{{ getCountryShortName(item.destCountryCode) }}</span>
+              <span>{{ getCountryDisplayName(item, item.destCountryCode, item.arrivalAirportId) }}</span>
             </template>
           </ClickableCell>
         </template>

--- a/src/stores/airports.store.js
+++ b/src/stores/airports.store.js
@@ -14,17 +14,33 @@ export const useAirportsStore = defineStore('airports', () => {
   const airport = ref(null)
   const loading = ref(false)
   const error = ref(null)
+  let initialized = false
 
   async function getAll() {
     loading.value = true
     error.value = null
     try {
-      airports.value = await fetchWrapper.get(baseUrl)
+      const result = await fetchWrapper.get(baseUrl)
+      airports.value = Array.isArray(result) ? result : []
+      initialized = true
     } catch (err) {
       error.value = err
+      initialized = false
     } finally {
       loading.value = false
     }
+  }
+
+  async function ensureLoaded() {
+    if (initialized && airports.value.length > 0) {
+      return
+    }
+
+    if (loading.value) {
+      return
+    }
+
+    await getAll()
   }
 
   async function getById(id) {
@@ -49,6 +65,7 @@ export const useAirportsStore = defineStore('airports', () => {
     try {
       const result = await fetchWrapper.post(baseUrl, airportData)
       airports.value.push(result)
+      initialized = true
       return result
     } catch (err) {
       error.value = err
@@ -97,6 +114,7 @@ export const useAirportsStore = defineStore('airports', () => {
     loading,
     error,
     getAll,
+    ensureLoaded,
     getById,
     create,
     update,

--- a/tests/airports.store.spec.js
+++ b/tests/airports.store.spec.js
@@ -78,6 +78,20 @@ describe('airports store', () => {
     })
   })
 
+  describe('ensureLoaded', () => {
+    it('loads airports only once when called multiple times', async () => {
+      fetchWrapper.get.mockResolvedValue(mockAirports)
+      const store = useAirportsStore()
+
+      await store.ensureLoaded()
+      await store.ensureLoaded()
+
+      expect(fetchWrapper.get).toHaveBeenCalledTimes(1)
+      expect(store.airports).toEqual(mockAirports)
+    })
+
+  })
+
   describe('getById', () => {
     it('fetches airport by id successfully', async () => {
       fetchWrapper.get.mockResolvedValue(mockAirport)


### PR DESCRIPTION
## Summary
- load airports data when the registers list mounts and reuse it to append IATA codes for avia shipments
- memoize transportation types and airports for quick lookups when formatting country display values
- add an ensureLoaded helper to the airports store and extend unit tests for the store and registers list

## Testing
- npx vitest run tests/airports.store.spec.js tests/Registers_List.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68e54d4cb9b48321a3d6bbb892480cde