### PR TITLE
Add parcel event processing settings view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -204,6 +204,9 @@ async function onReportFileSelected(event) {
         <v-list-item>
           <RouterLink to="/parcelstatuses" class="link">Статусы посылок</RouterLink>
         </v-list-item>
+        <v-list-item v-if="authStore.isAdminOrSrLogist">
+          <RouterLink to="/parceleventprocessing" class="link">Обработка событий посылок</RouterLink>
+        </v-list-item>
           <v-list-item>
             <RouterLink to="/stopwords" class="link">Стоп-слова</RouterLink>
           </v-list-item>

--- a/src/dialogs/ParcelEventsProcessing_Settings.vue
+++ b/src/dialogs/ParcelEventsProcessing_Settings.vue
@@ -1,0 +1,143 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { computed, onMounted, ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import router from '@/router'
+import { useParcelProcessingEventsStore } from '@/stores/parcel.processing.events.store.js'
+import { useParcelStatusesStore } from '@/stores/parcel.statuses.store.js'
+
+const parcelProcessingEventsStore = useParcelProcessingEventsStore()
+const parcelStatusesStore = useParcelStatusesStore()
+
+const { events, loading } = storeToRefs(parcelProcessingEventsStore)
+const { parcelStatuses } = storeToRefs(parcelStatusesStore)
+
+const statusSelections = ref({})
+const saving = ref(false)
+const initializing = ref(true)
+const errorMessage = ref('')
+
+const hasEvents = computed(() => events.value?.length > 0)
+
+function getEventTitle(event) {
+  return event.eventName || event.eventId
+}
+
+function onStatusChange(eventId, value) {
+  const newValue = value === '' ? null : Number(value)
+  statusSelections.value = {
+    ...statusSelections.value,
+    [eventId]: Number.isNaN(newValue) ? null : newValue
+  }
+}
+
+async function loadData() {
+  initializing.value = true
+  errorMessage.value = ''
+  try {
+    await parcelStatusesStore.ensureLoaded()
+    await parcelProcessingEventsStore.getAll()
+    statusSelections.value = events.value.reduce((result, item) => {
+      result[item.id] = item.parcelStatusId ?? null
+      return result
+    }, {})
+  } catch (error) {
+    errorMessage.value = error?.message || 'Не удалось загрузить настройки событий посылок'
+  } finally {
+    initializing.value = false
+  }
+}
+
+async function saveSettings() {
+  saving.value = true
+  errorMessage.value = ''
+  try {
+    const payload = events.value.map((item) => ({
+      id: item.id,
+      parcelStatusId: statusSelections.value[item.id] ?? null
+    }))
+
+    await parcelProcessingEventsStore.updateMany(payload)
+    await loadData()
+  } catch (error) {
+    errorMessage.value = error?.message || 'Не удалось сохранить изменения'
+  } finally {
+    saving.value = false
+  }
+}
+
+function cancel() {
+  router.back()
+}
+
+onMounted(async () => {
+  await loadData()
+})
+</script>
+
+<template>
+  <div class="settings form-2" data-testid="parcel-events-processing-settings">
+    <h1 class="primary-heading">Настройки обработки событий посылок</h1>
+    <hr class="hr" />
+
+    <div v-if="initializing" class="text-center m-5">
+      <span class="spinner-border spinner-border-lg align-center"></span>
+    </div>
+
+    <div v-else>
+      <div v-if="errorMessage" class="alert alert-danger mt-3 mb-0">{{ errorMessage }}</div>
+
+      <div v-if="loading" class="text-center m-5">
+        <span class="spinner-border spinner-border-lg align-center"></span>
+      </div>
+
+      <div v-else-if="hasEvents" class="parcel-events-table">
+        <div class="table-header">
+          <div class="table-cell">Событие</div>
+          <div class="table-cell">Статус посылки</div>
+        </div>
+        <div
+          v-for="event in events"
+          :key="event.id"
+          class="table-row"
+          data-testid="parcel-event-row"
+        >
+          <div class="table-cell label" :data-testid="`event-title-${event.id}`">{{ getEventTitle(event) }}</div>
+          <div class="table-cell selector">
+            <select
+              class="form-control input"
+              :id="`status-select-${event.id}`"
+              :value="statusSelections[event.id] ?? ''"
+              @change="onStatusChange(event.id, $event.target.value)">
+              <option value="">Не выбрано</option>
+              <option
+                v-for="status in parcelStatuses"
+                :key="status.id"
+                :value="status.id"
+              >
+                {{ status.title }}
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div v-else class="text-center m-5">Список событий пуст</div>
+
+      <div class="form-group mt-8">
+        <button class="button primary" type="button" :disabled="saving || initializing" @click="saveSettings">
+          <span v-show="saving" class="spinner-border spinner-border-sm mr-1"></span>
+          <font-awesome-icon size="1x" icon="fa-solid fa-check-double" class="mr-1" />
+          Сохранить
+        </button>
+        <button class="button secondary" type="button" :disabled="saving" @click="cancel">
+          <font-awesome-icon size="1x" icon="fa-solid fa-xmark" class="mr-1" />
+          Отменить
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -119,6 +119,12 @@ const router = createRouter({
       meta: { reqAnyRole: true }
     },
     {
+      path: '/parceleventprocessing',
+      name: 'Обработка событий посылок',
+      component: () => import('@/views/ParcelEventProcessing_View.vue'),
+      meta: { reqAdminOrSrLogist: true }
+    },
+    {
       path: '/parcelstatus/create',
       name: 'Регистрация статуса посылки',
       component: () => import('@/views/ParcelStatus_CreateView.vue'),

--- a/src/views/ParcelEventProcessing_View.vue
+++ b/src/views/ParcelEventProcessing_View.vue
@@ -1,0 +1,11 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import ParcelEventsProcessingSettings from '@/dialogs/ParcelEventsProcessing_Settings.vue'
+</script>
+
+<template>
+  <ParcelEventsProcessingSettings />
+</template>

--- a/tests/ParcelEventProcessing_View.spec.js
+++ b/tests/ParcelEventProcessing_View.spec.js
@@ -1,0 +1,22 @@
+/* @vitest-environment jsdom */
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ParcelEventProcessingView from '@/views/ParcelEventProcessing_View.vue'
+
+vi.mock('@/dialogs/ParcelEventsProcessing_Settings.vue', () => ({
+  default: {
+    name: 'ParcelEventsProcessingSettings',
+    template: '<div data-testid="parcel-events-processing-settings-stub" />'
+  }
+}))
+
+describe('ParcelEventProcessing_View.vue', () => {
+  it('renders settings dialog wrapper', () => {
+    const wrapper = mount(ParcelEventProcessingView)
+    expect(wrapper.find('[data-testid="parcel-events-processing-settings-stub"]').exists()).toBe(true)
+  })
+})

--- a/tests/ParcelEventsProcessing_Settings.spec.js
+++ b/tests/ParcelEventsProcessing_Settings.spec.js
@@ -1,0 +1,127 @@
+/* @vitest-environment jsdom */
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import ParcelEventsProcessingSettings from '@/dialogs/ParcelEventsProcessing_Settings.vue'
+import { resolveAll } from './helpers/test-utils'
+
+const mockEvents = ref([
+  { id: 1, eventId: 'Created', eventName: 'Создана', parcelStatusId: null },
+  { id: 2, eventId: 'Processing', eventName: 'В обработке', parcelStatusId: 3 }
+])
+
+const mockStatuses = ref([
+  { id: 1, title: 'Новый' },
+  { id: 3, title: 'В пути' }
+])
+
+const ensureLoaded = vi.hoisted(() => vi.fn())
+const getAll = vi.hoisted(() => vi.fn())
+const updateMany = vi.hoisted(() => vi.fn())
+const routerBack = vi.hoisted(() => vi.fn())
+
+vi.mock('@/stores/parcel.processing.events.store.js', () => ({
+  useParcelProcessingEventsStore: () => ({
+    events: mockEvents,
+    loading: ref(false),
+    getAll,
+    updateMany
+  })
+}))
+
+vi.mock('@/stores/parcel.statuses.store.js', () => ({
+  useParcelStatusesStore: () => ({
+    parcelStatuses: mockStatuses,
+    ensureLoaded
+  })
+}))
+
+vi.mock('@/router', () => ({
+  default: {
+    back: routerBack
+  }
+}))
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return {
+    ...actual,
+    storeToRefs: (store) => ({ ...store })
+  }
+})
+
+const mountComponent = () =>
+  mount(ParcelEventsProcessingSettings, {
+    global: {
+      stubs: {
+        'font-awesome-icon': true
+      }
+    }
+  })
+
+describe('ParcelEventsProcessing_Settings.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEvents.value = [
+      { id: 1, eventId: 'Created', eventName: 'Создана', parcelStatusId: null },
+      { id: 2, eventId: 'Processing', eventName: 'В обработке', parcelStatusId: 3 }
+    ]
+    mockStatuses.value = [
+      { id: 1, title: 'Новый' },
+      { id: 3, title: 'В пути' }
+    ]
+    ensureLoaded.mockResolvedValue()
+    getAll.mockImplementation(async () => {
+      mockEvents.value = [...mockEvents.value]
+    })
+    updateMany.mockResolvedValue()
+  })
+
+  it('renders event rows with selectors', async () => {
+    const wrapper = mountComponent()
+    await resolveAll()
+
+    expect(ensureLoaded).toHaveBeenCalled()
+    expect(getAll).toHaveBeenCalled()
+
+    const rows = wrapper.findAll('[data-testid="parcel-event-row"]')
+    expect(rows.length).toBe(2)
+    expect(wrapper.find('[data-testid="event-title-1"]').text()).toBe('Создана')
+
+    const options = wrapper.find('#status-select-1').findAll('option')
+    const optionTexts = options.map((o) => o.text())
+    expect(optionTexts).toContain('Новый')
+    expect(optionTexts).toContain('В пути')
+  })
+
+  it('updates selections and saves changes', async () => {
+    const wrapper = mountComponent()
+    await resolveAll()
+
+    const select = wrapper.find('#status-select-1')
+    await select.setValue('1')
+    await wrapper.find('button.button.primary').trigger('click')
+    await resolveAll()
+
+    expect(updateMany).toHaveBeenCalledWith([
+      { id: 1, parcelStatusId: 1 },
+      { id: 2, parcelStatusId: 3 }
+    ])
+  })
+
+  it('shows error message when save fails', async () => {
+    updateMany.mockRejectedValue(new Error('Save failed'))
+
+    const wrapper = mountComponent()
+    await resolveAll()
+
+    await wrapper.find('button.button.primary').trigger('click')
+    await resolveAll()
+
+    expect(wrapper.text()).toContain('Save failed')
+  })
+})


### PR DESCRIPTION
## Summary
- add parcel event processing settings dialog that maps events to parcel statuses using backend stores
- wire the new settings view into routing and navigation for admin logist users
- cover the new dialog and view with focused unit tests

## Testing
- npm test -- ParcelEventsProcessing
- npm test -- ParcelEventProcessing_View

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692175d148ec8321a43ad4492c6a15f9)