### PR TITLE
Disable validation actions for approved parcels

### DIFF
--- a/src/composables/useParcelActionGuards.js
+++ b/src/composables/useParcelActionGuards.js
@@ -1,0 +1,21 @@
+import { computed } from 'vue'
+import { CheckStatusCode } from '@/helpers/check.status.code.js'
+
+/**
+ * Provides common computed flags for parcel action availability.
+ * @param {import('vue').Ref} parcelRef
+ */
+export function useParcelActionGuards(parcelRef) {
+  const isApprovedWithExciseStatus = computed(() =>
+    CheckStatusCode.isApprovedWithExcise(parcelRef.value?.checkStatus)
+  )
+
+  const areValidationActionsDisabled = computed(() =>
+    isApprovedWithExciseStatus.value
+  )
+
+  return {
+    isApprovedWithExciseStatus,
+    areValidationActionsDisabled
+  }
+}

--- a/src/dialogs/OzonParcel_EditDialog.vue
+++ b/src/dialogs/OzonParcel_EditDialog.vue
@@ -28,12 +28,13 @@ import ActionButton from '@/components/ActionButton.vue'
 import FeacnCodeEditor from '@/components/FeacnCodeEditor.vue'
 import ParcelNumberExt from '@/components/ParcelNumberExt.vue'
 import { handleFellowsClick } from '@/helpers/parcel.number.ext.helpers.js'
