### PR TITLE
Add warehouse-specific headers to Registers list and tests

### DIFF
--- a/src/lists/Registers_List.vue
+++ b/src/lists/Registers_List.vue
@@ -387,7 +387,7 @@ function formatInvoiceInfo(item) {
 
 
 
-const headers = [
+const defaultHeaders = [
   { title: '', key: 'actions', sortable: false, align: 'center' },
   { title: 'Номер сделки', key: 'dealNumber' },
   { title: 'ТСД', key: 'invoice' },
@@ -398,6 +398,19 @@ const headers = [
   { title: 'Стоимость общая / К оформлению', key: 'price', minWidth: '200px', width: '200px' },
   { title: 'Дата загрузки', key: 'date' }
 ]
+
+const warehouseHeaders = [
+  { title: '', key: 'actions', sortable: false, align: 'center' },
+  { title: 'Номер сделки', key: 'dealNumber' },
+  { title: 'Мастер-накладная', key: 'invoice' },
+  { title: 'Страны', key: 'countries' },
+  { title: 'Отправитель/Получатель', key: 'senderRecipient' },
+  { title: 'Статус', key: 'status' },
+  { title: 'Склад', key: 'warehouse' },
+  { title: 'Дата прибытия', key: 'arrivalDate' }
+]
+
+const headers = computed(() => (isWarehouseMode.value ? warehouseHeaders : defaultHeaders))
 
 defineExpose({
   validationState,
@@ -523,6 +536,15 @@ defineExpose({
               </div>
             </template>
           </ClickableCell>
+        </template>
+        <template #[`item.status`]="{ item }">
+          <span class="truncated-cell">{{ item.status }}</span>
+        </template>
+        <template #[`item.warehouse`]="{ item }">
+          <span class="truncated-cell">{{ item.warehouse }}</span>
+        </template>
+        <template #[`item.arrivalDate`]="{ item }">
+          <span class="truncated-cell">{{ formatDate(item.arrivalDate) }}</span>
         </template>
         <template #[`item.date`]="{ item }">
           <ClickableCell 

--- a/tests/Registers_List.warehouse.spec.js
+++ b/tests/Registers_List.warehouse.spec.js
@@ -218,6 +218,35 @@ describe('Registers_List.vue in warehouse mode', () => {
     expect(hasWarehouseTooltip).toBe(true)
   })
 
+  it('uses warehouse-specific table headers', async () => {
+    const wrapper = createWrapper()
+    await wrapper.vm.$nextTick()
+
+    const headerKeys = wrapper.vm.headers.map(header => header.key)
+    const headerTitles = wrapper.vm.headers.map(header => header.title)
+
+    expect(headerKeys).toEqual([
+      'actions',
+      'dealNumber',
+      'invoice',
+      'countries',
+      'senderRecipient',
+      'status',
+      'warehouse',
+      'arrivalDate'
+    ])
+    expect(headerTitles).toEqual([
+      '',
+      'Номер сделки',
+      'Мастер-накладная',
+      'Страны',
+      'Отправитель/Получатель',
+      'Статус',
+      'Склад',
+      'Дата прибытия'
+    ])
+  })
+
   it('uses warehouse-specific items-per-page text', async () => {
     const wrapper = createWrapper()
     await wrapper.vm.$nextTick()


### PR DESCRIPTION
### Motivation
- Warehouse operation mode requires a different set of table columns (status, warehouse, arrival date, and a "Мастер-накладная" label) than the paperwork mode.
- Tests should assert the warehouse-specific column layout and ensure the component renders the new fields in warehouse mode.

### Description
- Introduce `warehouseHeaders` and make `headers` a `computed` value that returns `warehouseHeaders` when `isWarehouseMode` is true and `defaultHeaders` otherwise in `src/lists/Registers_List.vue`.
- Add cell templates to render `status`, `warehouse` and `arrivalDate` values (`item.status`, `item.warehouse`, `item.arrivalDate`) and format `arrivalDate` with the existing `formatDate` helper in `src/lists/Registers_List.vue`.
- Keep existing default/paperwork headers intact as `defaultHeaders` and preserve prior templates for shared columns.
- Add a unit test in `tests/Registers_List.warehouse.spec.js` to assert the `headers` keys and titles for warehouse mode.

### Testing
- Ran linter via `npm run lint` and it completed successfully.
- Ran the full test suite with coverage via `npm run coverage`; the newly added warehouse header tests passed, however the full run ended with a failure caused by an unresolved import error for `pinia-plugin-persistedstate` in `tests/op.mode.store.spec.js`, so coverage did not complete cleanly.
- Created a visual snapshot of the registers view during development (artifact: `artifacts/registers-warehouse-columns.png`) to aid manual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697112a7dc8c8321ad2bd6a511e56456)