### PR TITLE
Add product image actions to parcel edit dialogs

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1472,6 +1472,12 @@ a,
   font-size: 0.875rem;    /* Make no-link text smaller */
 }
 
+.product-link-with-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 /*
 .form-compact .button {
   font-size: 0.875rem;    
@@ -1508,6 +1514,17 @@ a,
 
 .product-link-in-list:hover {
   text-decoration: underline;
+}
+
+/* Shared styles for inline action button bars */
+.action-buttons {
+  display: flex;
+  gap: 0.25rem;
+  background: #ffffff;
+  border: 1px solid #74777c;
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2), 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 /* Shared styles for consolidated action buttons in tables */

--- a/src/components/CheckStatusActionsBar.vue
+++ b/src/components/CheckStatusActionsBar.vue
@@ -24,18 +24,6 @@ defineProps({
 defineEmits(['validate-sw', 'validate-sw-ex', 'validate-fc', 'approve', 'approve-excise'])
 </script>
 
-<style scoped>
-.action-buttons {
-  display: flex;
-  gap: 0.25rem;
-  background: #ffffff;
-  border: 1px solid #74777c;
-  border-radius: 0.5rem;
-  padding: 0.5rem;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2), 0 1px 2px rgba(0, 0, 0, 0.1);
-}
-</style>
-
 <template>
   <div class="action-buttons">
     <ActionButton

--- a/src/components/ProductImageActionsBar.vue
+++ b/src/components/ProductImageActionsBar.vue
@@ -1,0 +1,45 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { computed } from 'vue'
+import ActionButton from '@/components/ActionButton.vue'
+
+const props = defineProps({
+  item: {
+    type: Object,
+    required: true
+  },
+  hasImage: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const emit = defineEmits(['view', 'remove'])
+
+const isDisabled = computed(() => !props.hasImage)
+</script>
+
+<template>
+  <div class="action-buttons">
+    <ActionButton
+      :item="item"
+      icon="fa-solid fa-eye"
+      tooltip-text="Посмотреть изображение для тех. документации"
+      :disabled="isDisabled"
+      @click="emit('view', item)"
+      :iconSize="'1x'"
+    />
+    <ActionButton
+      :item="item"
+      icon="fa-solid fa-trash-can"
+      tooltip-text="Удалить изображение для тех. документации"
+      :disabled="isDisabled"
+      @click="emit('remove', item)"
+      variant="red"
+      :iconSize="'1x'"
+    />
+  </div>
+</template>

--- a/src/dialogs/OzonParcel_EditDialog.vue
+++ b/src/dialogs/OzonParcel_EditDialog.vue
@@ -26,6 +26,7 @@ import OzonFormField from '@/components/OzonFormField.vue'
 import { ensureHttps } from '@/helpers/url.helpers.js'
 import ParcelHeaderActionsBar from '@/components/ParcelHeaderActionsBar.vue'
 import CheckStatusActionsBar from '@/components/CheckStatusActionsBar.vue'
+import ProductImageActionsBar from '@/components/ProductImageActionsBar.vue'
 import FeacnCodeEditor from '@/components/FeacnCodeEditor.vue'
 import ParcelNumberExt from '@/components/ParcelNumberExt.vue'
 import ArticleWithH from '@/components/ArticleWithH.vue'
@@ -127,6 +128,14 @@ watch(() => item.value?.statusId, (newStatusId) => {
 }, { immediate: true })
 
 const productLinkWithProtocol = computed(() => ensureHttps(item.value?.productLink))
+
+function viewProductImage() {
+  // Stub action for viewing the technical documentation image
+}
+
+function removeProductImage() {
+  // Stub action for removing the technical documentation image
+}
 
 // Pre-fetch next parcels after component is mounted
 onMounted(() => {
@@ -491,7 +500,8 @@ async function onLookup(values) {
         />
         <div class="form-group">
           <label class="label">{{ ozonRegisterColumnTitles.productLink }}:</label>
-          <a
+          <div class="product-link-with-actions">
+            <a
               v-if="item?.productLink"
               :href="productLinkWithProtocol"
               target="_blank"
@@ -501,7 +511,14 @@ async function onLookup(values) {
               {{ productLinkWithProtocol }}
             </a>
             <span v-else class="no-link">Ссылка отсутствует</span>
+            <ProductImageActionsBar
+              :item="item"
+              :has-image="item?.hasImage"
+              @view="viewProductImage"
+              @remove="removeProductImage"
+            />
           </div>
+        </div>
           <OzonFormField name="countryCode" as="select" :errors="errors" :fullWidth="false">
             <option value="">Выберите страну</option>
             <option v-for="country in countries" :key="country.id" :value="country.isoNumeric">

--- a/src/dialogs/WbrParcel_EditDialog.vue
+++ b/src/dialogs/WbrParcel_EditDialog.vue
@@ -27,6 +27,7 @@ import { ensureHttps } from '@/helpers/url.helpers.js'
 import ActionButton from '@/components/ActionButton.vue'
 import ParcelHeaderActionsBar from '@/components/ParcelHeaderActionsBar.vue'
 import CheckStatusActionsBar from '@/components/CheckStatusActionsBar.vue'
+import ProductImageActionsBar from '@/components/ProductImageActionsBar.vue'
 import FeacnCodeEditor from '@/components/FeacnCodeEditor.vue'
 import ParcelNumberExt from '@/components/ParcelNumberExt.vue'
 import { handleFellowsClick } from '@/helpers/parcel.number.ext.helpers.js'
@@ -126,6 +127,14 @@ watch(() => item.value?.statusId, (newStatusId) => {
 }, { immediate: true })
 
 const productLinkWithProtocol = computed(() => ensureHttps(item.value?.productLink))
+
+function viewProductImage() {
+  // Stub action for viewing the technical documentation image
+}
+
+function removeProductImage() {
+  // Stub action for removing the technical documentation image
+}
 
 const isDescriptionVisible = ref(false)
 
@@ -493,16 +502,24 @@ async function onLookup(values) {
 
           <div class="form-group">
             <label class="label">{{ wbrRegisterColumnTitles.productLink }}:</label>
-            <a
-              v-if="item?.productLink"
-              :href="productLinkWithProtocol"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="product-link-inline"
-            >
-              {{ productLinkWithProtocol }}
-            </a>
-            <span v-else class="no-link">Ссылка отсутствует</span>
+            <div class="product-link-with-actions">
+              <a
+                v-if="item?.productLink"
+                :href="productLinkWithProtocol"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="product-link-inline"
+              >
+                {{ productLinkWithProtocol }}
+              </a>
+              <span v-else class="no-link">Ссылка отсутствует</span>
+              <ProductImageActionsBar
+                :item="item"
+                :has-image="item?.hasImage"
+                @view="viewProductImage"
+                @remove="removeProductImage"
+              />
+            </div>
           </div>
           <WbrFormField name="countryCode" as="select" :errors="errors" :fullWidth="false">
             <option value="">Выберите страну</option>

--- a/tests/ProductImageActionsBar.spec.js
+++ b/tests/ProductImageActionsBar.spec.js
@@ -1,0 +1,108 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import ProductImageActionsBar from '@/components/ProductImageActionsBar.vue'
+import ActionButton from '@/components/ActionButton.vue'
+
+vi.mock('@fortawesome/vue-fontawesome', () => ({
+  FontAwesomeIcon: {
+    name: 'FontAwesomeIcon',
+    template: '<i class="fa-icon" :class="[icon]"></i>',
+    props: ['icon', 'size', 'class']
+  }
+}))
+
+const globalComponents = {
+  'font-awesome-icon': {
+    name: 'FontAwesomeIcon',
+    template: '<i class="fa-icon" :class="[icon]"></i>',
+    props: ['icon', 'size', 'class']
+  }
+}
+
+const vuetify = createVuetify({
+  components,
+  directives
+})
+
+describe('ProductImageActionsBar', () => {
+  const defaultProps = {
+    item: { id: 10, hasImage: true },
+    hasImage: true
+  }
+
+  function createWrapper(props = {}) {
+    return mount(ProductImageActionsBar, {
+      props: { ...defaultProps, ...props },
+      global: {
+        plugins: [vuetify],
+        components: globalComponents
+      }
+    })
+  }
+
+  it('renders two ActionButton components', () => {
+    const wrapper = createWrapper()
+    const buttons = wrapper.findAllComponents(ActionButton)
+
+    expect(buttons).toHaveLength(2)
+  })
+
+  it('renders view image button with correct props', () => {
+    const wrapper = createWrapper()
+    const [viewButton] = wrapper.findAllComponents(ActionButton)
+
+    expect(viewButton.props('icon')).toBe('fa-solid fa-eye')
+    expect(viewButton.props('tooltipText')).toBe('Посмотреть изображение для тех. документации')
+    expect(viewButton.props('item')).toEqual(defaultProps.item)
+    expect(viewButton.props('disabled')).toBe(false)
+    expect(viewButton.props('iconSize')).toBe('1x')
+  })
+
+  it('renders remove image button with correct props', () => {
+    const wrapper = createWrapper()
+    const [, removeButton] = wrapper.findAllComponents(ActionButton)
+
+    expect(removeButton.props('icon')).toBe('fa-solid fa-trash-can')
+    expect(removeButton.props('tooltipText')).toBe('Удалить изображение для тех. документации')
+    expect(removeButton.props('item')).toEqual(defaultProps.item)
+    expect(removeButton.props('disabled')).toBe(false)
+    expect(removeButton.props('variant')).toBe('red')
+    expect(removeButton.props('iconSize')).toBe('1x')
+  })
+
+  it('disables both buttons when hasImage is false', () => {
+    const wrapper = createWrapper({ hasImage: false })
+    const buttons = wrapper.findAllComponents(ActionButton)
+
+    buttons.forEach(button => {
+      expect(button.props('disabled')).toBe(true)
+    })
+  })
+
+  it('emits view event when view button is clicked', async () => {
+    const wrapper = createWrapper()
+    const [viewButton] = wrapper.findAllComponents(ActionButton)
+
+    await viewButton.vm.$emit('click')
+
+    expect(wrapper.emitted('view')).toBeTruthy()
+    expect(wrapper.emitted('view')?.[0]).toEqual([defaultProps.item])
+  })
+
+  it('emits remove event when remove button is clicked', async () => {
+    const wrapper = createWrapper()
+    const [, removeButton] = wrapper.findAllComponents(ActionButton)
+
+    await removeButton.vm.$emit('click')
+
+    expect(wrapper.emitted('remove')).toBeTruthy()
+    expect(wrapper.emitted('remove')?.[0]).toEqual([defaultProps.item])
+  })
+})


### PR DESCRIPTION
### Motivation
- Provide an inline action panel next to the `productLink` field in parcel edit dialogs to view or remove technical documentation images.
- Buttons should mirror the existing action-bar design and be enabled only when `item.hasImage` is true.
- Avoid duplication by extracting a reusable component for the image actions and reuse the existing `ActionButton` primitive.
- Stub the actual view/remove behaviors for now so UI and tests can be added first.

### Description
- Added a new reusable component `ProductImageActionsBar.vue` that renders two `ActionButton` instances (icons `fa-eye` and `fa-trash-can`) and disables them when `hasImage` is false.
- Integrated `ProductImageActionsBar` into `OzonParcel_EditDialog.vue` and `WbrParcel_EditDialog.vue` next to the product link and added stub handlers `viewProductImage` and `removeProductImage`.
- Centralized shared `.action-buttons` CSS into `src/assets/main.css` and removed the duplicate scoped style from `CheckStatusActionsBar.vue` so the new component reuses the same styling.
- Added unit tests `tests/ProductImageActionsBar.spec.js` to validate rendering, props, disabled state, and emitted events.

### Testing
- Ran `npm run lint` and the linter completed successfully without errors.
- Ran `npm run test` (Vitest) and the full test suite passed.
- New unit tests `tests/ProductImageActionsBar.spec.js` were executed as part of the test run and succeeded.
- Visual verification performed by launching the dev server and capturing a screenshot of the updated dialogs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cd3b801488321a51774f72589f523)