### PR TITLE
Add scan jobs management UI, store, routes, and tests

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -156,6 +156,9 @@ const opModeToggleIcon = computed(() =>
             <RouterLink to="/warehouses" class="link">Склады</RouterLink>
           </v-list-item>
           <v-list-item>
+            <RouterLink to="/scanjobs" class="link">Задания сканирования</RouterLink>
+          </v-list-item>
+          <v-list-item>
             <RouterLink to="/airports" class="link">Коды аэропортов</RouterLink>
           </v-list-item>
           <v-list-item>

--- a/src/dialogs/ScanJobs_Settings.vue
+++ b/src/dialogs/ScanJobs_Settings.vue
@@ -1,0 +1,292 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { ref, computed } from 'vue'
+import router from '@/router'
+import { storeToRefs } from 'pinia'
+import { Form, Field } from 'vee-validate'
+import * as Yup from 'yup'
+import { useScanJobsStore } from '@/stores/scanjobs.store.js'
+import { useWarehousesStore } from '@/stores/warehouses.store.js'
+import { useAlertStore } from '@/stores/alert.store.js'
+
+const props = defineProps({
+  mode: {
+    type: String,
+    required: true,
+    validator: (value) => ['create', 'edit'].includes(value)
+  },
+  scanjobId: {
+    type: Number,
+    required: false
+  }
+})
+
+const scanJobsStore = useScanJobsStore()
+const warehousesStore = useWarehousesStore()
+const alertStore = useAlertStore()
+
+const { warehouses } = storeToRefs(warehousesStore)
+
+const isCreate = computed(() => props.mode === 'create')
+
+await warehousesStore.getAll()
+
+const typeOptions = [
+  { value: 0, label: 'Посылка' },
+  { value: 1, label: 'Мешок' }
+]
+
+const operationOptions = [
+  { value: 0, label: 'Входящее' },
+  { value: 1, label: 'Исходящее' },
+  { value: 2, label: 'Поиск' }
+]
+
+const modeOptions = [
+  { value: 0, label: 'Ручное' },
+  { value: 1, label: 'Автоматическое' }
+]
+
+const statusOptions = [
+  { value: 0, label: 'В работе' },
+  { value: 1, label: 'Завершено' }
+]
+
+let scanJob = ref({
+  id: 0,
+  name: '',
+  type: 0,
+  operation: 0,
+  mode: 0,
+  status: 0,
+  warehouseId: null
+})
+
+if (!isCreate.value) {
+  ;({ scanJob } = storeToRefs(scanJobsStore))
+  await scanJobsStore.getById(props.scanjobId)
+}
+
+function getTitle() {
+  return isCreate.value ? 'Создание задания сканирования' : 'Редактировать задание сканирования'
+}
+
+function getButtonText() {
+  return isCreate.value ? 'Создать' : 'Сохранить'
+}
+
+const schema = Yup.object({
+  id: Yup.number().required(),
+  name: Yup.string().required('Название обязательно'),
+  type: Yup.number().required('Тип обязателен'),
+  operation: Yup.number().required('Операция обязательна'),
+  mode: Yup.number().required('Режим обязателен'),
+  status: Yup.number().required('Статус обязателен'),
+  warehouseId: Yup.number().required('Склад обязателен')
+})
+
+function normalizeValues(values) {
+  if (values && typeof values === 'object' && values.value && typeof values.value === 'object') {
+    return values.value
+  }
+  return values
+}
+
+function toNumberOrNull(value) {
+  if (value === null || value === undefined || value === '') {
+    return null
+  }
+  return Number(value)
+}
+
+function onSubmit(values, { setErrors }) {
+  const normalizedValues = normalizeValues(values) || {}
+  const payload = {
+    ...normalizedValues,
+    type: toNumberOrNull(normalizedValues.type),
+    operation: toNumberOrNull(normalizedValues.operation),
+    mode: toNumberOrNull(normalizedValues.mode),
+    status: toNumberOrNull(normalizedValues.status),
+    warehouseId: toNumberOrNull(normalizedValues.warehouseId)
+  }
+
+  if (isCreate.value) {
+    return scanJobsStore
+      .create(payload)
+      .then(() => {
+        router.push('/scanjobs')
+      })
+      .catch((error) => {
+        if (error.message?.includes('409')) {
+          setErrors({ apiError: 'Задание с таким названием уже существует' })
+        } else {
+          setErrors({ apiError: error.message || 'Ошибка при создании задания сканирования' })
+        }
+      })
+  }
+
+  return scanJobsStore
+    .update(props.scanjobId, payload)
+    .then(() => {
+      router.push('/scanjobs')
+    })
+    .catch((error) => {
+      setErrors({ apiError: error.message || 'Ошибка при сохранении задания сканирования' })
+    })
+}
+</script>
+
+<template>
+  <div class="settings form-2">
+    <h1 class="primary-heading">{{ getTitle() }}</h1>
+    <hr class="hr" />
+    <Form
+      @submit="onSubmit"
+      :initial-values="scanJob"
+      :validation-schema="schema"
+      v-slot="{ errors, isSubmitting }"
+    >
+      <div class="form-group">
+        <label for="name" class="label">Название:</label>
+        <Field
+          name="name"
+          id="name"
+          type="text"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.name }"
+          placeholder="Название"
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="warehouseId" class="label">Склад:</label>
+        <Field
+          name="warehouseId"
+          id="warehouseId"
+          as="select"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.warehouseId }"
+        >
+          <option value="">Выберите склад</option>
+          <option
+            v-for="warehouse in warehouses"
+            :key="warehouse.id"
+            :value="warehouse.id"
+          >
+            {{ warehouse.name }}
+          </option>
+        </Field>
+      </div>
+
+      <div class="form-group">
+        <label for="type" class="label">Тип:</label>
+        <Field
+          name="type"
+          id="type"
+          as="select"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.type }"
+        >
+          <option value="">Выберите тип</option>
+          <option
+            v-for="typeOption in typeOptions"
+            :key="typeOption.value"
+            :value="typeOption.value"
+          >
+            {{ typeOption.label }}
+          </option>
+        </Field>
+      </div>
+
+      <div class="form-group">
+        <label for="operation" class="label">Операция:</label>
+        <Field
+          name="operation"
+          id="operation"
+          as="select"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.operation }"
+        >
+          <option value="">Выберите операцию</option>
+          <option
+            v-for="operationOption in operationOptions"
+            :key="operationOption.value"
+            :value="operationOption.value"
+          >
+            {{ operationOption.label }}
+          </option>
+        </Field>
+      </div>
+
+      <div class="form-group">
+        <label for="mode" class="label">Режим:</label>
+        <Field
+          name="mode"
+          id="mode"
+          as="select"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.mode }"
+        >
+          <option value="">Выберите режим</option>
+          <option
+            v-for="modeOption in modeOptions"
+            :key="modeOption.value"
+            :value="modeOption.value"
+          >
+            {{ modeOption.label }}
+          </option>
+        </Field>
+      </div>
+
+      <div class="form-group">
+        <label for="status" class="label">Статус:</label>
+        <Field
+          name="status"
+          id="status"
+          as="select"
+          class="form-control input"
+          :class="{ 'is-invalid': errors.status }"
+        >
+          <option value="">Выберите статус</option>
+          <option
+            v-for="statusOption in statusOptions"
+            :key="statusOption.value"
+            :value="statusOption.value"
+          >
+            {{ statusOption.label }}
+          </option>
+        </Field>
+      </div>
+
+      <div class="form-group mt-8">
+        <button class="button primary" type="submit" :disabled="isSubmitting">
+          <span v-show="isSubmitting" class="spinner-border spinner-border-sm mr-1"></span>
+          <font-awesome-icon size="1x" icon="fa-solid fa-check-double" class="mr-1" />
+          {{ getButtonText() }}
+        </button>
+        <button
+          class="button secondary"
+          type="button"
+          data-testid="cancel-button"
+          @click="$router.push('/scanjobs')"
+        >
+          <font-awesome-icon size="1x" icon="fa-solid fa-xmark" class="mr-1" />
+          Отменить
+        </button>
+      </div>
+      <div v-if="errors.name" class="alert alert-danger mt-3 mb-0">{{ errors.name }}</div>
+      <div v-if="errors.warehouseId" class="alert alert-danger mt-3 mb-0">{{ errors.warehouseId }}</div>
+      <div v-if="errors.type" class="alert alert-danger mt-3 mb-0">{{ errors.type }}</div>
+      <div v-if="errors.operation" class="alert alert-danger mt-3 mb-0">{{ errors.operation }}</div>
+      <div v-if="errors.mode" class="alert alert-danger mt-3 mb-0">{{ errors.mode }}</div>
+      <div v-if="errors.status" class="alert alert-danger mt-3 mb-0">{{ errors.status }}</div>
+      <div v-if="errors.apiError" class="alert alert-danger mt-3 mb-0">{{ errors.apiError }}</div>
+      <div v-if="alertStore.alert" class="mt-3">
+        <div :class="['alert', alertStore.alert.type]" role="alert">{{ alertStore.alert.message }}</div>
+      </div>
+    </Form>
+  </div>
+</template>

