### PR TITLE
Use consolidated next parcels endpoint

### DIFF
--- a/src/dialogs/OzonParcel_EditDialog.vue
+++ b/src/dialogs/OzonParcel_EditDialog.vue
@@ -88,13 +88,6 @@ const nextParcelsResult = ref({ withoutIssues: null, withIssues: null })
 let nextParcelsPromise = null
 let nextParcelsParcelId = null
 
-function normalizeNextParcels(result) {
-  return {
-    withoutIssues: result?.withoutIssues ?? result?.WithoutIssues ?? null,
-    withIssues: result?.withIssues ?? result?.WithIssues ?? null
-  }
-}
-
 function initNextParcelsPromise(id) {
   if (nextParcelsPromise != null && nextParcelsParcelId === id) {
     // already initialized for this parcel
@@ -107,9 +100,8 @@ function initNextParcelsPromise(id) {
   nextParcelsPromise = registersStore
     .nextParcels(id)
     .then(result => {
-      const normalized = normalizeNextParcels(result)
-      nextParcelsResult.value = normalized
-      return normalized
+      nextParcelsResult.value = result
+      return result
     })
 }
 

--- a/src/dialogs/WbrParcel_EditDialog.vue
+++ b/src/dialogs/WbrParcel_EditDialog.vue
@@ -88,13 +88,6 @@ const nextParcelsResult = ref({ withoutIssues: null, withIssues: null })
 let nextParcelsPromise = null
 let nextParcelsParcelId = null
 
-function normalizeNextParcels(result) {
-  return {
-    withoutIssues: result?.withoutIssues ?? result?.WithoutIssues ?? null,
-    withIssues: result?.withIssues ?? result?.WithIssues ?? null
-  }
-}
-
 function initNextParcelsPromise(id) {
   if (nextParcelsPromise != null && nextParcelsParcelId === id) {
     // already initialized for this parcel
@@ -107,9 +100,8 @@ function initNextParcelsPromise(id) {
   nextParcelsPromise = registersStore
     .nextParcels(id)
     .then(result => {
-      const normalized = normalizeNextParcels(result)
-      nextParcelsResult.value = normalized
-      return normalized
+      nextParcelsResult.value = result
+      return result
     })
 }
 

--- a/src/stores/registers.store.js
+++ b/src/stores/registers.store.js
@@ -371,6 +371,9 @@ export const useRegistersStore = defineStore('registers', () => {
       const params = buildParcelsFilterParams(authStore)
 
       const result = await fetchWrapper.get(`${baseUrl}/nextparcels/${parcelId}?${params.toString()}`)
+      if (!result) {
+        return { withoutIssues: null, withIssues: null }
+      }
       return {
         withoutIssues: result?.withoutIssues ?? result?.WithoutIssues ?? null,
         withIssues: result?.withIssues ?? result?.WithIssues ?? null

--- a/tests/registers.store.spec.js
+++ b/tests/registers.store.spec.js
@@ -1148,14 +1148,14 @@ describe('registers store', () => {
       }
       useAuthStore.mockReturnValueOnce(customAuthStore)
 
-      const response = { withoutIssues: { id: 3 }, withIssues: { id: 4 } }
+      const response = { WithoutIssues: { id: 3 }, WithIssues: { id: 4 } }
       fetchWrapper.get.mockResolvedValue(response)
       const store = useRegistersStore()
       const result = await store.nextParcels(7)
       expect(fetchWrapper.get).toHaveBeenCalledWith(
         `${apiUrl}/registers/nextparcels/7?sortBy=tnVed&sortOrder=desc`
       )
-      expect(result).toEqual(response)
+      expect(result).toEqual({ withoutIssues: response.WithoutIssues, withIssues: response.WithIssues })
     })
 
     it('requests next parcels with filtering parameters', async () => {


### PR DESCRIPTION
## Summary
- replace separate next-parcel store calls with a unified `nextParcels` method that normalizes API responses
- update parcel edit dialogs to use the combined next parcels promise and pass it through to dependent components
- refresh related unit tests for the new endpoint and prop naming

## Testing
- npm test -- tests/registers.store.spec.js tests/FeacnCodeEditor.spec.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f81848f8c8321859c5d221f4a295d)