### PR TITLE
Add WBR2 warehouse parcels list and mode-aware Parcels view/navigation

### DIFF
--- a/src/lists/Registers_List.vue
+++ b/src/lists/Registers_List.vue
@@ -334,7 +334,7 @@ const modeWatcherStop = watch(() => props.mode, () => {
 }, { immediate: false })
 
 function openParcels(item) {
-  router.push(`/registers/${item.id}/parcels`)
+  router.push(`/registers/${item.id}/parcels?mode=${props.mode}`)
 }
 
 function editRegister(item) {

--- a/src/lists/Wbr2Parcels_WhList.vue
+++ b/src/lists/Wbr2Parcels_WhList.vue
@@ -1,0 +1,181 @@
+<script setup>
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks UI application
+
+import { watch, ref, computed, onMounted, onUnmounted } from 'vue'
+import { useParcelsStore } from '@/stores/parcels.store.js'
+import { useRegistersStore } from '@/stores/registers.store.js'
+import { useTransportationTypesStore } from '@/stores/transportation.types.store.js'
+import { useAuthStore } from '@/stores/auth.store.js'
+import { useAlertStore } from '@/stores/alert.store.js'
+import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
+import { buildParcelListHeading } from '@/helpers/register.heading.helpers.js'
+import { formatWeight } from '@/helpers/number.formatters.js'
+import { loadOrders } from '@/helpers/parcels.list.helpers.js'
+import RegisterHeadingWithStats from '@/components/RegisterHeadingWithStats.vue'
+import PaginationFooter from '@/components/PaginationFooter.vue'
+import { storeToRefs } from 'pinia'
+
+const props = defineProps({
+  registerId: { type: Number, required: true }
+})
+
+const parcelsStore = useParcelsStore()
+const registersStore = useRegistersStore()
+const transportationTypesStore = useTransportationTypesStore()
+const authStore = useAuthStore()
+const alertStore = useAlertStore()
+
+const { alert } = storeToRefs(alertStore)
+const { items, loading, error, totalCount } = storeToRefs(parcelsStore)
+const { parcels_per_page, parcels_sort_by, parcels_page } = storeToRefs(authStore)
+
+const registerLoading = ref(true)
+const isInitializing = ref(true)
+const isComponentMounted = ref(true)
+
+const maxPage = computed(() => Math.max(1, Math.ceil((totalCount.value || 0) / parcels_per_page.value)))
+
+const pageOptions = computed(() => {
+  const mp = maxPage.value
+  const current = parcels_page.value || 1
+  if (mp <= 200) {
+    return Array.from({ length: mp }, (_, i) => ({ value: i + 1, title: String(i + 1) }))
+  }
+
+  const set = new Set()
+  for (let i = 1; i <= 10; i++) set.add(i)
+  for (let i = Math.max(1, mp - 9); i <= mp; i++) set.add(i)
+  for (let i = Math.max(1, current - 10); i <= Math.min(mp, current + 10); i++) set.add(i)
+
+  return Array.from(set).sort((a, b) => a - b).map(n => ({ value: n, title: String(n) }))
+})
+
+watch(maxPage, (v) => {
+  if (parcels_page.value > v) parcels_page.value = v
+})
+
+const headers = computed(() => [
+  { title: '№', key: 'id', align: 'start', width: '90px' },
+  { title: 'ШК', key: 'shk', align: 'start', width: '140px' },
+  { title: 'Sticker code', key: 'stickerCode', align: 'start', width: '150px' },
+  { title: 'WB sticker', key: 'wbSticker', align: 'start', width: '150px' },
+  { title: 'Seller sticker', key: 'sellerSticker', align: 'start', width: '150px' },
+  { title: 'Масса, кг', key: 'weightKg', align: 'start', width: '110px' },
+  { title: 'Кол-во', key: 'quantity', align: 'start', width: '90px' },
+  { title: 'Статус', key: 'statusId', align: 'start', width: '120px' }
+])
+
+const registerHeading = computed(() => {
+  if (registerLoading.value) return 'Загрузка реестра...'
+  return buildParcelListHeading(registersStore.item, transportationTypesStore.getDocument)
+})
+
+async function fetchRegister() {
+  if (!isComponentMounted.value) return
+  try {
+    await registersStore.getById(props.registerId)
+  } finally {
+    if (isComponentMounted.value) {
+      registerLoading.value = false
+    }
+  }
+}
+
+async function loadOrdersWrapper() {
+  await loadOrders(props.registerId, parcelsStore, isComponentMounted, alertStore)
+}
+
+const watcherStop = watch(
+  [parcels_page, parcels_per_page, parcels_sort_by],
+  () => loadOrdersWrapper(),
+  { immediate: false }
+)
+
+onMounted(async () => {
+  try {
+    await transportationTypesStore.ensureLoaded()
+    await fetchRegister()
+    await loadOrdersWrapper()
+  } catch (error) {
+    if (isComponentMounted.value) {
+      alertStore.error('Ошибка при инициализации компонента')
+      parcelsStore.error = error?.message || 'Ошибка при загрузке данных'
+    }
+  } finally {
+    if (isComponentMounted.value) {
+      isInitializing.value = false
+    }
+  }
+})
+
+onUnmounted(() => {
+  isComponentMounted.value = false
+  if (watcherStop) {
+    watcherStop()
+  }
+})
+</script>
+
+<template>
+  <div class="settings table-3">
+    <RegisterHeadingWithStats
+      :register-id="props.registerId"
+      :register="registersStore.item"
+      :heading="registerHeading"
+    />
+    <hr class="hr" />
+
+    <v-card class="table-card">
+      <v-data-table-server
+        v-model:items-per-page="parcels_per_page"
+        items-per-page-text="Посылок на странице"
+        :items-per-page-options="itemsPerPageOptions"
+        page-text="{0}-{1} из {2}"
+        v-model:page="parcels_page"
+        v-model:sort-by="parcels_sort_by"
+        :headers="headers"
+        :items="items"
+        :items-length="totalCount"
+        :loading="loading || isInitializing"
+        density="compact"
+        hide-default-footer
+        class="elevation-1 single-line-table interlaced-table wbr-parcels-table"
+      >
+        <template #[`item.weightKg`]="{ item }">
+          <span class="numeric-panel">{{ formatWeight(item.weightKg) }}</span>
+        </template>
+      </v-data-table-server>
+
+      <div class="v-data-table-footer">
+        <PaginationFooter
+          v-model:items-per-page="parcels_per_page"
+          v-model:page="parcels_page"
+          :items-per-page-options="itemsPerPageOptions"
+          :page-options="pageOptions"
+          :total-count="totalCount"
+          :max-page="maxPage"
+        />
+      </div>
+    </v-card>
+
+    <div v-if="error" class="text-center m-5">
+      <div class="text-danger">Ошибка при загрузке реестра: {{ error }}</div>
+    </div>
+    <div v-if="alert" class="alert alert-dismissable text-center m-5" :class="alert.type">
+      <button @click="alertStore.clear()" class="btn btn-link close">×</button>
+      {{ alert.message }}
+    </div>
+  </div>
+</template>
+
+<style scoped>
+:deep(.numeric-panel) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 100%;
+  text-align: right;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -345,9 +345,13 @@ const router = createRouter({
       path: '/registers/:id/parcels',
       name: 'Посылки',
       component: () => import('@/views/Parcels_View.vue'),
-      props: (route) => ({
-        id: Number(route.params.id)
-      }),
+      props: (route) => {
+        const validModes = [OP_MODE_PAPERWORK, OP_MODE_WAREHOUSE]
+        const rawMode = route.query.mode
+        const queryMode = typeof rawMode === 'string' ? rawMode : undefined
+        const mode = validModes.includes(queryMode) ? queryMode : OP_MODE_PAPERWORK
+        return { id: Number(route.params.id), mode }
+      },
       meta: { reqLogistOrSrLogist: true, hideSidebar: true }
     },
     {

--- a/src/views/Parcels_View.vue
+++ b/src/views/Parcels_View.vue
@@ -7,12 +7,15 @@ import { computed, ref, onMounted } from 'vue'
 import OzonParcelsList from '@/lists/OzonParcels_List.vue'
 import WbrParcelsList from '@/lists/WbrParcels_List.vue'
 import Wbr2ParcelsList from '@/lists/Wbr2Parcels_List.vue'
+import Wbr2ParcelsWhList from '@/lists/Wbr2Parcels_WhList.vue'
 import { OZON_COMPANY_ID, WBR_COMPANY_ID, WBR2_REGISTER_ID } from '@/helpers/company.constants.js'
+import { OP_MODE_PAPERWORK, OP_MODE_WAREHOUSE } from '@/helpers/op.mode.js'
 import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
 import { apiUrl } from '@/helpers/config.js'
 
 const props = defineProps({
-  id: { type: Number, required: true }
+  id: { type: Number, required: true },
+  mode: { type: String, default: OP_MODE_PAPERWORK }
 })
 
 const register = ref(null)
@@ -24,7 +27,9 @@ const listComponent = computed(() => {
   const registerType = register.value.registerType
   if (registerType === OZON_COMPANY_ID) return OzonParcelsList
   if (registerType === WBR_COMPANY_ID) return WbrParcelsList
-  if (registerType === WBR2_REGISTER_ID) return Wbr2ParcelsList
+  if (registerType === WBR2_REGISTER_ID) {
+    return props.mode === OP_MODE_WAREHOUSE ? Wbr2ParcelsWhList : Wbr2ParcelsList
+  }
   return null
 })
 

--- a/tests/Parcels_View.spec.js
+++ b/tests/Parcels_View.spec.js
@@ -8,6 +8,7 @@ import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import ParcelsView from '@/views/Parcels_View.vue'
 import { OZON_COMPANY_ID, WBR_COMPANY_ID, WBR2_REGISTER_ID } from '@/helpers/company.constants.js'
+import { OP_MODE_WAREHOUSE } from '@/helpers/op.mode.js'
 
 vi.mock('@/lists/WbrParcels_List.vue', () => ({
   default: {
@@ -30,6 +31,14 @@ vi.mock('@/lists/Wbr2Parcels_List.vue', () => ({
     name: 'Wbr2Parcels_List',
     props: ['register-id'],
     template: '<div data-test="wbr2-list">WBR2: {{ registerId }}</div>'
+  }
+}))
+
+vi.mock('@/lists/Wbr2Parcels_WhList.vue', () => ({
+  default: {
+    name: 'Wbr2Parcels_WhList',
+    props: ['register-id'],
+    template: '<div data-test="wbr2-wh-list">WBR2 WH: {{ registerId }}</div>'
   }
 }))
 
@@ -99,6 +108,26 @@ describe('Parcels_View', () => {
     await nextTick()
 
     expect(wrapper.find('[data-test="wbr2-list"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="wbr-list"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="ozon-list"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="wbr2-wh-list"]').exists()).toBe(false)
+  })
+
+  it('renders Wbr2Parcels_WhList when register has WBR2 registerType in warehouse mode', async () => {
+    mockGet.mockResolvedValue({ registerType: WBR2_REGISTER_ID })
+
+    const wrapper = mount(ParcelsView, {
+      props: {
+        id: 4,
+        mode: OP_MODE_WAREHOUSE
+      }
+    })
+
+    await nextTick()
+    await nextTick()
+
+    expect(wrapper.find('[data-test="wbr2-wh-list"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="wbr2-list"]').exists()).toBe(false)
     expect(wrapper.find('[data-test="wbr-list"]').exists()).toBe(false)
     expect(wrapper.find('[data-test="ozon-list"]').exists()).toBe(false)
   })

--- a/tests/Registers_List.spec.js
+++ b/tests/Registers_List.spec.js
@@ -399,7 +399,7 @@ describe('Registers_List.vue', () => {
       const router = (await import('@/router')).default
 
       wrapper.vm.openParcels(item)
-      expect(router.push).toHaveBeenCalledWith('/registers/123/parcels')
+      expect(router.push).toHaveBeenCalledWith('/registers/123/parcels?mode=modePaperwork')
     })
 
   })
@@ -424,7 +424,7 @@ describe('Registers_List.vue', () => {
       await wrapper.vm.$nextTick()
       const cell = wrapper.find('.open-parcels-link')
       await cell.trigger('click')
-      expect(router.push).toHaveBeenCalledWith('/registers/1/parcels')
+      expect(router.push).toHaveBeenCalledWith('/registers/1/parcels?mode=modePaperwork')
     })
 
     it('edits register when sender cell is clicked', async () => {

--- a/tests/Wbr2Parcels_WhList.spec.js
+++ b/tests/Wbr2Parcels_WhList.spec.js
@@ -1,0 +1,149 @@
+/* @vitest-environment jsdom */
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks UI application
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import Wbr2ParcelsWhList from '@/lists/Wbr2Parcels_WhList.vue'
+import { vuetifyStubs } from './helpers/test-utils.js'
+
+const mockItems = ref([
+  {
+    id: 1,
+    shk: 'SHK-1',
+    stickerCode: 'ST-1',
+    wbSticker: 'WB-1',
+    sellerSticker: 'SL-1',
+    weightKg: 2.4,
+    quantity: 3,
+    statusId: 7
+  }
+])
+const mockLoading = ref(false)
+const mockError = ref(null)
+const mockTotalCount = ref(1)
+
+const parcelsPerPage = ref(10)
+const parcelsSortBy = ref([])
+const parcelsPage = ref(1)
+
+const registerItem = ref({ dealNumber: 'D-1' })
+
+const ensureLoaded = vi.fn().mockResolvedValue()
+const getById = vi.fn().mockResolvedValue()
+
+const alertRef = ref(null)
+const alertError = vi.fn()
+const alertClear = vi.fn()
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return {
+    ...actual,
+    storeToRefs: (store) => {
+      const refs = {}
+      Object.keys(store).forEach((key) => {
+        const value = store[key]
+        if (value && typeof value === 'object' && 'value' in value) {
+          refs[key] = value
+        }
+      })
+      return refs
+    }
+  }
+})
+
+vi.mock('@/helpers/parcels.list.helpers.js', () => ({
+  loadOrders: vi.fn().mockResolvedValue()
+}))
+
+vi.mock('@/stores/parcels.store.js', () => ({
+  useParcelsStore: () => ({
+    items: mockItems,
+    loading: mockLoading,
+    error: mockError,
+    totalCount: mockTotalCount
+  })
+}))
+
+vi.mock('@/stores/registers.store.js', () => ({
+  useRegistersStore: () => ({
+    item: registerItem,
+    getById
+  })
+}))
+
+vi.mock('@/stores/transportation.types.store.js', () => ({
+  useTransportationTypesStore: () => ({
+    ensureLoaded,
+    getDocument: () => 'Документ'
+  })
+}))
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: () => ({
+    parcels_per_page: parcelsPerPage,
+    parcels_sort_by: parcelsSortBy,
+    parcels_page: parcelsPage
+  })
+}))
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => ({
+    alert: alertRef,
+    error: alertError,
+    clear: alertClear
+  })
+}))
+
+const globalStubs = {
+  ...vuetifyStubs,
+  RegisterHeadingWithStats: {
+    template: '<div data-testid="register-heading"></div>'
+  },
+  PaginationFooter: {
+    template: '<div data-testid="pagination-footer"></div>'
+  }
+}
+
+describe('Wbr2Parcels_WhList.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the required parcel fields in the table', async () => {
+    const wrapper = mount(Wbr2ParcelsWhList, {
+      props: { registerId: 1 },
+      global: { stubs: globalStubs }
+    })
+
+    const text = wrapper.text()
+    expect(text).toContain('SHK-1')
+    expect(text).toContain('ST-1')
+    expect(text).toContain('WB-1')
+    expect(text).toContain('SL-1')
+    expect(text).toContain('3')
+    expect(text).toContain('7')
+  })
+
+  it('defines headers only for the warehouse parcel columns', () => {
+    const wrapper = mount(Wbr2ParcelsWhList, {
+      props: { registerId: 1 },
+      global: { stubs: globalStubs }
+    })
+
+    const headerKeys = wrapper.vm.headers.map((header) => header.key)
+    expect(headerKeys).toEqual([
+      'id',
+      'shk',
+      'stickerCode',
+      'wbSticker',
+      'sellerSticker',
+      'weightKg',
+      'quantity',
+      'statusId'
+    ])
+  })
+})


