### PR TITLE
Disable parcel validation when approved with excise

### DIFF
--- a/src/helpers/check.status.code.js
+++ b/src/helpers/check.status.code.js
@@ -133,8 +133,29 @@ export class CheckStatusCode {
    * Check if the combined status has issues
    */
   static hasIssues(value) {
-    return (CheckStatusCode.getFC(value) & 0x0100) !== 0 || 
+    return (CheckStatusCode.getFC(value) & 0x0100) !== 0 ||
            (CheckStatusCode.getSW(value) & 0x0100) !== 0
+  }
+
+  /**
+   * Determine if the combined status represents an ApprovedWithExcise state
+   */
+  static isApprovedWithExcise(value) {
+    if (value instanceof CheckStatusCode) {
+      return (
+        value.fc === FCCheckStatus.ApprovedWithExcise &&
+        value.sw === SWCheckStatus.ApprovedWithExcise
+      )
+    }
+
+    if (value == null) {
+      return false
+    }
+
+    const fc = CheckStatusCode.getFC(Number(value))
+    const sw = CheckStatusCode.getSW(Number(value))
+
+    return fc === FCCheckStatus.ApprovedWithExcise && sw === SWCheckStatus.ApprovedWithExcise
   }
 
   /**
@@ -283,6 +304,13 @@ export class CheckStatusHelper {
    */
   static hasIssues(combined) {
     return CheckStatusCode.hasIssues(combined)
+  }
+
+  /**
+   * Determine if the combined status represents an ApprovedWithExcise state
+   */
+  static isApprovedWithExcise(combined) {
+    return CheckStatusCode.isApprovedWithExcise(combined)
   }
 
   /**

--- a/src/lists/OzonParcels_List.vue
+++ b/src/lists/OzonParcels_List.vue
@@ -347,6 +347,14 @@ async function exportParcelXml(item) {
   }
 }
 
+function isParcelValidationDisabled(item) {
+  if (runningAction.value || loading.value) {
+    return true
+  }
+
+  return CheckStatusCode.isApprovedWithExcise(item?.checkStatus)
+}
+
 async function validateParcelSw(item) {
   if (runningAction.value) return
   runningAction.value = true
@@ -609,23 +617,24 @@ function getGenericTemplateHeaders() {
               @click="editParcel" 
               :disabled="runningAction || loading" 
             />
-            <ActionButton 
-              :item="item" 
-              icon="fa-solid fa-spell-check" 
-              tooltip-text="Проверить по стоп-словам" 
-              @click="validateParcelSw" 
-              :disabled="runningAction || loading" 
+            <ActionButton
+              :item="item"
+              icon="fa-solid fa-spell-check"
+              tooltip-text="Проверить по стоп-словам"
+              @click="validateParcelSw"
+              :disabled="isParcelValidationDisabled(item)"
             />
-            <ActionButton 
-              :item="item" 
-              icon="fa-solid fa-anchor-circle-check" 
-              tooltip-text="Проверить по кодам ТН ВЭД" 
-              @click="validateParcelFc" :disabled="runningAction || loading" 
+            <ActionButton
+              :item="item"
+              icon="fa-solid fa-anchor-circle-check"
+              tooltip-text="Проверить по кодам ТН ВЭД"
+              @click="validateParcelFc"
+              :disabled="isParcelValidationDisabled(item)"
             />
-            <ActionButton 
-              :item="item" 
-              icon="fa-solid fa-magnifying-glass" 
-              tooltip-text="Подобрать код ТН ВЭД" 
+            <ActionButton
+              :item="item"
+              icon="fa-solid fa-magnifying-glass"
+              tooltip-text="Подобрать код ТН ВЭД"
               @click="lookupFeacnCodes" :disabled="runningAction || loading"
             />
             <ActionButton 

--- a/src/lists/WbrParcels_List.vue
+++ b/src/lists/WbrParcels_List.vue
@@ -328,6 +328,14 @@ async function exportParcelXml(item) {
   }
 }
 
+function isParcelValidationDisabled(item) {
+  if (runningAction.value || loading.value) {
+    return true
+  }
+
+  return CheckStatusCode.isApprovedWithExcise(item?.checkStatus)
+}
+
 async function validateParcelSw(item) {
   if (runningAction.value) return
   runningAction.value = true
@@ -589,24 +597,24 @@ function getGenericTemplateHeaders() {
               @click="editParcel" 
               :disabled="runningAction || loading" 
             />
-            <ActionButton 
-              :item="item" 
-              icon="fa-solid fa-spell-check" 
-              tooltip-text="Проверить по стоп-словам" 
-              @click="validateParcelSw" 
-              :disabled="runningAction || loading" 
+            <ActionButton
+              :item="item"
+              icon="fa-solid fa-spell-check"
+              tooltip-text="Проверить по стоп-словам"
+              @click="validateParcelSw"
+              :disabled="isParcelValidationDisabled(item)"
             />
-            <ActionButton 
-              :item="item" 
-              icon="fa-solid fa-anchor-circle-check" 
-              tooltip-text="Проверить по кодам ТН ВЭД" 
-              @click="validateParcelFc" 
-              :disabled="runningAction || loading" 
+            <ActionButton
+              :item="item"
+              icon="fa-solid fa-anchor-circle-check"
+              tooltip-text="Проверить по кодам ТН ВЭД"
+              @click="validateParcelFc"
+              :disabled="isParcelValidationDisabled(item)"
             />
-            <ActionButton 
-              :item="item" 
-              icon="fa-solid fa-magnifying-glass" 
-              tooltip-text="Подобрать код ТН ВЭД" 
+            <ActionButton
+              :item="item"
+              icon="fa-solid fa-magnifying-glass"
+              tooltip-text="Подобрать код ТН ВЭД"
               @click="lookupFeacnCodes" 
               :disabled="runningAction || loading" 
             />

--- a/tests/Parcels_HeaderActions.spec.js
+++ b/tests/Parcels_HeaderActions.spec.js
@@ -8,6 +8,7 @@ import { mount } from '@vue/test-utils'
 import { ref, reactive } from 'vue'
 import OzonParcelsList from '@/lists/OzonParcels_List.vue'
 import WbrParcelsList from '@/lists/WbrParcels_List.vue'
+import { CheckStatusCode } from '@/helpers/check.status.code.js'
 import { vuetifyStubs, resolveAll } from './helpers/test-utils.js'
 
 const stores = {}
@@ -55,7 +56,8 @@ function setupStores() {
 
   stores.parcelStatuses = {
     ensureLoaded: vi.fn().mockResolvedValue(),
-    parcelStatuses: []
+    parcelStatuses: [],
+    getStatusTitle: vi.fn(() => 'Status')
   }
 
   stores.parcelCheckStatuses = {
@@ -304,5 +306,30 @@ describe.each([
 
     wrapper.unmount()
     expect(registerHeaderActionsMock.stop).toHaveBeenCalled()
+  })
+
+  it('disables validation buttons when parcel is approved with excise', async () => {
+    stores.parcels.items.value = [{
+      id: 42,
+      postingNumber: 'PN-42',
+      shk: '1234567890',
+      checkStatus: CheckStatusCode.ApprovedWithExcise.value,
+      keyWordIds: [],
+      blockedByFellowItem: false
+    }]
+    stores.parcels.totalCount.value = 1
+
+    const wrapper = mount(Component, {
+      props: { registerId: 4 },
+      global: { stubs: vuetifyStubs }
+    })
+
+    await resolveAll()
+
+    const rowButtons = wrapper.findAll('.actions-container .action-button-stub')
+    expect(rowButtons).toHaveLength(6)
+    expect(rowButtons[1].attributes('disabled')).toBeDefined()
+    expect(rowButtons[2].attributes('disabled')).toBeDefined()
+    expect(rowButtons[3].attributes('disabled')).toBeUndefined()
   })
 })

--- a/tests/check.status.code.spec.js
+++ b/tests/check.status.code.spec.js
@@ -139,6 +139,27 @@ describe('CheckStatusCode', () => {
     })
   })
 
+  describe('isApprovedWithExcise method', () => {
+    it('should detect ApprovedWithExcise combined value', () => {
+      const approved = CheckStatusCode.ApprovedWithExcise
+      expect(CheckStatusCode.isApprovedWithExcise(approved.value)).toBe(true)
+    })
+
+    it('should detect ApprovedWithExcise instance', () => {
+      const approved = CheckStatusCode.ApprovedWithExcise
+      expect(CheckStatusCode.isApprovedWithExcise(approved)).toBe(true)
+    })
+
+    it('should return false for non-approved statuses', () => {
+      const noIssues = CheckStatusCode.NoIssues
+      const withIssues = CheckStatusCode.fromParts(FCCheckStatus.IssueFeacnCode, SWCheckStatus.IssueStopWord)
+
+      expect(CheckStatusCode.isApprovedWithExcise(noIssues.value)).toBe(false)
+      expect(CheckStatusCode.isApprovedWithExcise(withIssues.value)).toBe(false)
+      expect(CheckStatusCode.isApprovedWithExcise(null)).toBe(false)
+    })
+  })
+
   describe('compose method', () => {
     it('should compose FC and SW correctly', () => {
       expect(CheckStatusCode.compose(0x0230, 0x0010)).toBe(0x02300010)
@@ -325,6 +346,23 @@ describe('CheckStatusHelper', () => {
       expect(CheckStatusHelper.hasIssues(0x01000000)).toBe(true)
       expect(CheckStatusHelper.hasIssues(0x00000100)).toBe(true)
       expect(CheckStatusHelper.hasIssues(0x02300010)).toBe(false)
+    })
+  })
+
+  describe('isApprovedWithExcise method', () => {
+    it('should detect approved with excise states', () => {
+      const approved = CheckStatusCode.ApprovedWithExcise
+      expect(CheckStatusHelper.isApprovedWithExcise(approved.value)).toBe(true)
+      expect(CheckStatusHelper.isApprovedWithExcise(approved)).toBe(true)
+    })
+
+    it('should return false for non-approved states', () => {
+      expect(CheckStatusHelper.isApprovedWithExcise(CheckStatusCode.NoIssues.value)).toBe(false)
+      expect(
+        CheckStatusHelper.isApprovedWithExcise(
+          CheckStatusCode.fromParts(FCCheckStatus.IssueInvalidFeacnFormat, SWCheckStatus.NoIssues).value
+        )
+      ).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Summary
- add helpers to detect the ApprovedWithExcise check status
- disable parcel-level validation buttons in the Ozon and WBR parcel lists when parcels are already approved with excise
- extend unit tests for the new helper and ensure list actions remain disabled through component tests

## Testing
- `npx vitest run tests/Parcels_HeaderActions.spec.js tests/check.status.code.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68f027c0e0bc832195e4beff7ee56549