### PR TITLE
Add header upload action to customs reports list

### DIFF
--- a/tests/UploadCustomsReports_List.spec.js
+++ b/tests/UploadCustomsReports_List.spec.js
@@ -4,7 +4,7 @@
 // This file is a part of Logibooks ui application
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import { ref } from 'vue'
 import UploadCustomsReportsList from '@/lists/UploadCustomsReports_List.vue'
 import { defaultGlobalStubs } from './helpers/test-utils.js'
@@ -15,14 +15,25 @@ const errorRef = ref(null)
 const alertRef = ref(null)
 
 const getReportsMock = vi.hoisted(() => vi.fn())
+const uploadMock = vi.hoisted(() => vi.fn())
 const clearMock = vi.hoisted(() => vi.fn())
+const alertErrorMock = vi.hoisted(() => vi.fn())
 
 let decsStoreMock
 let alertStoreMock
 
 const testStubs = {
   ...defaultGlobalStubs,
-  'font-awesome-icon': { template: '<i class="fa-icon-stub" />' }
+  'font-awesome-icon': { template: '<i class="fa-icon-stub" />' },
+  'v-btn': {
+    inheritAttrs: false,
+    emits: ['click'],
+    template: '<button class="v-btn-stub" data-testid="v-btn" v-bind="$attrs" @click="$emit(\'click\', $event)"><slot></slot></button>'
+  },
+  ActionDialog: {
+    props: ['actionDialog'],
+    template: '<div class="action-dialog-stub" :data-show="actionDialog?.show" :data-title="actionDialog?.title"></div>'
+  }
 }
 
 vi.mock('pinia', async () => {
@@ -62,12 +73,14 @@ describe('UploadCustomsReports_List.vue', () => {
       reports: reportsRef,
       loading: loadingRef,
       error: errorRef,
-      getReports: getReportsMock
+      getReports: getReportsMock,
+      upload: uploadMock
     }
 
     alertStoreMock = {
       alert: alertRef,
-      clear: clearMock
+      clear: clearMock,
+      error: alertErrorMock
     }
   })
 
@@ -139,5 +152,118 @@ describe('UploadCustomsReports_List.vue', () => {
     })
 
     expect(wrapper.text()).toContain('Список отчетов пуст')
+  })
+
+  it('shows header upload button and triggers file input', async () => {
+    const wrapper = mount(UploadCustomsReportsList, {
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    await wrapper.vm.$nextTick()
+
+    const headerActions = wrapper.find('.header-actions .v-btn-stub')
+    expect(headerActions.exists()).toBe(true)
+
+    const input = wrapper.find('[data-testid="reports-upload-input"]')
+    const clickSpy = vi.fn()
+    Object.defineProperty(input.element, 'click', {
+      value: clickSpy,
+      writable: true
+    })
+
+    await headerActions.trigger('click')
+    expect(clickSpy).toHaveBeenCalled()
+  })
+
+  it('uploads a report from the header action and refreshes the list', async () => {
+    getReportsMock.mockResolvedValue()
+    const wrapper = mount(UploadCustomsReportsList, {
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    await flushPromises()
+
+    let resolveUpload
+    const uploadPromise = new Promise((resolve) => {
+      resolveUpload = resolve
+    })
+    uploadMock.mockReturnValue(uploadPromise)
+
+    const input = wrapper.find('[data-testid="reports-upload-input"]')
+    const file = new File(['dummy'], 'report.xlsx', { type: 'application/vnd.ms-excel' })
+    Object.defineProperty(input.element, 'files', {
+      value: [file],
+      configurable: true
+    })
+    let assignedInputValue = null
+    Object.defineProperty(input.element, 'value', {
+      configurable: true,
+      get() {
+        return assignedInputValue ?? ''
+      },
+      set(v) {
+        assignedInputValue = v
+      }
+    })
+
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+
+    await input.trigger('change')
+    await wrapper.vm.$nextTick()
+
+    expect(uploadMock).toHaveBeenCalledWith(file)
+    expect(wrapper.find('.action-dialog-stub').attributes('data-show')).toBe('true')
+
+    resolveUpload()
+    await flushPromises()
+
+    const dispatchedEvent = dispatchSpy.mock.calls.find((call) => call[0] instanceof globalThis.CustomEvent)
+    expect(dispatchedEvent?.[0].detail).toEqual({ fileName: 'report.xlsx' })
+    expect(getReportsMock).toHaveBeenCalledTimes(2)
+    expect(wrapper.find('.action-dialog-stub').attributes('data-show')).toBe('false')
+    expect(assignedInputValue).toBe('')
+    expect(alertErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('handles upload errors and clears the file input', async () => {
+    getReportsMock.mockResolvedValue()
+    const wrapper = mount(UploadCustomsReportsList, {
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    await flushPromises()
+
+    uploadMock.mockRejectedValue(new Error('upload failed'))
+
+    const input = wrapper.find('[data-testid="reports-upload-input"]')
+    const file = new File(['dummy'], 'broken.xlsx', { type: 'application/vnd.ms-excel' })
+    Object.defineProperty(input.element, 'files', {
+      value: [file],
+      configurable: true
+    })
+    let assignedInputValue = null
+    Object.defineProperty(input.element, 'value', {
+      configurable: true,
+      get() {
+        return assignedInputValue ?? ''
+      },
+      set(v) {
+        assignedInputValue = v
+      }
+    })
+
+    await input.trigger('change')
+    await flushPromises()
+
+    expect(uploadMock).toHaveBeenCalledWith(file)
+    expect(alertErrorMock).toHaveBeenCalledWith('upload failed')
+    expect(wrapper.find('.action-dialog-stub').attributes('data-show')).toBe('false')
+    expect(assignedInputValue).toBe('')
   })
 })


### PR DESCRIPTION
## Summary
- add a header upload action with hidden file input to the customs reports list
- reuse the upload workflow to dispatch update events and refresh the list after uploading
- add unit tests covering the new header action flow and error handling

## Testing
- npm test -- UploadCustomsReports_List.spec.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923b2b70d248321b7dbcfe764f55c6e)