### PR TITLE
Validate TnVed length in parcel edit dialogs

### DIFF
--- a/src/dialogs/OzonParcel_EditDialog.vue
+++ b/src/dialogs/OzonParcel_EditDialog.vue
@@ -139,7 +139,9 @@ onUnmounted(() => {
 const schema = Yup.object().shape({
   statusId: Yup.number(),
   checkStatus: Yup.number(),
-  tnVed: Yup.string().required('Необходимо указать ТН ВЭД'),
+  tnVed: Yup.string()
+    .required('Необходимо указать ТН ВЭД')
+    .matches(/^\d{10}$/, 'Код ТН ВЭД должен содержать ровно 10 цифр'),
   countryCode: Yup.number().required('Необходимо выбрать страну'),
   invoiceDate: Yup.date().nullable(),
   weightKg: Yup.number().nullable().min(0, 'Вес не может быть отрицательным'),

--- a/src/dialogs/WbrParcel_EditDialog.vue
+++ b/src/dialogs/WbrParcel_EditDialog.vue
@@ -140,7 +140,9 @@ onUnmounted(() => {
 
 const schema = Yup.object().shape({
   statusId: Yup.number().required('Необходимо выбрать статус'),
-  tnVed: Yup.string().required('Необходимо указать ТН ВЭД'),
+  tnVed: Yup.string()
+    .required('Необходимо указать ТН ВЭД')
+    .matches(/^\d{10}$/, 'Код ТН ВЭД должен содержать ровно 10 цифр'),
   countryCode: Yup.number().required('Необходимо выбрать страну'),
   invoiceDate: Yup.date().nullable(),
   weightKg: Yup.number().nullable().min(0, 'Вес не может быть отрицательным'),


### PR DESCRIPTION
## Summary
- enforce a strict 10-digit numeric validation for TnVed in the Wbr parcel edit dialog
- apply the same 10-digit TnVed validation to the Ozon parcel edit dialog

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692765c4756c8321b1d8f28f2ed50f05)