### PR TITLE
Add register/parcel status-after fields to Scanjob settings and list

### DIFF
--- a/src/lists/Scanjobs_List.vue
+++ b/src/lists/Scanjobs_List.vue
@@ -8,6 +8,8 @@ import router from '@/router'
 import { storeToRefs } from 'pinia'
 import { useScanjobsStore } from '@/stores/scanjobs.store.js'
 import { useWarehousesStore } from '@/stores/warehouses.store.js'
+import { useRegisterStatusesStore } from '@/stores/register.statuses.store.js'
+import { useParcelStatusesStore } from '@/stores/parcel.statuses.store.js'
 import ActionButton from '@/components/ActionButton.vue'
 import { useAuthStore } from '@/stores/auth.store.js'
 import { useAlertStore } from '@/stores/alert.store.js'
@@ -18,6 +20,8 @@ import { mdiMagnify } from '@mdi/js'
 
 const scanJobsStore = useScanjobsStore()
 const warehousesStore = useWarehousesStore()
+const registerStatusesStore = useRegisterStatusesStore()
+const parcelStatusesStore = useParcelStatusesStore()
 const authStore = useAuthStore()
 const alertStore = useAlertStore()
 const confirm = useConfirm()
@@ -44,11 +48,24 @@ const headers = [
   { title: 'Операция', key: 'operation', sortable: true },
   { title: 'Режим', key: 'mode', sortable: true },
   { title: 'Статус', key: 'status', sortable: true },
+  { title: 'Статус реестра после сканирования', key: 'registerStatusIdAfter', sortable: false },
+  { title: 'Статус найденной посылки', key: 'parcelFoundStatusIdAfter', sortable: false },
+  { title: 'Статус ненайденной посылки', key: 'parcelNotFoundStatusIdAfter', sortable: false },
   { title: 'Склад', key: 'warehouseId', sortable: true }
 ]
 
 function openEditDialog(scanJob) {
   router.push('/scanjob/edit/' + scanJob.id)
+}
+
+function getRegisterStatusTitle(id) {
+  if (id === null || id === undefined) return '—'
+  return registerStatusesStore.getStatusTitle(id)
+}
+
+function getParcelStatusTitle(id) {
+  if (id === null || id === undefined) return '—'
+  return parcelStatusesStore.getStatusTitle(id)
 }
 
 async function deleteScanjob(scanJob) {
@@ -167,6 +184,8 @@ onMounted(async () => {
     if (!isComponentMounted.value) return
     
     await warehousesStore.ensureLoaded()
+    await registerStatusesStore.ensureLoaded()
+    await parcelStatusesStore.ensureLoaded()
   } catch (error) {
     if (isComponentMounted.value) {
       alertStore.error('Ошибка при загрузке данных: ' + (error?.message || 'Неизвестная ошибка'))
@@ -250,6 +269,18 @@ defineExpose({
 
         <template v-slot:[`item.status`]="{ item }">
           {{ scanJobsStore.getOpsLabel(ops?.statuses, item.status) }}
+        </template>
+
+        <template v-slot:[`item.registerStatusIdAfter`]="{ item }">
+          {{ getRegisterStatusTitle(item.registerStatusIdAfter) }}
+        </template>
+
+        <template v-slot:[`item.parcelFoundStatusIdAfter`]="{ item }">
+          {{ getParcelStatusTitle(item.parcelFoundStatusIdAfter) }}
+        </template>
+
+        <template v-slot:[`item.parcelNotFoundStatusIdAfter`]="{ item }">
+          {{ getParcelStatusTitle(item.parcelNotFoundStatusIdAfter) }}
         </template>
 
         <template v-slot:[`item.warehouseId`]="{ item }">

--- a/tests/Scanjobs_List.spec.js
+++ b/tests/Scanjobs_List.spec.js
@@ -36,6 +36,9 @@ const mockScanjobs = ref([
     operation: 1,
     mode: 2,
     status: 3,
+    registerStatusIdAfter: 31,
+    parcelFoundStatusIdAfter: 41,
+    parcelNotFoundStatusIdAfter: 42,
     warehouseId: 10
   }
 ])
@@ -46,6 +49,12 @@ const mockOps = ref({
   modes: [{ value: 2, name: 'Режим 1' }],
   statuses: [{ value: 3, name: 'Статус 1' }]
 })
+
+const mockRegisterStatuses = ref([{ id: 31, title: 'Реестр готов' }])
+const mockParcelStatuses = ref([
+  { id: 41, title: 'Посылка найдена' },
+  { id: 42, title: 'Посылка не найдена' }
+])
 
 const mockWarehouses = ref([{ id: 10, name: 'Основной склад' }])
 
@@ -58,6 +67,8 @@ const mockTotalCount = ref(1)
 const getAllScanjobs = vi.hoisted(() => vi.fn())
 const ensureOpsLoaded = vi.hoisted(() => vi.fn())
 const getAllWarehouses = vi.hoisted(() => vi.fn())
+const ensureRegisterStatusesLoaded = vi.hoisted(() => vi.fn())
+const ensureParcelStatusesLoaded = vi.hoisted(() => vi.fn())
 const deleteScanjobFn = vi.hoisted(() => vi.fn())
 const startScanjobFn = vi.hoisted(() => vi.fn())
 const pauseScanjobFn = vi.hoisted(() => vi.fn())
@@ -143,6 +154,26 @@ vi.mock('@/stores/warehouses.store.js', () => ({
   })
 }))
 
+vi.mock('@/stores/register.statuses.store.js', () => ({
+  useRegisterStatusesStore: () => ({
+    ensureLoaded: ensureRegisterStatusesLoaded,
+    getStatusTitle: (id) => {
+      const match = mockRegisterStatuses.value.find((status) => status.id === id)
+      return match ? match.title : `Статус ${id}`
+    }
+  })
+}))
+
+vi.mock('@/stores/parcel.statuses.store.js', () => ({
+  useParcelStatusesStore: () => ({
+    ensureLoaded: ensureParcelStatusesLoaded,
+    getStatusTitle: (id) => {
+      const match = mockParcelStatuses.value.find((status) => status.id === id)
+      return match ? match.title : `Статус ${id}`
+    }
+  })
+}))
+
 vi.mock('@/stores/alert.store.js', () => ({
   useAlertStore: () => ({
     alert: null,
@@ -202,9 +233,12 @@ describe('Scanjobs_List.vue', () => {
     })
 
     await wrapper.vm.$nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(ensureOpsLoaded).toHaveBeenCalled()
     expect(getAllWarehouses).toHaveBeenCalled()
+    expect(ensureRegisterStatusesLoaded).toHaveBeenCalled()
+    expect(ensureParcelStatusesLoaded).toHaveBeenCalled()
     expect(wrapper.exists()).toBe(true)
   })
 
@@ -224,6 +258,9 @@ describe('Scanjobs_List.vue', () => {
         operation: 1,
         mode: 2,
         status: 3,
+        registerStatusIdAfter: 31,
+        parcelFoundStatusIdAfter: 41,
+        parcelNotFoundStatusIdAfter: 42,
         warehouseId: 10
       }
     ]
@@ -257,6 +294,19 @@ describe('Scanjobs_List.vue', () => {
   it('maps warehouse name', async () => {
     expect(mockGetWarehouseName(10)).toBe('Основной склад')
     expect(mockGetWarehouseName(20)).toBe('20')
+  })
+
+  it('maps register and parcel statuses', async () => {
+    const wrapper = mount(ScanjobsList, {
+      global: {
+        stubs: testStubs
+      }
+    })
+
+    expect(wrapper.vm.getRegisterStatusTitle(31)).toBe('Реестр готов')
+    expect(wrapper.vm.getRegisterStatusTitle(null)).toBe('—')
+    expect(wrapper.vm.getParcelStatusTitle(41)).toBe('Посылка найдена')
+    expect(wrapper.vm.getParcelStatusTitle(undefined)).toBe('—')
   })
 
   it('calls delete function when delete button is clicked', async () => {


### PR DESCRIPTION
### Motivation
- The ScanJob DTO was extended with three optional status-after fields and the UI must collect, persist and display them.
- The list view should show the selected post-scan statuses for quick inspection and the settings dialog should allow selecting them when creating/updating a scanjob.

### Description
- Updated `Scanjob_Settings.vue` to load register and parcel status stores, add three new form fields (`registerStatusIdAfter`, `parcelFoundStatusIdAfter`, `parcelNotFoundStatusIdAfter`), wire them into form initial values and `buildPayload`, and render selectors in the settings form template.
- Updated `Scanjobs_List.vue` to load register/parcel status stores, add three columns to the table headers, and render human-friendly titles via small helper functions that call `getStatusTitle` from the respective stores.
- Extended unit tests `tests/Scanjob_Settings.spec.js` and `tests/Scanjobs_List.spec.js` to cover loading the status stores, the new selectors, and persisting/reading the new fields.
- Minor test utilities adjustments: mocked status stores and ensured `ops` availability in the scanjobs store mock used by the settings tests.

### Testing
- Ran lint with `npm run lint` and it completed without errors (auto-fix applied where appropriate).
- Ran unit tests with `npm test` and all tests passed: `152` test files, `1965` tests in total all succeeded.
- Ran coverage with `npm run coverage`; coverage report was generated but overall coverage is `91.34%` (below the 95% target).
- Files changed and covered by tests include `src/dialogs/Scanjob_Settings.vue`, `src/lists/Scanjobs_List.vue`, `tests/Scanjob_Settings.spec.js`, and `tests/Scanjobs_List.spec.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a4d5c3c388321b8ca01c8146207bb)