### PR TITLE
Add Wbr2FormField component, tests and wire into Wbr2Parcels_EditDialog

### DIFF
--- a/src/components/Wbr2FormField.vue
+++ b/src/components/Wbr2FormField.vue
@@ -1,0 +1,45 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application 
+
+import { Field } from 'vee-validate'
+import { wbr2RegisterColumnTitles } from '@/helpers/wbr2.register.mapping.js'
+
+defineProps({
+  name: { type: String, required: true },
+  type: { type: String, default: 'text' },
+  step: { type: String, default: null },
+  as: { type: String, default: null },
+  errors: { type: Object, default: () => ({}) },
+  fullWidth: { type: Boolean, default: true }
+})
+</script>
+
+<template>
+  <div :class="fullWidth ? 'form-group-1' : 'form-group'">
+    <label 
+      :for="name" 
+      :class="fullWidth ? 'label-1' : 'label'" 
+    >
+      {{ wbr2RegisterColumnTitles[name] }}:
+    </label>
+    <Field 
+      v-if="as === 'select'"
+      :name="name" 
+      :id="name" 
+      as="select"
+      :class="['form-control', fullWidth ? 'input-1' : 'input', { 'is-invalid': errors && errors[name] }]"
+    >
+      <slot />
+    </Field>
+    <Field 
+      v-else
+      :name="name" 
+      :id="name" 
+      :type="type || 'text'"
+      :step="step"
+      :class="['form-control', fullWidth ? 'input-1' : 'input', { 'is-invalid': errors && errors[name] }]"
+    />
+  </div>
+</template>

--- a/src/dialogs/Wbr2Parcels_EditDialog.vue
+++ b/src/dialogs/Wbr2Parcels_EditDialog.vue
@@ -23,7 +23,7 @@ import { useConfirm } from 'vuetify-use-dialog'
 import { wbr2RegisterColumnTitles, wbr2RegisterColumnTooltips } from '@/helpers/wbr2.register.mapping.js'
 import { getCheckStatusInfo, getCheckStatusClass } from '@/helpers/parcels.check.helpers.js'
 import { CheckStatusCode } from '@/helpers/check.status.code.js'
-import WbrFormField from '@/components/WbrFormField.vue'
+import Wbr2FormField from '@/components/Wbr2FormField.vue'
 import ParcelHeaderActionsBar from '@/components/ParcelHeaderActionsBar.vue'
 import CheckStatusActionsBar from '@/components/CheckStatusActionsBar.vue'
 import FeacnCodeEditor from '@/components/FeacnCodeEditor.vue'
