### PR TITLE
Make customs report parcel numbers clickable

### DIFF
--- a/src/lists/CustomsReportRows_List.vue
+++ b/src/lists/CustomsReportRows_List.vue
@@ -12,6 +12,8 @@ import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
 import TruncateTooltipCell from '@/components/TruncateTooltipCell.vue'
 import PaginationFooter from '@/components/PaginationFooter.vue'
 import { mdiMagnify } from '@mdi/js'
+import router from '@/router'
+import ClickableCell from '@/components/ClickableCell.vue'
 const props = defineProps({
   reportId: {
     type: Number,
@@ -163,6 +165,12 @@ const pageOptions = computed(() => {
   return Array.from(set).sort((a, b) => a - b).map(n => ({ value: n, title: String(n) }))
 })
 
+function openParcelsByNumber(item) {
+  if (!item?.parcelNumber) return
+  authStore.parcels_number = item.parcelNumber
+  router.push('/parcels/by-number')
+}
+
 // Navigation handled by parent view; no local back action
 </script>
 
@@ -229,6 +237,15 @@ const pageOptions = computed(() => {
               <TruncateTooltipCell
                 v-else-if="TRUNCATABLE_COLUMNS.includes(col.key)"
                 :text="item[col.key]"
+              />
+
+              <ClickableCell
+                v-else-if="col.key === 'parcelNumber'"
+                :item="item"
+                :display-value="item.parcelNumber"
+                cell-class="truncated-cell clickable-cell"
+                :data-testid="`customs-report-row-parcel-number-${item.parcelNumber}`"
+                @click="() => openParcelsByNumber(item)"
               />
 
               <!-- Fallback for all other columns -->

--- a/tests/CustomsReportRows_List.spec.js
+++ b/tests/CustomsReportRows_List.spec.js
@@ -16,6 +16,7 @@ const alertRef = ref(null)
 const perPageRef = ref(10)
 const sortByRef = ref([{ key: 'rowNumber', order: 'asc' }])
 const pageRef = ref(1)
+const parcelsNumberRef = ref('')
 
 const getReportRowsMock = vi.hoisted(() => vi.fn())
 const clearMock = vi.hoisted(() => vi.fn())
@@ -108,6 +109,15 @@ vi.mock('@/router', () => ({
   }
 }))
 
+vi.mock('@/components/ClickableCell.vue', () => ({
+  default: {
+    name: 'ClickableCell',
+    template: '<button class="clickable-cell" @click="$emit(\'click\', item)">{{ displayValue }}</button>',
+    props: ['item', 'displayValue', 'cellClass', 'dataTestid'],
+    emits: ['click']
+  }
+}))
+
 describe('CustomsReportRows_List.vue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -115,6 +125,7 @@ describe('CustomsReportRows_List.vue', () => {
     loadingRef.value = false
     errorRef.value = null
     alertRef.value = null
+    parcelsNumberRef.value = ''
 
     decsStoreMock = {
       reportRows: reportRowsRef,
@@ -146,6 +157,12 @@ describe('CustomsReportRows_List.vue', () => {
         get: () => pageRef.value,
         set: (val) => {
           pageRef.value = val
+        }
+      },
+      parcels_number: {
+        get: () => parcelsNumberRef.value,
+        set: (val) => {
+          parcelsNumberRef.value = val
         }
       }
     })
@@ -245,5 +262,30 @@ describe('CustomsReportRows_List.vue', () => {
     await flushPromises()
 
     expect(wrapper.find('h1').text()).toContain('Отчёт о выпуске для №42')
+  })
+
+  it('routes to parcels by number when parcel number is clicked', async () => {
+    reportRowsRef.value = [
+      {
+        id: 11,
+        parcelNumber: 'PN-123',
+        rowNumber: 1,
+        dTag: 'DT001'
+      }
+    ]
+
+    const wrapper = mount(CustomsReportRowsList, {
+      props: { reportId: 5 },
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    await flushPromises()
+
+    await wrapper.find('.clickable-cell').trigger('click')
+
+    expect(parcelsNumberRef.value).toBe('PN-123')
+    expect(routerPushMock).toHaveBeenCalledWith('/parcels/by-number')
   })
 })


### PR DESCRIPTION
### Motivation
- Allow users to jump from a customs report row directly to the parcel search view by parcel number for faster investigation.
- Reuse the existing `ClickableCell` UX pattern used elsewhere (e.g. `Registers_List`) to provide consistent behavior.
- Keep navigation state in sync by setting the search input in `authStore` before routing to the parcel lookup page.

### Description
- Import `router` and `ClickableCell` and add `openParcelsByNumber(item)` which sets `authStore.parcels_number` and calls `router.push('/parcels/by-number')`.
- Render the `parcelNumber` column using `ClickableCell` with `@click` wired to `openParcelsByNumber` and include a `data-testid` for testing.
- Add a mock `ClickableCell` in tests and expose `parcels_number` on the `authStore` mock to observe the store update.
- Add a unit test that clicks the parcel number cell and asserts `authStore.parcels_number` was set and `router.push` was called.

### Testing
- Ran `npm run test -- tests/CustomsReportRows_List.spec.js` and the spec suite completed successfully with 6 tests passing.
- An earlier incorrect invocation with duplicate `--run` flags failed due to CLI argument parsing, but the corrected test run passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952a0f679b88321b998f6b5b2665cdc)