### PR DESCRIPTION
### Motivation
- Provide a lightweight warehouse-oriented view for WBR2 registers that shows only warehouse-relevant parcel fields and does not expose edit/actions.
- Make the Parcels view mode-aware so the UI can render different list components for paperwork vs warehouse workflows.
- Ensure Registers list forwards the selected operation mode when navigating to Parcels so the correct list component is shown.

### Description
- Added new component `Wbr2Parcels_WhList.vue` which renders a server data table without action buttons or edit-on-click behavior and exposes only the fields: `id`, `shk`, `stickerCode`, `wbSticker`, `sellerSticker`, `weightKg`, `quantity`, `statusId`.
- Updated `Parcels_View.vue` to accept a `mode` prop and pick `Wbr2Parcels_WhList` when `registerType === WBR2_REGISTER_ID` and `mode === OP_MODE_WAREHOUSE`, otherwise fall back to the existing `Wbr2Parcels_List`.
- Updated router props for the `/registers/:id/parcels` route to accept and validate `mode` query (defaults to `OP_MODE_PAPERWORK`) and pass it to the view via props.
- Modified `Registers_List.vue` so navigation to parcels includes the current `props.mode` (e.g. `?mode=...`) when pushing the `/registers/:id/parcels` route.
- Added unit tests: `tests/Wbr2Parcels_WhList.spec.js` and extended `tests/Parcels_View.spec.js` and `tests/Registers_List.spec.js` to cover the new component selection and mode-aware navigation.

### Testing
- Ran linter with `npm run lint` and it completed successfully.
- Ran unit tests with `npm test` (Vitest); all automated tests passed: 152 files, 1939 tests (all green).
- New/updated tests include `tests/Wbr2Parcels_WhList.spec.js`, `tests/Parcels_View.spec.js` (extended), and `tests/Registers_List.spec.js` (adjusted) and they passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976a3e6b4488321b5084f613ade54d7)