### PR TITLE
Add image viewer overlay for parcel dialogs (Ozon & WBR)

### DIFF
--- a/src/components/ParcelImageOverlay.vue
+++ b/src/components/ParcelImageOverlay.vue
@@ -1,0 +1,71 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application 
+
+defineProps({
+  open: { type: Boolean, default: false },
+  imageUrl: { type: String, default: '' },
+  loading: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['close'])
+</script>
+
+<template>
+  <div v-if="open" class="image-overlay" data-test="parcel-image-overlay">
+    <div class="image-overlay-content">
+      <button class="image-overlay-close" type="button" @click="emit('close')" aria-label="Close image overlay">
+        ×
+      </button>
+      <div v-if="loading" class="image-overlay-loading" data-test="parcel-image-loading">
+        Загрузка...
+      </div>
+      <img v-else-if="imageUrl" :src="imageUrl" alt="Parcel image" class="image-overlay-image" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.image-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.image-overlay-content {
+  position: relative;
+  background: #fff;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  max-width: 90vw;
+  max-height: 90vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.image-overlay-close {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.5rem;
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.image-overlay-image {
+  max-width: 86vw;
+  max-height: 86vh;
+  object-fit: contain;
+}
+
+.image-overlay-loading {
+  font-size: 1rem;
+}
+</style>

--- a/src/dialogs/OzonParcel_EditDialog.vue
+++ b/src/dialogs/OzonParcel_EditDialog.vue
@@ -30,6 +30,7 @@ import FeacnCodeEditor from '@/components/FeacnCodeEditor.vue'
 import ParcelNumberExt from '@/components/ParcelNumberExt.vue'
 import ArticleWithH from '@/components/ArticleWithH.vue'
 import ProductLinkWithActions from '@/components/ProductLinkWithActions.vue'
+import ParcelImageOverlay from '@/components/ParcelImageOverlay.vue'
 import { handleFellowsClick } from '@/helpers/parcel.number.ext.helpers.js'
 import {
   validateParcelData,
@@ -41,6 +42,7 @@ import {
 } from '@/helpers/parcel.actions.helpers.js'
 import { DEC_REPORT_UPLOADED_EVENT } from '@/helpers/dec.report.events.js'
 import { SwValidationMatchMode } from '@/models/sw.validation.match.mode.js'
+import { useParcelImageOverlay } from '@/helpers/parcel.image.overlay.js'
 
 const props = defineProps({
   registerId: { type: Number, required: true },
@@ -75,6 +77,13 @@ await parcelViewsStore.add(currentParcelId.value)
 const alertStore = useAlertStore()
 const { alert } = storeToRefs(alertStore)
 const confirm = useConfirm()
+const {
+  imageOverlayOpen,
+  imageUrl,
+  imageLoading,
+  openImageOverlay,
+  closeImageOverlay
+} = useParcelImageOverlay(parcelsStore, alertStore)
 
 // Set the selected parcel ID in auth store
 authStore.selectedParcelId = currentParcelId.value
@@ -138,6 +147,21 @@ onMounted(() => {
 onUnmounted(() => {
   isComponentMounted.value = false
   window.removeEventListener(DEC_REPORT_UPLOADED_EVENT, refreshParcelAfterReportUpload)
+  document.removeEventListener('keydown', handleImageOverlayEscape)
+})
+
+function handleImageOverlayEscape(event) {
+  if (event.key === 'Escape' && imageOverlayOpen.value) {
+    closeImageOverlay()
+  }
+}
+
+watch(imageOverlayOpen, (isOpen) => {
+  if (isOpen) {
+    document.addEventListener('keydown', handleImageOverlayEscape)
+  } else {
+    document.removeEventListener('keydown', handleImageOverlayEscape)
+  }
 })
 
 const schema = Yup.object().shape({
@@ -155,6 +179,10 @@ const schema = Yup.object().shape({
 
 async function deleteProductImage(values) {
   await deleteProductImageHelper(values, isComponentMounted, runningAction, currentParcelId, confirm, parcelsStore)
+}
+
+async function viewProductImage() {
+  await openImageOverlay(item.value?.id)
 }
 
 async function validateParcel(values, sw, matchMode) {
@@ -375,7 +403,7 @@ async function onLookup(values) {
       :initial-values="item" 
       :validation-schema="schema" 
       v-slot="{ errors, values, isSubmitting, setFieldValue }" 
-      :class="{ 'form-disabled': overlayActive }"
+      :class="{ 'form-disabled': overlayActive || imageOverlayOpen }"
     >
     <div class="header-with-actions">
       <h1 class="primary-heading">
@@ -498,6 +526,7 @@ async function onLookup(values) {
           :label="ozonRegisterColumnTitles.productLink"
           :item="item"
           :disabled="isSubmitting || runningAction || loading"
+          @view-image="viewProductImage"
           @delete-image="() => deleteProductImage(values)"
         />
           <OzonFormField name="countryCode" as="select" :errors="errors" :fullWidth="false">
@@ -554,6 +583,12 @@ async function onLookup(values) {
       {{ alert.message }}
     </div>
   </div>
+  <ParcelImageOverlay
+    :open="imageOverlayOpen"
+    :image-url="imageUrl"
+    :loading="imageLoading"
+    @close="closeImageOverlay"
+  />
 </template>
 
 <style scoped>

--- a/src/dialogs/WbrParcel_EditDialog.vue
+++ b/src/dialogs/WbrParcel_EditDialog.vue
@@ -30,6 +30,7 @@ import CheckStatusActionsBar from '@/components/CheckStatusActionsBar.vue'
 import FeacnCodeEditor from '@/components/FeacnCodeEditor.vue'
 import ParcelNumberExt from '@/components/ParcelNumberExt.vue'
 import ProductLinkWithActions from '@/components/ProductLinkWithActions.vue'
+import ParcelImageOverlay from '@/components/ParcelImageOverlay.vue'
 import { handleFellowsClick } from '@/helpers/parcel.number.ext.helpers.js'
 import {
   validateParcelData,
@@ -40,6 +41,7 @@ import {
 } from '@/helpers/parcel.actions.helpers.js'
 import { DEC_REPORT_UPLOADED_EVENT } from '@/helpers/dec.report.events.js'
 import { SwValidationMatchMode } from '@/models/sw.validation.match.mode.js'
+import { useParcelImageOverlay } from '@/helpers/parcel.image.overlay.js'
 
 const props = defineProps({
   registerId: { type: Number, required: true },
@@ -74,6 +76,13 @@ await parcelViewsStore.add(currentParcelId.value)
 const alertStore = useAlertStore()
 const { alert } = storeToRefs(alertStore)
 const confirm = useConfirm()
+const {
+  imageOverlayOpen,
+  imageUrl,
+  imageLoading,
+  openImageOverlay,
+  closeImageOverlay
+} = useParcelImageOverlay(parcelsStore, alertStore)
 
 // Set the selected parcel ID in auth store
 authStore.selectedParcelId = currentParcelId.value
@@ -139,6 +148,21 @@ onMounted(() => {
 onUnmounted(() => {
   isComponentMounted.value = false
   window.removeEventListener(DEC_REPORT_UPLOADED_EVENT, refreshParcelAfterReportUpload)
+  document.removeEventListener('keydown', handleImageOverlayEscape)
+})
+
+function handleImageOverlayEscape(event) {
+  if (event.key === 'Escape' && imageOverlayOpen.value) {
+    closeImageOverlay()
+  }
+}
+
+watch(imageOverlayOpen, (isOpen) => {
+  if (isOpen) {
+    document.addEventListener('keydown', handleImageOverlayEscape)
+  } else {
+    document.removeEventListener('keydown', handleImageOverlayEscape)
+  }
 })
 
 const schema = Yup.object().shape({
@@ -155,6 +179,10 @@ const schema = Yup.object().shape({
 
 async function deleteProductImage(values) {
   await deleteProductImageHelper(values, isComponentMounted, runningAction, currentParcelId, confirm, parcelsStore)
+}
+
+async function viewProductImage() {
+  await openImageOverlay(item.value?.id)
 }
 
 async function validateParcel(values, sw, matchMode) {
@@ -361,7 +389,7 @@ async function onLookup(values) {
       :initial-values="item" 
       :validation-schema="schema" 
       v-slot="{ errors, values, isSubmitting, setFieldValue }" 
-      :class="{ 'form-disabled': overlayActive }"
+      :class="{ 'form-disabled': overlayActive || imageOverlayOpen }"
     >
     <div class="header-with-actions">
       <h1 class="primary-heading">
@@ -499,6 +527,7 @@ async function onLookup(values) {
             :label="wbrRegisterColumnTitles.productLink"
             :item="item"
             :disabled="isSubmitting || runningAction || loading"
+            @view-image="viewProductImage"
             @delete-image="() => deleteProductImage(values)"
           />
           <WbrFormField name="countryCode" as="select" :errors="errors" :fullWidth="false">
@@ -550,6 +579,12 @@ async function onLookup(values) {
       {{ alert.message }}
     </div>
   </div>
+  <ParcelImageOverlay
+    :open="imageOverlayOpen"
+    :image-url="imageUrl"
+    :loading="imageLoading"
+    @close="closeImageOverlay"
+  />
 </template>
 
 <style scoped>

--- a/tests/OzonParcel_EditDialog.view.spec.js
+++ b/tests/OzonParcel_EditDialog.view.spec.js
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref, nextTick } from 'vue'
+import { resolveAll } from './helpers/test-utils'
+
+let confirmMock = null
+vi.mock('vuetify-use-dialog', () => ({
+  useConfirm: () => confirmMock
+}))
+
+const parcelsMock = {
+  item: ref({ id: 2, productLink: 'http://example.com', hasImage: true }),
+  loading: ref(false),
+  getImageProcessingUrl: vi.fn(() => 'http://test/api/parcels/2/image'),
+  getById: vi.fn().mockResolvedValue({ id: 2, hasImage: true })
+}
+vi.mock('@/stores/parcels.store.js', () => ({
+  useParcelsStore: () => parcelsMock
+}))
+
+const ensureLoadedFactory = () => ({ ensureLoaded: vi.fn().mockResolvedValue(), add: vi.fn().mockResolvedValue() })
+vi.mock('@/stores/parcel.statuses.store.js', () => ({ useParcelStatusesStore: () => ({ ensureLoaded: vi.fn().mockResolvedValue(), parcelStatuses: [] }) }))
+vi.mock('@/stores/stop.words.store.js', () => ({ useStopWordsStore: () => ensureLoadedFactory() }))
+vi.mock('@/stores/key.words.store.js', () => ({ useKeyWordsStore: () => ensureLoadedFactory() }))
+vi.mock('@/stores/feacn.orders.store.js', () => ({ useFeacnOrdersStore: () => ensureLoadedFactory() }))
+vi.mock('@/stores/feacn.prefixes.store.js', () => ({ useFeacnPrefixesStore: () => ensureLoadedFactory() }))
+vi.mock('@/stores/countries.store.js', () => ({ useCountriesStore: () => ({ ensureLoaded: vi.fn().mockResolvedValue(), countries: [] }) }))
+vi.mock('@/stores/parcel.views.store.js', () => ({ useParcelViewsStore: () => ({ add: vi.fn().mockResolvedValue() }) }))
+vi.mock('@/stores/registers.store.js', () => ({ useRegistersStore: () => ({ nextParcels: vi.fn().mockResolvedValue({ withoutIssues: null, withIssues: null }) }) }))
+
+vi.mock('@/stores/auth.store.js', () => ({ useAuthStore: () => ({ selectedParcelId: null }) }))
+const alertErrorMock = vi.fn()
+vi.mock('@/stores/alert.store.js', () => ({ useAlertStore: () => ({ alert: ref(null), error: alertErrorMock, clear: vi.fn() }) }))
+
+const getFileMock = vi.fn()
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: {
+    getFile: (...args) => getFileMock(...args)
+  }
+}))
+
+vi.mock('@/components/ProductLinkWithActions.vue', () => ({
+  default: { template: '<button data-test="view-btn" @click="$emit(\'view-image\')">View</button>' }
+}))
+
+import OzonParcel_EditDialog from '@/dialogs/OzonParcel_EditDialog.vue'
+
+describe('OzonParcel_EditDialog image overlay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    confirmMock = vi.fn()
+    getFileMock.mockResolvedValue({
+      blob: vi.fn().mockResolvedValue(new Blob(['test'], { type: 'image/png' }))
+    })
+    global.URL.createObjectURL = vi.fn(() => 'blob:mock')
+    global.URL.revokeObjectURL = vi.fn()
+  })
+
+  it('opens and closes overlay when view-image is triggered', async () => {
+    const TestWrapper = {
+      components: { OzonParcel_EditDialog },
+      template: '<Suspense><OzonParcel_EditDialog :registerId="1" :id="2" /></Suspense>'
+    }
+
+    const wrapper = mount(TestWrapper, {
+      global: {
+        stubs: {
+          Field: { template: '<input />' },
+          Form: {
+            template: '<div><slot :errors="{}" :values="{ id: 2 }" :isSubmitting="false" :setFieldValue="() => {}"></slot></div>'
+          },
+          ParcelHeaderActionsBar: true,
+          CheckStatusActionsBar: true,
+          FeacnCodeEditor: true,
+          ParcelNumberExt: true,
+          ArticleWithH: true,
+          ActionButton: true,
+          'font-awesome-icon': true,
+          VTooltip: true
+        }
+      }
+    })
+
+    await nextTick()
+    await resolveAll()
+
+    await wrapper.find('[data-test="view-btn"]').trigger('click')
+    await resolveAll()
+
+    expect(getFileMock).toHaveBeenCalledWith('http://test/api/parcels/2/image')
+    const overlay = wrapper.find('[data-test="parcel-image-overlay"]')
+    expect(overlay.exists()).toBe(true)
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await resolveAll()
+    expect(wrapper.find('[data-test="parcel-image-overlay"]').exists()).toBe(false)
+    expect(global.URL.revokeObjectURL).toHaveBeenCalled()
+  })
+})

--- a/tests/WbrParcel_EditDialog.view.spec.js
+++ b/tests/WbrParcel_EditDialog.view.spec.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref, nextTick } from 'vue'
+import { resolveAll } from './helpers/test-utils'
+
+let confirmMock = null
+vi.mock('vuetify-use-dialog', () => ({
+  useConfirm: () => confirmMock
+}))
+
+const parcelsMock = {
+  item: ref({ id: 3, productLink: 'http://example.com', hasImage: true }),
+  loading: ref(false),
+  getImageProcessingUrl: vi.fn(() => 'http://test/api/parcels/3/image'),
+  getById: vi.fn().mockResolvedValue({ id: 3, hasImage: true })
+}
+vi.mock('@/stores/parcels.store.js', () => ({
+  useParcelsStore: () => parcelsMock
+}))
+
+const ensureLoadedFactory = () => ({ ensureLoaded: vi.fn().mockResolvedValue(), add: vi.fn().mockResolvedValue() })
+vi.mock('@/stores/parcel.statuses.store.js', () => ({ useParcelStatusesStore: () => ({ ensureLoaded: vi.fn().mockResolvedValue(), parcelStatuses: [] }) }))
+vi.mock('@/stores/stop.words.store.js', () => ({ useStopWordsStore: () => ensureLoadedFactory() }))
+vi.mock('@/stores/key.words.store.js', () => ({ useKeyWordsStore: () => ensureLoadedFactory() }))
+vi.mock('@/stores/feacn.orders.store.js', () => ({ useFeacnOrdersStore: () => ensureLoadedFactory() }))
+vi.mock('@/stores/feacn.prefixes.store.js', () => ({ useFeacnPrefixesStore: () => ensureLoadedFactory() }))
+vi.mock('@/stores/countries.store.js', () => ({ useCountriesStore: () => ({ ensureLoaded: vi.fn().mockResolvedValue(), countries: [] }) }))
+vi.mock('@/stores/parcel.views.store.js', () => ({ useParcelViewsStore: () => ({ add: vi.fn().mockResolvedValue() }) }))
+vi.mock('@/stores/registers.store.js', () => ({ useRegistersStore: () => ({ nextParcels: vi.fn().mockResolvedValue({ withoutIssues: null, withIssues: null }) }) }))
+
+vi.mock('@/stores/auth.store.js', () => ({ useAuthStore: () => ({ selectedParcelId: null }) }))
+const alertErrorMock = vi.fn()
+vi.mock('@/stores/alert.store.js', () => ({ useAlertStore: () => ({ alert: ref(null), error: alertErrorMock, clear: vi.fn() }) }))
+
+const getFileMock = vi.fn()
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: {
+    getFile: (...args) => getFileMock(...args)
+  }
+}))
+
+vi.mock('@/components/ProductLinkWithActions.vue', () => ({
+  default: { template: '<button data-test="view-btn" @click="$emit(\'view-image\')">View</button>' }
+}))
+
+import WbrParcel_EditDialog from '@/dialogs/WbrParcel_EditDialog.vue'
+
+describe('WbrParcel_EditDialog image overlay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    confirmMock = vi.fn()
+    getFileMock.mockResolvedValue({
+      blob: vi.fn().mockResolvedValue(new Blob(['test'], { type: 'image/png' }))
+    })
+    global.URL.createObjectURL = vi.fn(() => 'blob:mock')
+    global.URL.revokeObjectURL = vi.fn()
+  })
+
+  it('opens and closes overlay when view-image is triggered', async () => {
+    const TestWrapper = {
+      components: { WbrParcel_EditDialog },
+      template: '<Suspense><WbrParcel_EditDialog :registerId="1" :id="3" /></Suspense>'
+    }
+
+    const wrapper = mount(TestWrapper, {
+      global: {
+        stubs: {
+          Field: { template: '<input />' },
+          Form: {
+            template: '<div><slot :errors="{}" :values="{ id: 3 }" :isSubmitting="false" :setFieldValue="() => {}"></slot></div>'
+          },
+          ParcelHeaderActionsBar: true,
+          CheckStatusActionsBar: true,
+          FeacnCodeEditor: true,
+          ParcelNumberExt: true,
+          ActionButton: true,
+          'font-awesome-icon': true,
+          VTooltip: true
+        }
+      }
+    })
+
+    await nextTick()
+    await resolveAll()
+
+    await wrapper.find('[data-test="view-btn"]').trigger('click')
+    await resolveAll()
+
+    expect(getFileMock).toHaveBeenCalledWith('http://test/api/parcels/3/image')
+    const overlay = wrapper.find('[data-test="parcel-image-overlay"]')
+    expect(overlay.exists()).toBe(true)
+
+    await overlay.find('button').trigger('click')
+    await resolveAll()
+    expect(wrapper.find('[data-test="parcel-image-overlay"]').exists()).toBe(false)
+    expect(global.URL.revokeObjectURL).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### Motivation
- Provide `view-image` support for Ozon and WBR parcel edit dialogs so users can view parcel images fetched from the backend as inline images.
- Use the existing API that returns raw image bytes (`GET /parcels/{id}/image`) and render images inline instead of forcing download.
- Ensure the overlay UI is minimal (only an `X` close button) and supports closing via the Escape key.
- Avoid code duplication by introducing a shared helper for fetch and object-URL lifecycle management.

### Description
- Added a shared composable `useParcelImageOverlay` that downloads image blobs using `fetchWrapper.getFile`, creates object URLs, manages loading state, and revokes URLs on close/unmount (`src/helpers/parcel.image.overlay.js`).
- Added `ParcelImageOverlay.vue`, a lightweight overlay component that shows a loading state, the image, and a single close (`X`) button (`src/components/ParcelImageOverlay.vue`).
- Wired the overlay into both parcel edit dialogs (`OzonParcel_EditDialog.vue` and `WbrParcel_EditDialog.vue`): hooked the `@view-image` event from `ProductLinkWithActions`, used the shared composable to open/close the overlay, and added Escape-key handling and form disabling while the overlay is open.
- Kept image fetching and cleanup in the shared helper to avoid duplicating fetch/object URL logic across dialogs.

### Testing
- Added unit tests `tests/OzonParcel_EditDialog.view.spec.js` and `tests/WbrParcel_EditDialog.view.spec.js` to cover the view-image flow and overlay open/close behavior.
- Ran the tests with `npm test -- tests/OzonParcel_EditDialog.view.spec.js tests/WbrParcel_EditDialog.view.spec.js` and both tests passed.
- The new helper/component are covered by the introduced tests that assert `fetchWrapper.getFile` is invoked, the overlay appears, and object URLs are revoked on close.
- All automated tests executed for these specs completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e39158f448321a4057bfe364aaa69)