@@ -504,19 +504,19 @@ async function onLookup(values) {
             @view-image="viewProductImage"
             @delete-image="() => deleteProductImage(values)"
           />
-          <WbrFormField name="countryCode" as="select" :errors="errors" :fullWidth="false">
+          <Wbr2FormField name="countryCode" as="select" :errors="errors" :fullWidth="false">
             <option value="">Выберите страну</option>
             <option v-for="country in countries" :key="country.id" :value="country.isoNumeric">
               {{ country.nameRuOfficial }}
             </option>
-          </WbrFormField>
-          <WbrFormField name="weightKg" type="number" step="1.0" :errors="errors" :fullWidth="false" />
-          <WbrFormField name="quantity" type="number" step="1.0" :errors="errors" :fullWidth="false" />
-          <WbrFormField name="currency" :errors="errors" :fullWidth="false" />
+          </Wbr2FormField>
+          <Wbr2FormField name="weightKg" type="number" step="1.0" :errors="errors" :fullWidth="false" />
+          <Wbr2FormField name="quantity" type="number" step="1.0" :errors="errors" :fullWidth="false" />
+          <Wbr2FormField name="currency" :errors="errors" :fullWidth="false" />
         </div>
         <div class="form-row">
-          <WbrFormField name="recipientName" :errors="errors" :fullWidth="false" />
-          <WbrFormField name="passportNumber" :errors="errors" :fullWidth="false" />
+          <Wbr2FormField name="recipientName" :errors="errors" :fullWidth="false" />
+          <Wbr2FormField name="passportNumber" :errors="errors" :fullWidth="false" />
         </div>
       </div>
       <!-- DTag -->

--- a/tests/Wbr2FormField.spec.js
+++ b/tests/Wbr2FormField.spec.js
@@ -1,0 +1,296 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application 
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import Wbr2FormField from '@/components/Wbr2FormField.vue'
+import { createPinia } from 'pinia'
+
+describe('Wbr2FormField', () => {
+  it('renders correctly with required props', () => {
+    const wrapper = mount(Wbr2FormField, {
+      props: {
+        name: 'tnVed',
+        errors: {}
+      },
+      global: {
+        plugins: [createPinia()],
+        stubs: {
+          Field: {
+            template: '<input :name="name" :id="id" :type="type" />',
+            props: ['name', 'id', 'type', 'step', 'as']
+          }
+        }
+      }
+    })
+
+    expect(wrapper.find('label').exists()).toBe(true)
+    expect(wrapper.find('input').exists()).toBe(true)
+    expect(wrapper.find('input').attributes('name')).toBe('tnVed')
+  })
+
+  it('displays validation error styling when errors exist', () => {
+    const wrapper = mount(Wbr2FormField, {
+      props: {
+        name: 'tnVed',
+        errors: { tnVed: 'Required field' }
+      },
+      global: {
+        plugins: [createPinia()],
+        stubs: {
+          Field: {
+            template: '<input :name="name" :class="classes" />',
+            props: ['name', 'class'],
+            computed: {
+              classes() {
+                return this.class
+              }
+            }
+          }
+        }
+      }
+    })
+
+    expect(wrapper.find('input').classes()).toContain('is-invalid')
+  })
+
+  it('renders select field when as="select" prop is provided', () => {
+    const wrapper = mount(Wbr2FormField, {
+      props: {
+        name: 'countryCode',
+        as: 'select',
+        errors: {}
+      },
+      slots: {
+        default: '<option value="1">Test Option</option>'
+      },
+      global: {
+        plugins: [createPinia()],
+        stubs: {
+          Field: {
+            template: '<select :name="name" :id="id"><slot /></select>',
+            props: ['name', 'id', 'as']
+          }
+        }
+      }
+    })
+
+    expect(wrapper.find('select').exists()).toBe(true)
+    expect(wrapper.find('select').attributes('name')).toBe('countryCode')
+    expect(wrapper.text()).toContain('Test Option')
+  })
+
+  it('renders input field with number type when type="number" is provided', () => {
+    const wrapper = mount(Wbr2FormField, {
+      props: {
+        name: 'quantity',
+        type: 'number',
+        step: '1',
+        errors: {}
+      },
+      global: {
+        plugins: [createPinia()],
+        stubs: {
+          Field: {
+            template: '<input :name="name" :id="id" :type="type" :step="step" />',
+            props: ['name', 'id', 'type', 'step']
+          }
+        }
+      }
+    })
+
+    expect(wrapper.find('input').exists()).toBe(true)
+    expect(wrapper.find('input').attributes('type')).toBe('number')
+    expect(wrapper.find('input').attributes('step')).toBe('1')
+  })
+
+  describe('fullWidth prop', () => {
+    it('uses full-width classes when fullWidth is true (default)', () => {
+      const wrapper = mount(Wbr2FormField, {
+        props: {
+          name: 'productName',
+          errors: {}
+        },
+        global: {
+          plugins: [createPinia()],
+          stubs: {
+            Field: {
+              template: '<input :name="name" :class="classes" />',
+              props: ['name', 'class'],
+              computed: {
+                classes() {
+                  return this.class
+                }
+              }
+            }
+          }
+        }
+      })
+
+      expect(wrapper.find('.form-group-1').exists()).toBe(true)
+      expect(wrapper.find('.label-1').exists()).toBe(true)
+      expect(wrapper.find('input').classes()).toContain('input-1')
+    })
+
+    it('uses full-width classes when fullWidth is explicitly true', () => {
+      const wrapper = mount(Wbr2FormField, {
+        props: {
+          name: 'productName',
+          fullWidth: true,
+          errors: {}
+        },
+        global: {
+          plugins: [createPinia()],
+          stubs: {
+            Field: {
+              template: '<input :name="name" :class="classes" />',
+              props: ['name', 'class'],
+              computed: {
+                classes() {
+                  return this.class
+                }
+              }
+            }
+          }
+        }
+      })
+
+      expect(wrapper.find('.form-group-1').exists()).toBe(true)
+      expect(wrapper.find('.label-1').exists()).toBe(true)
+      expect(wrapper.find('input').classes()).toContain('input-1')
+    })
+
+    it('uses standard classes when fullWidth is false', () => {
+      const wrapper = mount(Wbr2FormField, {
+        props: {
+          name: 'tnVed',
+          fullWidth: false,
+          errors: {}
+        },
+        global: {
+          plugins: [createPinia()],
+          stubs: {
+            Field: {
+              template: '<input :name="name" :class="classes" />',
+              props: ['name', 'class'],
+              computed: {
+                classes() {
+                  return this.class
+                }
+              }
+            }
+          }
+        }
+      })
+
+      expect(wrapper.find('.form-group').exists()).toBe(true)
+      expect(wrapper.find('.label').exists()).toBe(true)
+      expect(wrapper.find('input').classes()).toContain('input')
+      expect(wrapper.find('input').classes()).not.toContain('input-1')
+    })
+
+    it('applies fullWidth classes to select fields correctly', () => {
+      const wrapper = mount(Wbr2FormField, {
+        props: {
+          name: 'countryCode',
+          as: 'select',
+          fullWidth: false,
+          errors: {}
+        },
+        global: {
+          plugins: [createPinia()],
+          stubs: {
+            Field: {
+              template: '<select :name="name" :class="classes"><slot /></select>',
+              props: ['name', 'as', 'class'],
+              computed: {
+                classes() {
+                  return this.class
+                }
+              }
+            }
+          }
+        }
+      })
+
+      expect(wrapper.find('.form-group').exists()).toBe(true)
+      expect(wrapper.find('.label').exists()).toBe(true)
+      expect(wrapper.find('select').classes()).toContain('input')
+      expect(wrapper.find('select').classes()).not.toContain('input-1')
+    })
+
+    it('maintains validation error styling with different fullWidth values', () => {
+      const wrapper = mount(Wbr2FormField, {
+        props: {
+          name: 'tnVed',
+          fullWidth: false,
+          errors: { tnVed: 'Required field' }
+        },
+        global: {
+          plugins: [createPinia()],
+          stubs: {
+            Field: {
+              template: '<input :name="name" :class="classes" />',
+              props: ['name', 'class'],
+              computed: {
+                classes() {
+                  return this.class
+                }
+              }
+            }
+          }
+        }
+      })
+
+      expect(wrapper.find('input').classes()).toContain('is-invalid')
+      expect(wrapper.find('input').classes()).toContain('input')
+    })
+
+    it('displays correct label text from wbr2RegisterColumnTitles', () => {
+      const wrapper = mount(Wbr2FormField, {
+        props: {
+          name: 'tnVed',
+          fullWidth: false,
+          errors: {}
+        },
+        global: {
+          plugins: [createPinia()],
+          stubs: {
+            Field: {
+              template: '<input />',
+              props: ['name', 'id', 'type']
+            }
+          }
+        }
+      })
+
+      const label = wrapper.find('label')
+      expect(label.exists()).toBe(true)
+      expect(label.text()).toContain(':')
+    })
+
+    it('applies tooltip from wbr2RegisterColumnTooltips regardless of fullWidth', () => {
+      const wrapper = mount(Wbr2FormField, {
+        props: {
+          name: 'tnVed',
+          fullWidth: false,
+          errors: {}
+        },
+        global: {
+          plugins: [createPinia()],
+          stubs: {
+            Field: {
+              template: '<input />',
+              props: ['name', 'id', 'type']
+            }
+          }
+        }
+      })
+
+      const label = wrapper.find('label')
+      expect(label.exists()).toBe(true)
+      expect(label.attributes('title')).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
### Motivation
- Provide a dedicated form field component for WBR2 registers that uses the `wbr2` mapping instead of the original `wbr` mapping.

### Description
- Added `src/components/Wbr2FormField.vue` cloned from the existing form field and wired to `wbr2.register.mapping.js` to render WBR2 labels (`wbr2RegisterColumnTitles`).
- Added unit tests `tests/Wbr2FormField.spec.js` cloned and updated from the WBR variant to validate rendering, `select` behavior, classes, and error styling.
- Updated `src/dialogs/Wbr2Parcels_EditDialog.vue` to import and use `Wbr2FormField` in place of the old `WbrFormField` for WBR2 parcel fields.

### Testing
- Ran `npm run lint` and the linter completed successfully.
- Ran `npm test` and all unit tests passed; test summary shows `Test Files 132 passed` and `Tests 1756 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eb52d656c83218fd1a5752ce8e049)