--- a/src/lists/ScanJobs_List.vue
+++ b/src/lists/ScanJobs_List.vue
@@ -1,0 +1,313 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { computed, onMounted, onUnmounted, ref, watch, toRef } from 'vue'
+import router from '@/router'
+import { storeToRefs } from 'pinia'
+import { useScanJobsStore } from '@/stores/scanjobs.store.js'
+import { useWarehousesStore } from '@/stores/warehouses.store.js'
+import { useAuthStore } from '@/stores/auth.store.js'
+import { useAlertStore } from '@/stores/alert.store.js'
+import { useConfirm } from 'vuetify-use-dialog'
+import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
+import { mdiMagnify } from '@mdi/js'
+import { useDebouncedFilterSync } from '@/composables/useDebouncedFilterSync.js'
+import PaginationFooter from '@/components/PaginationFooter.vue'
+import ActionButton from '@/components/ActionButton.vue'
+
+const scanJobsStore = useScanJobsStore()
+const warehousesStore = useWarehousesStore()
+const authStore = useAuthStore()
+const alertStore = useAlertStore()
+const confirm = useConfirm()
+
+const scanjobs_search = toRef(authStore, 'scanjobs_search')
+const scanjobs_page = toRef(authStore, 'scanjobs_page')
+const scanjobs_per_page = toRef(authStore, 'scanjobs_per_page')
+const scanjobs_sort_by = toRef(authStore, 'scanjobs_sort_by')
+
+const { scanJobs, loading, error, totalCount } = storeToRefs(scanJobsStore)
+const { warehouses } = storeToRefs(warehousesStore)
+const { alert } = storeToRefs(alertStore)
+
+const localSearch = ref(scanjobs_search.value || '')
+const runningAction = ref(false)
+const isComponentMounted = ref(true)
+
+const typeOptions = [
+  { value: 0, label: 'Посылка' },
+  { value: 1, label: 'Мешок' }
+]
+
+const operationOptions = [
+  { value: 0, label: 'Входящее' },
+  { value: 1, label: 'Исходящее' },
+  { value: 2, label: 'Поиск' }
+]
+
+const modeOptions = [
+  { value: 0, label: 'Ручное' },
+  { value: 1, label: 'Автоматическое' }
+]
+
+const statusOptions = [
+  { value: 0, label: 'В работе' },
+  { value: 1, label: 'Завершено' }
+]
+
+const warehousesById = computed(() => {
+  if (!Array.isArray(warehouses.value)) return new Map()
+  return new Map(warehouses.value.map((warehouse) => [warehouse.id, warehouse]))
+})
+
+function getWarehouseName(id) {
+  const warehouse = warehousesById.value.get(Number(id))
+  return warehouse?.name || id
+}
+
+function getOptionLabel(options, value) {
+  const match = options.find((option) => option.value === Number(value))
+  return match ? match.label : value
+}
+
+function openEditDialog(scanJob) {
+  router.push('/scanjob/edit/' + scanJob.id)
+}
+
+function openCreateDialog() {
+  router.push('/scanjob/create')
+}
+
+async function deleteScanJob(scanJob) {
+  if (runningAction.value) return
+  runningAction.value = true
+  try {
+    const content = `Удалить задание сканирования "${scanJob.name}" ?`
+    const confirmed = await confirm({
+      title: 'Подтверждение',
+      confirmationText: 'Удалить',
+      cancellationText: 'Не удалять',
+      dialogProps: {
+        width: '30%',
+        minWidth: '250px'
+      },
+      confirmationButtonProps: {
+        color: 'orange-darken-3'
+      },
+      content
+    })
+
+    if (confirmed) {
+      try {
+        await scanJobsStore.remove(scanJob.id)
+      } catch (err) {
+        if (err.message?.includes('409')) {
+          alertStore.error('Нельзя удалить задание сканирования с зависимыми записями')
+        } else {
+          alertStore.error('Ошибка при удалении задания сканирования')
+        }
+      }
+    }
+  } finally {
+    runningAction.value = false
+  }
+}
+
+async function loadScanJobs() {
+  await scanJobsStore.getAll()
+}
+
+const { triggerLoad, stop: stopFilterSync } = useDebouncedFilterSync({
+  filters: [{ local: localSearch, store: scanjobs_search }],
+  loadFn: loadScanJobs,
+  isComponentMounted,
+  debounceMs: 300
+})
+
+const watcherStop = watch([scanjobs_page, scanjobs_per_page, scanjobs_sort_by], () => {
+  triggerLoad()
+}, { immediate: false })
+
+onMounted(async () => {
+  try {
+    await warehousesStore.getAll()
+    if (!isComponentMounted.value) return
+    await scanJobsStore.getAll()
+  } catch (err) {
+    if (isComponentMounted.value) {
+      scanJobsStore.error = err?.message || 'Ошибка при загрузке заданий сканирования'
+    }
+  }
+})
+
+onUnmounted(() => {
+  isComponentMounted.value = false
+  stopFilterSync()
+  if (watcherStop) {
+    watcherStop()
+  }
+})
+
+const baseHeaders = [
+  { title: 'Название', key: 'name', sortable: true },
+  { title: 'Склад', key: 'warehouseId', sortable: true },
+  { title: 'Тип', key: 'type', sortable: true },
+  { title: 'Операция', key: 'operation', sortable: true },
+  { title: 'Режим', key: 'mode', sortable: true },
+  { title: 'Статус', key: 'status', sortable: true }
+]
+
+const headers = computed(() => {
+  const list = [...baseHeaders]
+  if (authStore.isSrLogistPlus) {
+    list.unshift({ title: '', align: 'center', key: 'actions', sortable: false, width: '120px' })
+  }
+  return list
+})
+
+const maxPage = computed(() => Math.max(1, Math.ceil((totalCount.value || 0) / scanjobs_per_page.value)))
+
+const pageOptions = computed(() => {
+  const mp = maxPage.value
+  const current = scanjobs_page.value || 1
+  if (mp <= 200) {
+    return Array.from({ length: mp }, (_, i) => ({ value: i + 1, title: String(i + 1) }))
+  }
+
+  const set = new Set()
+  for (let i = 1; i <= 10; i++) set.add(i)
+  for (let i = Math.max(1, mp - 9); i <= mp; i++) set.add(i)
+  for (let i = Math.max(1, current - 10); i <= Math.min(mp, current + 10); i++) set.add(i)
+
+  return Array.from(set).sort((a, b) => a - b).map((n) => ({ value: n, title: String(n) }))
+})
+</script>
+
+<template>
+  <div class="settings table-2">
+    <div class="header-with-actions">
+      <h1 class="primary-heading">Задания сканирования</h1>
+      <div style="display:flex; align-items:center;" v-if="authStore.isSrLogistPlus">
+        <div v-if="runningAction || loading" class="header-actions header-actions-group">
+          <span class="spinner-border spinner-border-m"></span>
+        </div>
+        <div class="header-actions header-actions-group">
+          <ActionButton
+            :item="{}"
+            icon="fa-solid fa-plus"
+            tooltip-text="Создать задание сканирования"
+            iconSize="2x"
+            :disabled="runningAction || loading"
+            @click="openCreateDialog"
+          />
+        </div>
+      </div>
+    </div>
+
+    <hr class="hr" />
+
+    <div>
+      <v-text-field
+        v-model="localSearch"
+        :append-inner-icon="mdiMagnify"
+        label="Поиск по заданиям сканирования"
+        variant="solo"
+        hide-details
+        :disabled="runningAction || loading"
+      />
+    </div>
+
+    <v-card class="table-card">
+      <v-data-table-server
+        v-model:items-per-page="scanjobs_per_page"
+        :items-per-page-options="itemsPerPageOptions"
+        v-model:page="scanjobs_page"
+        v-model:sort-by="scanjobs_sort_by"
+        :headers="headers"
+        :items="scanJobs"
+        :items-length="totalCount"
+        :loading="loading"
+        item-value="id"
+        density="compact"
+        class="elevation-1 interlaced-table"
+        fixed-header
+        hide-default-footer
+      >
+        <template #item="{ item, columns }">
+          <tr>
+            <td
+              v-for="col in columns"
+              :key="col.key"
+              :class="[
+                col.class,
+                col.align === 'center' ? 'text-center' : col.align === 'end' ? 'text-right' : 'text-start'
+              ]"
+              :data-column-key="col.key"
+            >
+              <template v-if="col.key === 'actions'">
+                <div v-if="authStore.isSrLogistPlus" class="actions-container">
+                  <ActionButton
+                    :item="item"
+                    icon="fa-solid fa-pen"
+                    tooltip-text="Редактировать задание сканирования"
+                    @click="openEditDialog"
+                    :disabled="runningAction || loading"
+                  />
+                  <ActionButton
+                    :item="item"
+                    icon="fa-solid fa-trash-can"
+                    tooltip-text="Удалить задание сканирования"
+                    @click="deleteScanJob"
+                    :disabled="runningAction || loading"
+                  />
+                </div>
+              </template>
+              <template v-else-if="col.key === 'warehouseId'">
+                {{ getWarehouseName(item.warehouseId) }}
+              </template>
+              <template v-else-if="col.key === 'type'">
+                {{ getOptionLabel(typeOptions, item.type) }}
+              </template>
+              <template v-else-if="col.key === 'operation'">
+                {{ getOptionLabel(operationOptions, item.operation) }}
+              </template>
+              <template v-else-if="col.key === 'mode'">
+                {{ getOptionLabel(modeOptions, item.mode) }}
+              </template>
+              <template v-else-if="col.key === 'status'">
+                {{ getOptionLabel(statusOptions, item.status) }}
+              </template>
+              <template v-else>
+                {{ item[col.key] }}
+              </template>
+            </td>
+          </tr>
+        </template>
+      </v-data-table-server>
+      <div class="v-data-table-footer">
+        <PaginationFooter
+          v-model:items-per-page="scanjobs_per_page"
+          v-model:page="scanjobs_page"
+          :items-per-page-options="itemsPerPageOptions"
+          :page-options="pageOptions"
+          :total-count="totalCount"
+          :max-page="maxPage"
+        />
+      </div>
+    </v-card>
+
+    <div v-if="error" class="text-center m-5">
+      <div class="text-danger">Ошибка при загрузке информации: {{ error }}</div>
+    </div>
+    <div v-if="alert" class="alert alert-dismissable mt-3 mb-0" :class="alert.type">
+      <button @click="alertStore.clear()" class="btn btn-link close">×</button>
+      {{ alert.message }}
+    </div>
+  </div>
+</template>
+
+<style scoped>
+@import '@/assets/styles/scrollable-table.css';
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -62,6 +62,12 @@ const router = createRouter({
       meta: { reqAnyRole: true }
     },
     {
+      path: '/scanjobs',
+      name: 'Задания сканирования',
+      component: () => import('@/views/ScanJobs_View.vue'),
+      meta: { reqAnyRole: true }
+    },
+    {
       path: '/notifications',
       name: 'Нотификации',
       component: () => import('@/views/Notifications_View.vue'),
@@ -95,9 +101,24 @@ const router = createRouter({
       meta: { reqAdminOrSrLogist: true }
     },
     {
+      path: '/scanjob/create',
+      name: 'Создание задания сканирования',
+      component: () => import('@/views/ScanJobs_CreateView.vue'),
+      meta: { reqAdminOrSrLogist: true }
+    },
+    {
       path: '/warehouse/edit/:id',
       name: 'Изменить информацию о складе',
       component: () => import('@/views/Warehouse_EditView.vue'),
+      props: (route) => ({
+        id: Number(route.params.id)
+      }),
+      meta: { reqAdminOrSrLogist: true }
+    },
+    {
+      path: '/scanjob/edit/:id',
+      name: 'Редактировать задание сканирования',
+      component: () => import('@/views/ScanJobs_EditView.vue'),
       props: (route) => ({
         id: Number(route.params.id)
       }),

--- a/src/stores/auth.store.js
+++ b/src/stores/auth.store.js
@@ -62,6 +62,10 @@ export const useAuthStore = defineStore('auth', () => {
   const warehouses_search = ref('')
   const warehouses_sort_by = ref(['id'])
   const warehouses_page = ref(1)
+  const scanjobs_per_page = ref(100)
+  const scanjobs_search = ref('')
+  const scanjobs_sort_by = ref([{ key: 'id', order: 'asc' }])
+  const scanjobs_page = ref(1)
   const notifications_per_page = ref(100)
   const notifications_search = ref('')
   const notifications_sort_by = ref(['id'])
@@ -242,6 +246,10 @@ export const useAuthStore = defineStore('auth', () => {
     warehouses_search,
     warehouses_sort_by,
     warehouses_page,
+    scanjobs_per_page,
+    scanjobs_search,
+    scanjobs_sort_by,
+    scanjobs_page,
     notifications_per_page,
     notifications_search,
     notifications_sort_by,

--- a/src/stores/scanjobs.store.js
+++ b/src/stores/scanjobs.store.js
@@ -1,0 +1,143 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+import { useAuthStore } from '@/stores/auth.store.js'
+
+const baseUrl = `${apiUrl}/scanjobs`
+
+export const useScanJobsStore = defineStore('scanjobs', () => {
+  const scanJobs = ref([])
+  const scanJob = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+  const totalCount = ref(0)
+  const hasNextPage = ref(false)
+  const hasPreviousPage = ref(false)
+
+  async function getAll() {
+    const authStore = useAuthStore()
+    loading.value = true
+    error.value = null
+    try {
+      const queryParams = new URLSearchParams({
+        page: authStore.scanjobs_page.toString(),
+        pageSize: authStore.scanjobs_per_page.toString(),
+        sortBy: authStore.scanjobs_sort_by?.[0]?.key || 'id',
+        sortOrder: authStore.scanjobs_sort_by?.[0]?.order || 'asc'
+      })
+
+      if (authStore.scanjobs_search) {
+        queryParams.append('search', authStore.scanjobs_search)
+      }
+
+      const response = await fetchWrapper.get(`${baseUrl}?${queryParams.toString()}`)
+
+      if (Array.isArray(response)) {
+        scanJobs.value = response
+        totalCount.value = response.length
+        hasNextPage.value = false
+        hasPreviousPage.value = false
+      } else {
+        scanJobs.value = response?.items || []
+        totalCount.value = response?.pagination?.totalCount || 0
+        hasNextPage.value = response?.pagination?.hasNextPage || false
+        hasPreviousPage.value = response?.pagination?.hasPreviousPage || false
+      }
+    } catch (err) {
+      error.value = err
+      scanJobs.value = []
+      totalCount.value = 0
+      hasNextPage.value = false
+      hasPreviousPage.value = false
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getById(id) {
+    scanJob.value = { loading: true }
+    loading.value = true
+    error.value = null
+    try {
+      scanJob.value = await fetchWrapper.get(`${baseUrl}/${id}`)
+      return scanJob.value
+    } catch (err) {
+      error.value = err
+      scanJob.value = { error: err }
+      return null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function create(scanJobData) {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await fetchWrapper.post(baseUrl, scanJobData)
+      scanJobs.value.push(result)
+      return result
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function update(id, scanJobData) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.put(`${baseUrl}/${id}`, scanJobData)
+      const index = scanJobs.value.findIndex((job) => job.id === id)
+      if (index !== -1) {
+        scanJobs.value[index] = { ...scanJobs.value[index], ...scanJobData }
+      }
+      if (scanJob.value?.id === id) {
+        scanJob.value = { ...scanJob.value, ...scanJobData }
+      }
+      return true
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function remove(id) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.delete(`${baseUrl}/${id}`)
+      scanJobs.value = scanJobs.value.filter((job) => job.id !== id)
+      return true
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    scanJobs,
+    scanJob,
+    totalCount,
+    hasNextPage,
+    hasPreviousPage,
+    loading,
+    error,
+    getAll,
+    getById,
+    create,
+    update,
+    remove
+  }
+})

--- a/src/views/ScanJobs_CreateView.vue
+++ b/src/views/ScanJobs_CreateView.vue
@@ -1,0 +1,13 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import ScanJobsSettings from '@/dialogs/ScanJobs_Settings.vue'
+</script>
+
+<template>
+  <Suspense>
+    <ScanJobsSettings :mode="'create'" />
+  </Suspense>
+</template>

--- a/src/views/ScanJobs_EditView.vue
+++ b/src/views/ScanJobs_EditView.vue
@@ -1,0 +1,20 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import ScanJobsSettings from '@/dialogs/ScanJobs_Settings.vue'
+
+const props = defineProps({
+  id: {
+    type: Number,
+    required: true
+  }
+})
+</script>
+
+<template>
+  <Suspense>
+    <ScanJobsSettings :mode="'edit'" :scanjob-id="props.id" />
+  </Suspense>
+</template>

--- a/src/views/ScanJobs_View.vue
+++ b/src/views/ScanJobs_View.vue
@@ -1,0 +1,11 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import ScanJobsList from '@/lists/ScanJobs_List.vue'
+</script>
+
+<template>
+  <ScanJobsList />
+</template>

--- a/tests/ScanJobs_CreateView.spec.js
+++ b/tests/ScanJobs_CreateView.spec.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import ScanJobsCreateView from '@/views/ScanJobs_CreateView.vue'
+
+vi.mock('@/dialogs/ScanJobs_Settings.vue', () => ({
+  default: {
+    name: 'ScanJobs_Settings',
+    props: ['mode'],
+    template: '<div data-testid="scanjobs-settings">ScanJobs Settings (mode: {{ mode }})</div>'
+  }
+}))
+
+describe('ScanJobs_CreateView.vue', () => {
+  let vuetify
+  let pinia
+
+  beforeEach(() => {
+    vuetify = createVuetify({ components, directives })
+    pinia = createPinia()
+  })
+
+  it('renders ScanJobs_Settings in create mode', () => {
+    const wrapper = mount(ScanJobsCreateView, {
+      global: {
+        plugins: [vuetify, pinia]
+      }
+    })
+
+    const settings = wrapper.find('[data-testid="scanjobs-settings"]')
+    expect(settings.exists()).toBe(true)
+    expect(settings.text()).toContain('mode: create')
+  })
+})

--- a/tests/ScanJobs_EditView.spec.js
+++ b/tests/ScanJobs_EditView.spec.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import ScanJobsEditView from '@/views/ScanJobs_EditView.vue'
+
+vi.mock('@/dialogs/ScanJobs_Settings.vue', () => ({
+  default: {
+    name: 'ScanJobs_Settings',
+    props: ['mode', 'scanjobId'],
+    template: '<div data-testid="scanjobs-settings">ScanJobs Settings (mode: {{ mode }}, id: {{ scanjobId }})</div>'
+  }
+}))
+
+describe('ScanJobs_EditView.vue', () => {
+  let vuetify
+  let pinia
+
+  beforeEach(() => {
+    vuetify = createVuetify({ components, directives })
+    pinia = createPinia()
+  })
+
+  it('renders ScanJobs_Settings in edit mode with id', () => {
+    const wrapper = mount(ScanJobsEditView, {
+      props: { id: 12 },
+      global: {
+        plugins: [vuetify, pinia]
+      }
+    })
+
+    const settings = wrapper.find('[data-testid="scanjobs-settings"]')
+    expect(settings.exists()).toBe(true)
+    expect(settings.text()).toContain('mode: edit')
+    expect(settings.text()).toContain('id: 12')
+  })
+})

--- a/tests/ScanJobs_List.spec.js
+++ b/tests/ScanJobs_List.spec.js
@@ -1,0 +1,214 @@
+/* @vitest-environment jsdom */
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { reactive, ref } from 'vue'
+import ScanJobsList from '@/lists/ScanJobs_List.vue'
+import { defaultGlobalStubs } from './helpers/test-utils.js'
+
+const scanJobsRef = ref([
+  {
+    id: 1,
+    name: 'Сканирование',
+    type: 0,
+    operation: 1,
+    mode: 0,
+    status: 0,
+    warehouseId: 10
+  }
+])
+
+const warehousesRef = ref([
+  { id: 10, name: 'Основной склад' },
+  { id: 11, name: 'Склад 2' }
+])
+
+const loadingRef = ref(false)
+const errorRef = ref(null)
+const totalCountRef = ref(1)
+
+const getAllScanJobs = vi.hoisted(() => vi.fn())
+const removeScanJob = vi.hoisted(() => vi.fn())
+const getAllWarehouses = vi.hoisted(() => vi.fn())
+const errorFn = vi.hoisted(() => vi.fn())
+const confirmMock = vi.hoisted(() => vi.fn().mockResolvedValue(true))
+const routerPushMock = vi.hoisted(() => vi.fn())
+const triggerLoadMock = vi.hoisted(() => vi.fn())
+
+const authStoreMock = reactive({
+  scanjobs_per_page: 10,
+  scanjobs_search: '',
+  scanjobs_sort_by: [{ key: 'id', order: 'asc' }],
+  scanjobs_page: 1,
+  isSrLogistPlus: true
+})
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return {
+    ...actual,
+    storeToRefs: (store) => {
+      const refs = {}
+      Object.keys(store).forEach((key) => {
+        const value = store[key]
+        if (value && typeof value === 'object' && 'value' in value) {
+          refs[key] = value
+        }
+      })
+      return refs
+    }
+  }
+})
+
+vi.mock('@/stores/scanjobs.store.js', () => ({
+  useScanJobsStore: () => ({
+    scanJobs: scanJobsRef,
+    loading: loadingRef,
+    error: errorRef,
+    totalCount: totalCountRef,
+    getAll: getAllScanJobs,
+    remove: removeScanJob
+  })
+}))
+
+vi.mock('@/stores/warehouses.store.js', () => ({
+  useWarehousesStore: () => ({
+    warehouses: warehousesRef,
+    getAll: getAllWarehouses
+  })
+}))
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: () => authStoreMock
+}))
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => ({
+    alert: null,
+    error: errorFn,
+    clear: vi.fn()
+  })
+}))
+
+vi.mock('vuetify-use-dialog', () => ({
+  useConfirm: () => confirmMock
+}))
+
+vi.mock('@/router', () => ({
+  default: {
+    push: routerPushMock
+  }
+}))
+
+vi.mock('@/helpers/items.per.page.js', () => ({
+  itemsPerPageOptions: [10, 25, 50]
+}))
+
+vi.mock('@mdi/js', () => ({
+  mdiMagnify: 'mdi-magnify'
+}))
+
+vi.mock('@/composables/useDebouncedFilterSync.js', () => ({
+  useDebouncedFilterSync: () => ({
+    triggerLoad: triggerLoadMock,
+    stop: vi.fn()
+  })
+}))
+
+describe('ScanJobs_List.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authStoreMock.scanjobs_search = ''
+    authStoreMock.scanjobs_page = 1
+    authStoreMock.scanjobs_per_page = 10
+    authStoreMock.scanjobs_sort_by = [{ key: 'id', order: 'asc' }]
+  })
+
+  it('calls getAll methods on mount', async () => {
+    mount(ScanJobsList, {
+      global: {
+        stubs: {
+          ...defaultGlobalStubs,
+          ActionButton: { template: '<button data-testid="action-button" />' },
+          PaginationFooter: { template: '<div data-testid="pagination-footer"></div>' },
+          'font-awesome-icon': { template: '<i class="fa-icon-stub" />' }
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(getAllWarehouses).toHaveBeenCalled()
+    expect(getAllScanJobs).toHaveBeenCalled()
+  })
+
+  it('maps option labels correctly', async () => {
+    const wrapper = mount(ScanJobsList, {
+      global: {
+        stubs: {
+          ...defaultGlobalStubs,
+          ActionButton: { template: '<button data-testid="action-button" />' },
+          PaginationFooter: { template: '<div data-testid="pagination-footer"></div>' },
+          'font-awesome-icon': { template: '<i class="fa-icon-stub" />' }
+        }
+      }
+    })
+
+    expect(wrapper.vm.getOptionLabel([{ value: 0, label: 'Посылка' }], 0)).toBe('Посылка')
+    expect(wrapper.vm.getOptionLabel([{ value: 1, label: 'Исходящее' }], 1)).toBe('Исходящее')
+    expect(wrapper.vm.getOptionLabel([{ value: 1, label: 'Автоматическое' }], 1)).toBe('Автоматическое')
+    expect(wrapper.vm.getOptionLabel([{ value: 1, label: 'Завершено' }], 1)).toBe('Завершено')
+  })
+
+  it('navigates to create page when create action is called', async () => {
+    const wrapper = mount(ScanJobsList, {
+      global: {
+        stubs: {
+          ...defaultGlobalStubs,
+          ActionButton: { template: '<button data-testid="action-button" />' },
+          PaginationFooter: { template: '<div data-testid="pagination-footer"></div>' },
+          'font-awesome-icon': { template: '<i class="fa-icon-stub" />' }
+        }
+      }
+    })
+
+    await wrapper.vm.openCreateDialog()
+    expect(routerPushMock).toHaveBeenCalledWith('/scanjob/create')
+  })
+
+  it('navigates to edit page when edit is called', async () => {
+    const wrapper = mount(ScanJobsList, {
+      global: {
+        stubs: {
+          ...defaultGlobalStubs,
+          ActionButton: { template: '<button data-testid="action-button" />' },
+          PaginationFooter: { template: '<div data-testid="pagination-footer"></div>' },
+          'font-awesome-icon': { template: '<i class="fa-icon-stub" />' }
+        }
+      }
+    })
+
+    await wrapper.vm.openEditDialog({ id: 7 })
+    expect(routerPushMock).toHaveBeenCalledWith('/scanjob/edit/7')
+  })
+
+  it('calls remove when deleteScanJob is confirmed', async () => {
+    const wrapper = mount(ScanJobsList, {
+      global: {
+        stubs: {
+          ...defaultGlobalStubs,
+          ActionButton: { template: '<button data-testid="action-button" />' },
+          PaginationFooter: { template: '<div data-testid="pagination-footer"></div>' },
+          'font-awesome-icon': { template: '<i class="fa-icon-stub" />' }
+        }
+      }
+    })
+
+    await wrapper.vm.deleteScanJob({ id: 1, name: 'Сканирование' })
+
+    expect(removeScanJob).toHaveBeenCalledWith(1)
+  })
+})

--- a/tests/ScanJobs_Settings.spec.js
+++ b/tests/ScanJobs_Settings.spec.js
@@ -1,0 +1,239 @@
+/* @vitest-environment jsdom */
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { Suspense, ref } from 'vue'
+import ScanJobsSettings from '@/dialogs/ScanJobs_Settings.vue'
+import { defaultGlobalStubs, createMockStore, resolveAll } from './helpers/test-utils.js'
+
+const mockScanJobData = {
+  id: 1,
+  name: 'Сканирование посылок',
+  type: 0,
+  operation: 1,
+  mode: 0,
+  status: 0,
+  warehouseId: 10
+}
+
+const scanJobRef = ref({ ...mockScanJobData })
+
+const mockScanJobsStore = createMockStore({
+  scanJob: scanJobRef,
+  getById: vi.fn().mockImplementation(async () => mockScanJobData),
+  create: vi.fn().mockResolvedValue(mockScanJobData),
+  update: vi.fn().mockResolvedValue()
+})
+
+const mockWarehousesStore = createMockStore({
+  warehouses: [
+    { id: 10, name: 'Основной склад' },
+    { id: 12, name: 'Склад 2' }
+  ],
+  getAll: vi.fn().mockResolvedValue([])
+})
+
+const mockAlertStore = createMockStore({
+  alert: null,
+  error: vi.fn(),
+  clear: vi.fn()
+})
+
+vi.mock('@/stores/scanjobs.store.js', () => ({
+  useScanJobsStore: () => mockScanJobsStore
+}))
+
+vi.mock('@/stores/warehouses.store.js', () => ({
+  useWarehousesStore: () => mockWarehousesStore
+}))
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => mockAlertStore
+}))
+
+const mockRouter = vi.hoisted(() => ({
+  push: vi.fn()
+}))
+
+vi.mock('@/router', () => ({
+  default: mockRouter
+}))
+
+vi.mock('pinia', () => ({
+  storeToRefs: (store) => {
+    if (store.scanJob !== undefined) {
+      return { scanJob: store.scanJob }
+    }
+    if (store.warehouses !== undefined) {
+      return { warehouses: { value: store.warehouses } }
+    }
+    return {}
+  }
+}))
+
+vi.mock('vee-validate', () => ({
+  Form: {
+    name: 'Form',
+    props: ['initialValues', 'validationSchema'],
+    emits: ['submit'],
+    data() {
+      return {
+        errors: {},
+        isSubmitting: false
+      }
+    },
+    methods: {
+      async handleSubmit() {
+        const actions = {
+          setErrors: this.setErrors.bind(this)
+        }
+        this.$emit('submit', this.$props.initialValues || {}, actions)
+      },
+      setErrors(newErrors) {
+        this.errors = { ...this.errors, ...newErrors }
+      }
+    },
+    template: `
+      <form @submit.prevent="handleSubmit">
+        <slot :errors="errors" :isSubmitting="isSubmitting" />
+      </form>
+    `
+  },
+  Field: {
+    name: 'Field',
+    props: ['name', 'id', 'type', 'as', 'class', 'placeholder', 'value'],
+    template: `
+      <input v-if="!as || as === 'input'" :name="name" :id="id" :type="type" :value="value" />
+      <select v-else-if="as === 'select'" :name="name" :id="id">
+        <slot></slot>
+      </select>
+      <component v-else :is="as" :name="name" :id="id" />
+    `
+  }
+}))
+
+const AsyncWrapper = {
+  components: { ScanJobsSettings, Suspense },
+  props: ['mode', 'scanjobId'],
+  template: `
+    <Suspense>
+      <ScanJobsSettings :mode="mode" :scanjob-id="scanjobId" />
+      <template #fallback>
+        <div>Loading...</div>
+      </template>
+    </Suspense>
+  `
+}
+
+beforeEach(async () => {
+  scanJobRef.value = { ...mockScanJobData }
+  vi.clearAllMocks()
+  await import('@/router')
+})
+
+describe('ScanJobs_Settings.vue', () => {
+  it('renders create mode correctly', async () => {
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'create' },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    expect(wrapper.find('h1').text()).toBe('Создание задания сканирования')
+    expect(wrapper.find('button[type="submit"]').text()).toContain('Создать')
+    expect(mockScanJobsStore.getById).not.toHaveBeenCalled()
+    expect(mockWarehousesStore.getAll).toHaveBeenCalled()
+  })
+
+  it('renders edit mode correctly', async () => {
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'edit', scanjobId: 1 },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    expect(mockScanJobsStore.getById).toHaveBeenCalledWith(1)
+    expect(wrapper.find('h1').text()).toBe('Редактировать задание сканирования')
+    expect(wrapper.find('button[type="submit"]').text()).toContain('Сохранить')
+  })
+
+  it('submits create form successfully', async () => {
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'create' },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    const formComponent = wrapper.findComponent({ name: 'Form' })
+    await formComponent.vm.$emit('submit', {
+      name: 'Новое задание',
+      warehouseId: 10,
+      type: 0,
+      operation: 1,
+      mode: 0,
+      status: 0
+    }, { setErrors: vi.fn() })
+    await resolveAll()
+
+    expect(mockScanJobsStore.create).toHaveBeenCalled()
+    expect(mockRouter.push).toHaveBeenCalledWith('/scanjobs')
+  })
+
+  it('submits edit form successfully', async () => {
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'edit', scanjobId: 1 },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    const formComponent = wrapper.findComponent({ name: 'Form' })
+    await formComponent.vm.$emit('submit', {
+      name: 'Обновленное задание',
+      warehouseId: 12,
+      type: 1,
+      operation: 2,
+      mode: 1,
+      status: 1
+    }, { setErrors: vi.fn() })
+    await resolveAll()
+
+    expect(mockScanJobsStore.update).toHaveBeenCalledWith(1, expect.any(Object))
+    expect(mockRouter.push).toHaveBeenCalledWith('/scanjobs')
+  })
+
+  it('shows api error message on create conflict', async () => {
+    mockScanJobsStore.create.mockRejectedValueOnce(new Error('409 Conflict'))
+
+    const wrapper = mount(AsyncWrapper, {
+      props: { mode: 'create' },
+      global: {
+        stubs: defaultGlobalStubs
+      }
+    })
+
+    await resolveAll()
+
+    const formComponent = wrapper.findComponent({ name: 'Form' })
+    const setErrors = vi.fn()
+
+    await formComponent.vm.$emit('submit', { name: 'Задание' }, { setErrors })
+    await resolveAll()
+
+    expect(setErrors).toHaveBeenCalledWith({ apiError: 'Задание с таким названием уже существует' })
+  })
+})

