### PR TITLE
Add `noHistoricData` prop to RegisterHeaderActionsBar

### DIFF
--- a/src/components/RegisterHeaderActionsBar.vue
+++ b/src/components/RegisterHeaderActionsBar.vue
@@ -12,6 +12,7 @@ const props = defineProps({
   disabled: { type: Boolean, default: false },
   iconSize: { type: String, default: '2x' },
   loading: { type: Boolean, default: false },
+  noHistoricData: { type: Boolean, default: false },
 })
 
 const emit = defineEmits([
@@ -69,7 +70,7 @@ function openInvoiceSettings(selection = InvoiceParcelSelection.All) {
         icon="fa-solid fa-book-journal-whills"
         tooltip-text="Проверить по стоп-словам с учётом исторических данных"
         :iconSize="iconSize"
-        :disabled="disabled"
+        :disabled="disabled || noHistoricData"
         @click="run('validate-sw-ex')"
       />
       <ActionButton
@@ -93,7 +94,7 @@ function openInvoiceSettings(selection = InvoiceParcelSelection.All) {
         icon="fa-solid fa-book-skull"
         tooltip-text="Подбор кодов ТН ВЭД с учётом исторических данных"
         :iconSize="iconSize"
-        :disabled="disabled"
+        :disabled="disabled || noHistoricData"
         @click="run('lookup-ex')"
       />
     </div>

--- a/src/lists/Wbr2Parcels_List.vue
+++ b/src/lists/Wbr2Parcels_List.vue
@@ -469,6 +469,7 @@ function getGenericTemplateHeaders() {
         :item="registersStore.item"
         :disabled="generalActionsDisabled"
         :loading="runningAction || loading || isInitializing"
+        :no-historic-data="true"
         @validate-sw="validateRegisterSwHeader"
         @validate-sw-ex="validateRegisterSwHeaderEx"
         @validate-fc="validateRegisterFcHeader"

--- a/tests/RegisterHeaderActionsBar.spec.js
+++ b/tests/RegisterHeaderActionsBar.spec.js
@@ -105,4 +105,31 @@ describe('RegisterHeaderActionsBar', () => {
 
     expect(pushMock).not.toHaveBeenCalled()
   })
+
+  it('disables historic data actions when noHistoricData is true', () => {
+    const wrapper = mount(RegisterHeaderActionsBar, {
+      props: { ...baseProps, noHistoricData: true },
+      global: { stubs: vuetifyStubs }
+    })
+
+    const actionButtons = wrapper.findAllComponents(ActionButton)
+    const getButtonByTooltip = (tooltipText) =>
+      actionButtons.find((button) => button.props('tooltipText') === tooltipText)
+
+    const stopWordsHistoric = getButtonByTooltip(
+      'Проверить по стоп-словам с учётом исторических данных'
+    )
+    const lookupHistoric = getButtonByTooltip(
+      'Подбор кодов ТН ВЭД с учётом исторических данных'
+    )
+    const stopWords = getButtonByTooltip('Проверить по стоп-словам')
+
+    expect(stopWordsHistoric).toBeTruthy()
+    expect(lookupHistoric).toBeTruthy()
+    expect(stopWords).toBeTruthy()
+
+    expect(stopWordsHistoric.props('disabled')).toBe(true)
+    expect(lookupHistoric.props('disabled')).toBe(true)
+    expect(stopWords.props('disabled')).toBe(false)
+  })
 })


### PR DESCRIPTION
### Motivation
- Provide a way to permanently disable historic-data actions (historic stop-words and historic FEACN lookup) when the header is used in contexts that should not access historical data, with a default of `false`.
- Specifically ensure `RegisterHeaderActionsBar` can be initialized from `Wbr2Parcels_List` with historic actions disabled.

### Description
- Add a `noHistoricData` prop to `RegisterHeaderActionsBar` with type `Boolean` and default `false` and use it to disable the two historic action buttons by changing their `:disabled` binding to `:disabled="disabled || noHistoricData"`.
- Pass `:no-historic-data="true"` from `Wbr2Parcels_List` when rendering `RegisterHeaderActionsBar` so historic actions are turned off for that list.
- Add a unit test in `tests/RegisterHeaderActionsBar.spec.js` that mounts `RegisterHeaderActionsBar` with `noHistoricData: true` and asserts that historic buttons are present but disabled while regular actions remain enabled.

### Testing
- Ran the linter via `npm run lint` and no lint errors remained after the changes (succeeded).
- Ran the full test suite via `npm test` and all tests passed, including the updated `tests/RegisterHeaderActionsBar.spec.js` (test run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e92abd5708321a868cd0ec04fde8d)