-import { 
-  validateParcelData, 
-  approveParcel as approveParcelHelper, 
+import {
+  validateParcelData,
+  approveParcel as approveParcelHelper,
   approveParcelWithExcise as approveParcelWithExciseHelper,
-  generateXml as generateXmlHelper 
+  generateXml as generateXmlHelper
 } from '@/helpers/parcel.actions.helpers.js'
+import { useParcelActionGuards } from '@/composables/useParcelActionGuards.js'
 
 const props = defineProps({
   registerId: { type: Number, required: true },
@@ -109,9 +110,7 @@ watch(() => item.value?.statusId, (newStatusId) => {
 }, { immediate: true })
 
 const productLinkWithProtocol = computed(() => ensureHttps(item.value?.productLink))
-const isApprovedWithExciseStatus = computed(() =>
-  CheckStatusCode.isApprovedWithExcise(item.value?.checkStatus)
-)
+const { isApprovedWithExciseStatus, areValidationActionsDisabled } = useParcelActionGuards(item)
 
 // Pre-fetch next parcels after component is mounted
 onMounted(() => {
@@ -350,7 +349,7 @@ function handleFellows() {
                 :item="item"
                 icon="fa-solid fa-spell-check"
                 tooltip-text="Сохранить и проверить стоп слова"
-                :disabled="isSubmitting || runningAction || loading"
+                :disabled="isSubmitting || runningAction || loading || areValidationActionsDisabled"
                 @click="() => validateParcel(values, true)"
                 :iconSize="'1x'"
               />
@@ -358,7 +357,7 @@ function handleFellows() {
                 :item="item"
                 icon="fa-solid fa-anchor-circle-check"
                 tooltip-text="Сохранить и проверить коды ТН ВЭД"
-                :disabled="isSubmitting || runningAction || loading"
+                :disabled="isSubmitting || runningAction || loading || areValidationActionsDisabled"
                 @click="() => validateParcel(values, false)"
                 :iconSize="'1x'"
               />

--- a/src/dialogs/WbrParcel_EditDialog.vue
+++ b/src/dialogs/WbrParcel_EditDialog.vue
@@ -28,12 +28,13 @@ import ActionButton from '@/components/ActionButton.vue'
 import FeacnCodeEditor from '@/components/FeacnCodeEditor.vue'
 import ParcelNumberExt from '@/components/ParcelNumberExt.vue'
 import { handleFellowsClick } from '@/helpers/parcel.number.ext.helpers.js'
-import { 
-  validateParcelData, 
-  approveParcel as approveParcelHelper, 
-  approveParcelWithExcise as approveParcelWithExciseHelper, 
-  generateXml as generateXmlHelper 
+import {
+  validateParcelData,
+  approveParcel as approveParcelHelper,
+  approveParcelWithExcise as approveParcelWithExciseHelper,
+  generateXml as generateXmlHelper
 } from '@/helpers/parcel.actions.helpers.js'
+import { useParcelActionGuards } from '@/composables/useParcelActionGuards.js'
 
 const props = defineProps({
   registerId: { type: Number, required: true },
@@ -109,9 +110,7 @@ watch(() => item.value?.statusId, (newStatusId) => {
 }, { immediate: true })
 
 const productLinkWithProtocol = computed(() => ensureHttps(item.value?.productLink))
-const isApprovedWithExciseStatus = computed(() =>
-  CheckStatusCode.isApprovedWithExcise(item.value?.checkStatus)
-)
+const { isApprovedWithExciseStatus, areValidationActionsDisabled } = useParcelActionGuards(item)
 
 const isDescriptionVisible = ref(false)
 
@@ -356,7 +355,7 @@ function handleFellows() {
                 :item="item"
                 icon="fa-solid fa-spell-check"
                 tooltip-text="Сохранить и проверить стоп слова"
-                :disabled="isSubmitting || runningAction || loading"
+                :disabled="isSubmitting || runningAction || loading || areValidationActionsDisabled"
                 @click="() => validateParcel(values, true)"
                 :iconSize="'1x'"
               />
@@ -364,7 +363,7 @@ function handleFellows() {
                 :item="item"
                 icon="fa-solid fa-anchor-circle-check"
                 tooltip-text="Сохранить и проверить коды ТН ВЭД"
-                :disabled="isSubmitting || runningAction || loading"
+                :disabled="isSubmitting || runningAction || loading || areValidationActionsDisabled"
                 @click="() => validateParcel(values, false)"
                 :iconSize="'1x'"
               />

--- a/tests/Parcel_EditDialogs.spec.js
+++ b/tests/Parcel_EditDialogs.spec.js
@@ -271,6 +271,13 @@ function getApprovalButtons(wrapper) {
   return { approveButton, approveWithExciseButton }
 }
 
+function getValidationButtons(wrapper) {
+  const buttons = wrapper.findAll('button.action-button-stub')
+  const validateStopWordsButton = buttons.find((btn) => btn.attributes('data-tooltip') === 'Сохранить и проверить стоп слова')
+  const validateFeacnButton = buttons.find((btn) => btn.attributes('data-tooltip') === 'Сохранить и проверить коды ТН ВЭД')
+  return { validateStopWordsButton, validateFeacnButton }
+}
+
 describe('Parcel edit dialogs approval state', () => {
   beforeEach(() => {
     currentParcelData = { ...baseParcelData }
@@ -317,6 +324,28 @@ describe('Parcel edit dialogs approval state', () => {
     expect(approveWithExciseButton.element.disabled).toBe(true)
   })
 
+  it('disables validation actions in Ozon dialog when status is ApprovedWithExcise', async () => {
+    currentParcelData = { ...currentParcelData, checkStatus: CheckStatusCode.ApprovedWithExcise.value }
+
+    const dialog = await mountOzonDialog()
+    const { validateStopWordsButton, validateFeacnButton } = getValidationButtons(dialog)
+
+    expect(validateStopWordsButton).toBeTruthy()
+    expect(validateFeacnButton).toBeTruthy()
+    expect(validateStopWordsButton.element.disabled).toBe(true)
+    expect(validateFeacnButton.element.disabled).toBe(true)
+  })
+
+  it('keeps validation actions enabled in Ozon dialog when status is not ApprovedWithExcise', async () => {
+    const dialog = await mountOzonDialog()
+    const { validateStopWordsButton, validateFeacnButton } = getValidationButtons(dialog)
+
+    expect(validateStopWordsButton).toBeTruthy()
+    expect(validateFeacnButton).toBeTruthy()
+    expect(validateStopWordsButton.element.disabled).toBe(false)
+    expect(validateFeacnButton.element.disabled).toBe(false)
+  })
+
   it('keeps approval actions enabled in Ozon dialog when status is not ApprovedWithExcise', async () => {
     const dialog = await mountOzonDialog()
     const { approveButton, approveWithExciseButton } = getApprovalButtons(dialog)
@@ -337,6 +366,28 @@ describe('Parcel edit dialogs approval state', () => {
     expect(approveWithExciseButton).toBeTruthy()
     expect(approveButton.element.disabled).toBe(true)
     expect(approveWithExciseButton.element.disabled).toBe(true)
+  })
+
+  it('disables validation actions in WBR dialog when status is ApprovedWithExcise', async () => {
+    currentParcelData = { ...currentParcelData, checkStatus: CheckStatusCode.ApprovedWithExcise.value }
+
+    const dialog = await mountWbrDialog()
+    const { validateStopWordsButton, validateFeacnButton } = getValidationButtons(dialog)
+
+    expect(validateStopWordsButton).toBeTruthy()
+    expect(validateFeacnButton).toBeTruthy()
+    expect(validateStopWordsButton.element.disabled).toBe(true)
+    expect(validateFeacnButton.element.disabled).toBe(true)
+  })
+
+  it('keeps validation actions enabled in WBR dialog when status is not ApprovedWithExcise', async () => {
+    const dialog = await mountWbrDialog()
+    const { validateStopWordsButton, validateFeacnButton } = getValidationButtons(dialog)
+
+    expect(validateStopWordsButton).toBeTruthy()
+    expect(validateFeacnButton).toBeTruthy()
+    expect(validateStopWordsButton.element.disabled).toBe(false)
+    expect(validateFeacnButton.element.disabled).toBe(false)
   })
 
   it('keeps approval actions enabled in WBR dialog when status is not ApprovedWithExcise', async () => {


### PR DESCRIPTION
## Summary
- add a reusable parcel action guard composable
- disable validation buttons in the Ozon and WBR parcel dialogs when a parcel is already approved with excise
- extend the parcel edit dialog tests to cover the validation button state

## Testing
- npm test -- Parcel_EditDialogs

------
https://chatgpt.com/codex/tasks/task_e_68f033d4b0e4832196babf9aa9bb3762