--- a/tests/ScanJobs_View.spec.js
+++ b/tests/ScanJobs_View.spec.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { beforeEach, describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import ScanJobsView from '@/views/ScanJobs_View.vue'
+
+vi.mock('@/lists/ScanJobs_List.vue', () => ({
+  default: {
+    name: 'ScanJobs_List',
+    template: '<div data-testid="scanjobs-list">ScanJobs List Component</div>'
+  }
+}))
+
+describe('ScanJobs_View', () => {
+  let vuetify
+  let pinia
+
+  beforeEach(() => {
+    vuetify = createVuetify({
+      components,
+      directives
+    })
+    pinia = createPinia()
+  })
+
+  it('mounts successfully', () => {
+    const wrapper = mount(ScanJobsView, {
+      global: {
+        plugins: [vuetify, pinia]
+      }
+    })
+
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('renders ScanJobs_List component', () => {
+    const wrapper = mount(ScanJobsView, {
+      global: {
+        plugins: [vuetify, pinia]
+      }
+    })
+
+    const listComponent = wrapper.find('[data-testid="scanjobs-list"]')
+    expect(listComponent.exists()).toBe(true)
+    expect(listComponent.text()).toBe('ScanJobs List Component')
+  })
+
+  it('has correct component structure', () => {
+    const wrapper = mount(ScanJobsView, {
+      global: {
+        plugins: [vuetify, pinia]
+      }
+    })
+
+    expect(wrapper.html()).toContain('ScanJobs List Component')
+  })
+})

--- a/tests/scanjobs.store.spec.js
+++ b/tests/scanjobs.store.spec.js
@@ -1,0 +1,244 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks ui application
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useScanJobsStore } from '@/stores/scanjobs.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+import { useAuthStore } from '@/stores/auth.store.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => ({
+  fetchWrapper: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn()
+  }
+}))
+
+vi.mock('@/helpers/config.js', () => ({
+  apiUrl: 'http://localhost:8080/api'
+}))
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: vi.fn()
+}))
+
+const mockScanJobs = [
+  {
+    id: 1,
+    name: 'Сканирование посылок',
+    type: 0,
+    operation: 1,
+    mode: 0,
+    status: 0,
+    warehouseId: 10
+  },
+  {
+    id: 2,
+    name: 'Поиск мешков',
+    type: 1,
+    operation: 2,
+    mode: 1,
+    status: 1,
+    warehouseId: 11
+  }
+]
+
+const mockScanJob = mockScanJobs[0]
+
+describe('scanjobs store', () => {
+  const defaultAuthStore = {
+    scanjobs_page: 1,
+    scanjobs_per_page: 10,
+    scanjobs_sort_by: [{ key: 'id', order: 'asc' }],
+    scanjobs_search: ''
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    useAuthStore.mockReturnValue(defaultAuthStore)
+  })
+
+  it('initializes with default values', () => {
+    const store = useScanJobsStore()
+    expect(store.scanJobs).toEqual([])
+    expect(store.scanJob).toBeNull()
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  describe('getAll', () => {
+    it('fetches scan jobs with pagination metadata', async () => {
+      const response = {
+        items: mockScanJobs,
+        pagination: {
+          totalCount: 2,
+          hasNextPage: false,
+          hasPreviousPage: false
+        }
+      }
+      fetchWrapper.get.mockResolvedValue(response)
+
+      const store = useScanJobsStore()
+      await store.getAll()
+
+      expect(fetchWrapper.get).toHaveBeenCalledWith(
+        `${apiUrl}/scanjobs?page=1&pageSize=10&sortBy=id&sortOrder=asc`
+      )
+      expect(store.scanJobs).toEqual(mockScanJobs)
+      expect(store.totalCount).toBe(2)
+      expect(store.hasNextPage).toBe(false)
+      expect(store.hasPreviousPage).toBe(false)
+    })
+
+    it('fetches scan jobs with search term', async () => {
+      useAuthStore.mockReturnValueOnce({
+        scanjobs_page: 2,
+        scanjobs_per_page: 5,
+        scanjobs_sort_by: [{ key: 'name', order: 'desc' }],
+        scanjobs_search: 'Поиск'
+      })
+
+      fetchWrapper.get.mockResolvedValue({ items: [], pagination: { totalCount: 0 } })
+
+      const store = useScanJobsStore()
+      await store.getAll()
+
+      expect(fetchWrapper.get).toHaveBeenCalledWith(
+        `${apiUrl}/scanjobs?page=2&pageSize=5&sortBy=name&sortOrder=desc&search=%D0%9F%D0%BE%D0%B8%D1%81%D0%BA`
+      )
+    })
+
+    it('handles legacy array response', async () => {
+      fetchWrapper.get.mockResolvedValue(mockScanJobs)
+
+      const store = useScanJobsStore()
+      await store.getAll()
+
+      expect(store.scanJobs).toEqual(mockScanJobs)
+      expect(store.totalCount).toBe(2)
+    })
+
+    it('handles fetch error', async () => {
+      const error = new Error('Network error')
+      fetchWrapper.get.mockRejectedValue(error)
+
+      const store = useScanJobsStore()
+      await store.getAll()
+
+      expect(store.scanJobs).toEqual([])
+      expect(store.totalCount).toBe(0)
+      expect(store.error).toBe(error)
+    })
+  })
+
+  describe('getById', () => {
+    it('fetches scan job by id successfully', async () => {
+      fetchWrapper.get.mockResolvedValue(mockScanJob)
+
+      const store = useScanJobsStore()
+      const result = await store.getById(1)
+
+      expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/scanjobs/1`)
+      expect(store.scanJob).toEqual(mockScanJob)
+      expect(result).toEqual(mockScanJob)
+      expect(store.error).toBeNull()
+    })
+
+    it('handles fetch error and returns null', async () => {
+      const error = new Error('Not found')
+      fetchWrapper.get.mockRejectedValue(error)
+
+      const store = useScanJobsStore()
+      const result = await store.getById(999)
+
+      expect(result).toBeNull()
+      expect(store.error).toBe(error)
+    })
+  })
+
+  describe('create', () => {
+    it('creates scan job successfully', async () => {
+      const newScanJob = { ...mockScanJob, id: 3 }
+      fetchWrapper.post.mockResolvedValue(newScanJob)
+
+      const store = useScanJobsStore()
+      store.scanJobs = [...mockScanJobs]
+
+      const result = await store.create(mockScanJob)
+
+      expect(fetchWrapper.post).toHaveBeenCalledWith(`${apiUrl}/scanjobs`, mockScanJob)
+      expect(store.scanJobs).toHaveLength(3)
+      expect(store.scanJobs[2]).toEqual(newScanJob)
+      expect(result).toEqual(newScanJob)
+    })
+
+    it('handles create error', async () => {
+      const error = new Error('Conflict')
+      fetchWrapper.post.mockRejectedValue(error)
+
+      const store = useScanJobsStore()
+      await expect(store.create(mockScanJob)).rejects.toThrow('Conflict')
+
+      expect(store.error).toBe(error)
+    })
+  })
+
+  describe('update', () => {
+    it('updates scan job successfully', async () => {
+      fetchWrapper.put.mockResolvedValue({})
+
+      const store = useScanJobsStore()
+      store.scanJobs = [...mockScanJobs]
+      store.scanJob = { ...mockScanJob }
+
+      const updateData = { status: 1 }
+      const result = await store.update(1, updateData)
+
+      expect(fetchWrapper.put).toHaveBeenCalledWith(`${apiUrl}/scanjobs/1`, updateData)
+      expect(store.scanJobs[0]).toEqual({ ...mockScanJobs[0], ...updateData })
+      expect(store.scanJob).toEqual({ ...mockScanJob, ...updateData })
+      expect(result).toBe(true)
+    })
+
+    it('handles update error', async () => {
+      const error = new Error('Not found')
+      fetchWrapper.put.mockRejectedValue(error)
+
+      const store = useScanJobsStore()
+      await expect(store.update(999, {})).rejects.toThrow('Not found')
+
+      expect(store.error).toBe(error)
+    })
+  })
+
+  describe('remove', () => {
+    it('removes scan job successfully', async () => {
+      fetchWrapper.delete.mockResolvedValue({})
+
+      const store = useScanJobsStore()
+      store.scanJobs = [...mockScanJobs]
+
+      const result = await store.remove(1)
+
+      expect(fetchWrapper.delete).toHaveBeenCalledWith(`${apiUrl}/scanjobs/1`)
+      expect(store.scanJobs).not.toContain(mockScanJobs[0])
+      expect(store.scanJobs.length).toBe(1)
+      expect(result).toBe(true)
+    })
+
+    it('handles remove error', async () => {
+      const error = new Error('Conflict')
+      fetchWrapper.delete.mockRejectedValue(error)
+
+      const store = useScanJobsStore()
+      await expect(store.remove(1)).rejects.toThrow('Conflict')
+
+      expect(store.error).toBe(error)
+    })
+  })
+})


### PR DESCRIPTION
### Motivation
- Introduce ScanJobs management in the UI to mirror backend controller functionality and provide CRUD and paged listing for scan job entities.
- Reuse established patterns from warehouses, decs, and registers for pagination, forms, and store interactions to keep UX and state handling consistent.
- Ensure the new functionality is covered by unit tests and integrated into app navigation and routing.

### Description
- Added a new Pinia store `useScanJobsStore` implementing paged `getAll`, `getById`, `create`, `update`, and `remove` operations wired to `apiUrl/scanjobs` and to auth pagination/search state (`src/stores/scanjobs.store.js`, `src/stores/auth.store.js`).
- Implemented list, settings (form), create/edit and view wrappers: `ScanJobs_List.vue`, `ScanJobs_Settings.vue`, `ScanJobs_CreateView.vue`, `ScanJobs_EditView.vue`, and `ScanJobs_View.vue`, following the Warehouse/Decs/Register components' patterns (includes search, pagination, mapping to warehouses and option labels).
- Wired routes and navigation: added `/scanjobs`, `/scanjob/create`, `/scanjob/edit/:id` and sidebar entry in the app menu and router (`src/router/index.js`, `src/App.vue`).
- Added comprehensive unit tests for the store and UI components: `tests/scanjobs.store.spec.js`, `tests/ScanJobs_List.spec.js`, `tests/ScanJobs_Settings.spec.js`, `tests/ScanJobs_CreateView.spec.js`, `tests/ScanJobs_EditView.spec.js`, and `tests/ScanJobs_View.spec.js` following existing test conventions and stubs.

### Testing
- Ran lint with `npm run lint` and auto-fix; no lint errors were reported.
- Ran the full test suite with `npm test` (Vitest); all tests passed: test run summary shows 147 test files and 1835 tests executed and passed.
- Manual dev/run smoke checked the list view in the running dev server and captured a screenshot of the ScanJobs list rendering (dev server and a mock API route were used for quick verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973ec9249188321aa18fb931e42f84a)