### PR TITLE
Add product link action panel to parcel edit dialogs

### DIFF
--- a/src/components/ParcelProductLinkPanel.vue
+++ b/src/components/ParcelProductLinkPanel.vue
@@ -1,0 +1,102 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application 
+
+import { computed } from 'vue'
+import ActionButton from '@/components/ActionButton.vue'
+import { ensureHttps } from '@/helpers/url.helpers.js'
+
+const props = defineProps({
+  item: {
+    type: Object,
+    default: () => ({})
+  },
+  label: {
+    type: String,
+    required: true
+  },
+  productLink: {
+    type: String,
+    default: ''
+  },
+  disabled: {
+    type: Boolean,
+    default: false
+  }
+})
+
+defineEmits(['view-image', 'delete-image'])
+
+const productLinkWithProtocol = computed(() => ensureHttps(props.productLink))
+const actionsDisabled = computed(() => props.disabled || !props.item?.hasImage)
+</script>
+
+<template>
+  <div class="product-link-panel">
+    <label class="label">{{ label }}:</label>
+    <div class="product-link-content">
+      <div class="product-link-text">
+        <a
+          v-if="productLinkWithProtocol"
+          :href="productLinkWithProtocol"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="product-link-inline"
+        >
+          {{ productLinkWithProtocol }}
+        </a>
+        <span v-else class="no-link">Ссылка отсутствует</span>
+      </div>
+      <div class="product-link-actions">
+        <ActionButton
+          :item="item"
+          icon="fa-solid fa-eye"
+          tooltip-text="Посмотреть изображение для тех. документации"
+          :disabled="actionsDisabled"
+          @click="$emit('view-image')"
+          :iconSize="'1x'"
+        />
+        <ActionButton
+          :item="item"
+          icon="fa-solid fa-trash-can"
+          tooltip-text="Удалить изображение для тех. документации"
+          :disabled="actionsDisabled"
+          @click="$emit('delete-image')"
+          :iconSize="'1x'"
+          variant="red"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.product-link-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.product-link-content {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.product-link-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.product-link-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 0.25rem;
+  background: #ffffff;
+  border: 1px solid #74777c;
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2), 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+</style>

--- a/src/dialogs/OzonParcel_EditDialog.vue
+++ b/src/dialogs/OzonParcel_EditDialog.vue
@@ -17,18 +17,18 @@ import { useParcelViewsStore } from '@/stores/parcel.views.store.js'
 import { storeToRefs } from 'pinia'
 import { useAuthStore } from '@/stores/auth.store.js'
 import { useAlertStore } from '@/stores/alert.store.js'
-import { ref, watch, computed, onMounted, onUnmounted } from 'vue'
+import { ref, watch, onMounted, onUnmounted } from 'vue'
 import { ozonRegisterColumnTitles, ozonRegisterColumnTooltips } from '@/helpers/ozon.register.mapping.js'
 import { getCheckStatusInfo, getCheckStatusClass } from '@/helpers/parcels.check.helpers.js'
 import { CheckStatusCode } from '@/helpers/check.status.code.js'
 import { useRegistersStore } from '@/stores/registers.store.js'
 import OzonFormField from '@/components/OzonFormField.vue'
-import { ensureHttps } from '@/helpers/url.helpers.js'
 import ParcelHeaderActionsBar from '@/components/ParcelHeaderActionsBar.vue'
 import CheckStatusActionsBar from '@/components/CheckStatusActionsBar.vue'
 import FeacnCodeEditor from '@/components/FeacnCodeEditor.vue'
 import ParcelNumberExt from '@/components/ParcelNumberExt.vue'
 import ArticleWithH from '@/components/ArticleWithH.vue'
