### PR TITLE
Add DEC store upload support

### DIFF
--- a/src/stores/dec.store.js
+++ b/src/stores/dec.store.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/dec`
+
+export const useDecStore = defineStore('dec', () => {
+  const loading = ref(false)
+  const error = ref(null)
+
+  async function upload(file) {
+    loading.value = true
+    error.value = null
+    try {
+      const formData = new FormData()
+      formData.append('file', file)
+      const response = await fetchWrapper.postFile(`${baseUrl}/upload`, formData)
+      return response
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    loading,
+    error,
+    upload
+  }
+})

--- a/tests/dec.store.spec.js
+++ b/tests/dec.store.spec.js
@@ -1,0 +1,61 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useDecStore } from '@/stores/dec.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: {
+    postFile: vi.fn()
+  }
+}))
+
+vi.mock('@/helpers/config.js', () => ({
+  apiUrl: 'http://localhost:8080/api'
+}))
+
+describe('dec.store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('initializes with default state', () => {
+    const store = useDecStore()
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('uploads file using fetchWrapper.postFile', async () => {
+    const store = useDecStore()
+    const file = new File(['content'], 'dec.xlsx', { type: 'application/vnd.ms-excel' })
+    const response = { success: true }
+    fetchWrapper.postFile.mockResolvedValue(response)
+
+    const promise = store.upload(file)
+    expect(store.loading).toBe(true)
+    await expect(promise).resolves.toBe(response)
+
+    expect(fetchWrapper.postFile).toHaveBeenCalledTimes(1)
+    const [url, formData] = fetchWrapper.postFile.mock.calls[0]
+    expect(url).toBe('http://localhost:8080/api/dec/upload')
+    expect(formData).toBeInstanceOf(FormData)
+    expect(formData.get('file')).toBe(file)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('stores error and rethrows when upload fails', async () => {
+    const store = useDecStore()
+    const file = new File(['bad'], 'dec.xlsx')
+    const error = new Error('upload failed')
+    fetchWrapper.postFile.mockRejectedValue(error)
+
+    await expect(store.upload(file)).rejects.toThrow('upload failed')
+    expect(store.error).toBe(error)
+    expect(store.loading).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add a DEC Pinia store that wraps the backend DEC upload endpoint
- cover the new store with unit tests for success and failure cases
- remove the unused `uploadFile` ref from the DEC store and its tests

## Testing
- npm run test -- dec.store.spec.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc47a9a108321a82dd1b3769cf3bd)