+import ParcelProductLinkPanel from '@/components/ParcelProductLinkPanel.vue'
 import { handleFellowsClick } from '@/helpers/parcel.number.ext.helpers.js'
 import {
   validateParcelData,
@@ -126,8 +126,6 @@ watch(() => item.value?.statusId, (newStatusId) => {
   currentStatusId.value = newStatusId
 }, { immediate: true })
 
-const productLinkWithProtocol = computed(() => ensureHttps(item.value?.productLink))
-
 // Pre-fetch next parcels after component is mounted
 onMounted(() => {
   window.addEventListener(DEC_REPORT_UPLOADED_EVENT, refreshParcelAfterReportUpload)
@@ -215,6 +213,14 @@ async function approveParcelWithNotification(values) {
   } finally {
     if (isComponentMounted.value) runningAction.value = false
   }
+}
+
+function onViewTechDocImage() {
+  // Stub action: view tech documentation image
+}
+
+function onDeleteTechDocImage() {
+  // Stub action: delete tech documentation image
 }
 
 async function refreshParcelAfterReportUpload() {
@@ -490,18 +496,15 @@ async function onLookup(values) {
           @approve-notification="approveParcelWithNotification(values)"
         />
         <div class="form-group">
-          <label class="label">{{ ozonRegisterColumnTitles.productLink }}:</label>
-          <a
-              v-if="item?.productLink"
-              :href="productLinkWithProtocol"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="product-link-inline"
-            >
-              {{ productLinkWithProtocol }}
-            </a>
-            <span v-else class="no-link">Ссылка отсутствует</span>
-          </div>
+          <ParcelProductLinkPanel
+            :item="item"
+            :label="ozonRegisterColumnTitles.productLink"
+            :product-link="item?.productLink"
+            :disabled="isSubmitting || runningAction || loading"
+            @view-image="onViewTechDocImage"
+            @delete-image="onDeleteTechDocImage"
+          />
+        </div>
           <OzonFormField name="countryCode" as="select" :errors="errors" :fullWidth="false">
             <option value="">Выберите страну</option>
             <option v-for="country in countries" :key="country.id" :value="country.isoNumeric">

--- a/src/dialogs/WbrParcel_EditDialog.vue
+++ b/src/dialogs/WbrParcel_EditDialog.vue
@@ -18,17 +18,17 @@ import { useRegistersStore } from '@/stores/registers.store.js'
 import { useAuthStore } from '@/stores/auth.store.js'
 import { useAlertStore } from '@/stores/alert.store.js'
 import { storeToRefs } from 'pinia'
-import { ref, watch, computed, onMounted, onUnmounted } from 'vue'
+import { ref, watch, onMounted, onUnmounted } from 'vue'
 import { wbrRegisterColumnTitles, wbrRegisterColumnTooltips } from '@/helpers/wbr.register.mapping.js'
 import { getCheckStatusInfo, getCheckStatusClass } from '@/helpers/parcels.check.helpers.js'
 import { CheckStatusCode } from '@/helpers/check.status.code.js'
 import WbrFormField from '@/components/WbrFormField.vue'
-import { ensureHttps } from '@/helpers/url.helpers.js'
 import ActionButton from '@/components/ActionButton.vue'
 import ParcelHeaderActionsBar from '@/components/ParcelHeaderActionsBar.vue'
 import CheckStatusActionsBar from '@/components/CheckStatusActionsBar.vue'
 import FeacnCodeEditor from '@/components/FeacnCodeEditor.vue'
 import ParcelNumberExt from '@/components/ParcelNumberExt.vue'
+import ParcelProductLinkPanel from '@/components/ParcelProductLinkPanel.vue'
 import { handleFellowsClick } from '@/helpers/parcel.number.ext.helpers.js'
 import {
   validateParcelData,
@@ -125,8 +125,6 @@ watch(() => item.value?.statusId, (newStatusId) => {
   currentStatusId.value = newStatusId
 }, { immediate: true })
 
-const productLinkWithProtocol = computed(() => ensureHttps(item.value?.productLink))
-
 const isDescriptionVisible = ref(false)
 
 // Pre-fetch next parcels after component is mounted
@@ -201,6 +199,14 @@ async function approveParcelWithExcise(values, setFieldValue) {
   } finally {
     if (isComponentMounted.value) runningAction.value = false
   }
+}
+
+function onViewTechDocImage() {
+  // Stub action: view tech documentation image
+}
+
+function onDeleteTechDocImage() {
+  // Stub action: delete tech documentation image
 }
 
 async function refreshParcelAfterReportUpload() {
@@ -492,17 +498,14 @@ async function onLookup(values) {
           </div>          
 
           <div class="form-group">
-            <label class="label">{{ wbrRegisterColumnTitles.productLink }}:</label>
-            <a
-              v-if="item?.productLink"
-              :href="productLinkWithProtocol"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="product-link-inline"
-            >
-              {{ productLinkWithProtocol }}
-            </a>
-            <span v-else class="no-link">Ссылка отсутствует</span>
+            <ParcelProductLinkPanel
+              :item="item"
+              :label="wbrRegisterColumnTitles.productLink"
+              :product-link="item?.productLink"
+              :disabled="isSubmitting || runningAction || loading"
+              @view-image="onViewTechDocImage"
+              @delete-image="onDeleteTechDocImage"
+            />
           </div>
           <WbrFormField name="countryCode" as="select" :errors="errors" :fullWidth="false">
             <option value="">Выберите страну</option>

--- a/tests/ParcelProductLinkPanel.spec.js
+++ b/tests/ParcelProductLinkPanel.spec.js
@@ -1,0 +1,111 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application 
+
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import ParcelProductLinkPanel from '@/components/ParcelProductLinkPanel.vue'
+import ActionButton from '@/components/ActionButton.vue'
+
+vi.mock('@fortawesome/vue-fontawesome', () => ({
+  FontAwesomeIcon: {
+    name: 'FontAwesomeIcon',
+    template: '<i class="fa-icon" :class="[icon]"></i>',
+    props: ['icon', 'size', 'class']
+  }
+}))
+
+const globalComponents = {
+  'font-awesome-icon': {
+    name: 'FontAwesomeIcon',
+    template: '<i class="fa-icon" :class="[icon]"></i>',
+    props: ['icon', 'size', 'class']
+  }
+}
+
+const vuetify = createVuetify({
+  components,
+  directives
+})
+
+describe('ParcelProductLinkPanel', () => {
+  const baseProps = {
+    item: { id: 1, hasImage: true },
+    label: 'Ссылка на товар',
+    productLink: 'example.com'
+  }
+
+  function createWrapper(props = {}) {
+    return mount(ParcelProductLinkPanel, {
+      props: { ...baseProps, ...props },
+      global: {
+        plugins: [vuetify],
+        components: globalComponents
+      }
+    })
+  }
+
+  it('renders the label text', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.find('label').text()).toBe('Ссылка на товар:')
+  })
+
+  it('renders a product link with https protocol', () => {
+    const wrapper = createWrapper({ productLink: 'example.com' })
+    const link = wrapper.find('a')
+    expect(link.exists()).toBe(true)
+    expect(link.text()).toBe('https://example.com')
+    expect(link.attributes('href')).toBe('https://example.com')
+  })
+
+  it('renders no-link text when productLink is empty', () => {
+    const wrapper = createWrapper({ productLink: '' })
+    expect(wrapper.find('.no-link').text()).toBe('Ссылка отсутствует')
+  })
+
+  it('disables action buttons when item has no image', () => {
+    const wrapper = createWrapper({ item: { id: 2, hasImage: false } })
+    const buttons = wrapper.findAllComponents(ActionButton)
+    expect(buttons).toHaveLength(2)
+    buttons.forEach(button => {
+      expect(button.props('disabled')).toBe(true)
+    })
+  })
+
+  it('disables action buttons when disabled prop is true', () => {
+    const wrapper = createWrapper({ disabled: true })
+    const buttons = wrapper.findAllComponents(ActionButton)
+    buttons.forEach(button => {
+      expect(button.props('disabled')).toBe(true)
+    })
+  })
+
+  it('enables action buttons when item has image and disabled is false', () => {
+    const wrapper = createWrapper({ item: { id: 3, hasImage: true }, disabled: false })
+    const buttons = wrapper.findAllComponents(ActionButton)
+    buttons.forEach(button => {
+      expect(button.props('disabled')).toBe(false)
+    })
+  })
+
+  it('emits view-image when view button is clicked', async () => {
+    const wrapper = createWrapper()
+    const buttons = wrapper.findAllComponents(ActionButton)
+
+    await buttons[0].vm.$emit('click')
+
+    expect(wrapper.emitted('view-image')).toBeTruthy()
+  })
+
+  it('emits delete-image when delete button is clicked', async () => {
+    const wrapper = createWrapper()
+    const buttons = wrapper.findAllComponents(ActionButton)
+
+    await buttons[1].vm.$emit('click')
+
+    expect(wrapper.emitted('delete-image')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
### Motivation
- Provide a reusable UI for the product link plus tech-doc image actions to avoid duplication across parcel edit dialogs. 
- Add right-aligned action buttons (view / delete) next to the product link, enabled only when `item.hasImage` is true. 
- Keep actions as stubs for now and keep the product link to occupy remaining horizontal space. 
- Maintain linting and testability while integrating into both Ozon and WBR parcel edit dialogs.

### Description
- Added a new component `ParcelProductLinkPanel.vue` that renders the product link text and a right-aligned action panel containing two `ActionButton` instances (`faEye` and `fa-trash-can`).
- Integrated `ParcelProductLinkPanel` into `OzonParcel_EditDialog.vue` and `WbrParcel_EditDialog.vue`, replacing inlined link markup and wiring `@view-image` and `@delete-image` to stub handlers. 
- Implemented computed `actionsDisabled` logic in the component so buttons are disabled if `props.disabled` is true or `item.hasImage` is falsy. 
- Added unit tests `tests/ParcelProductLinkPanel.spec.js` to cover rendering, link normalization (`https`), disabled states, and emitted events when buttons are clicked.

### Testing
- Ran `npm run lint` and the linter completed successfully. 
- Ran `npm run test` (Vitest) and the full test suite completed successfully with all tests passing. 
- New unit tests for the component were executed as part of the suite and passed. 
- Verified the app can start with `npm run dev` and a screenshot was captured during startup for basic smoke validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cdc11adc48321bd5b454c1c6b451e)