### PR TITLE
Rename decs store to customsreports store

### DIFF
--- a/src/lists/CustomsReportRows_List.vue
+++ b/src/lists/CustomsReportRows_List.vue
@@ -5,7 +5,7 @@
 
 import { onUnmounted, computed, watch, ref, toRef } from 'vue'
 import { storeToRefs } from 'pinia'
-import { useDecsStore } from '@/stores/decs.store.js'
+import { useCustomsReportsStore } from '@/stores/customsreports.store.js'
 import { useAlertStore } from '@/stores/alert.store.js'
 import { useAuthStore } from '@/stores/auth.store.js'
 import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
@@ -26,7 +26,7 @@ const props = defineProps({
   }
 })
 
-const decsStore = useDecsStore()
+const customsReportsStore = useCustomsReportsStore()
 const alertStore = useAlertStore()
 const authStore = useAuthStore()
 const customsreportrows_search = toRef(authStore, 'customsreportrows_search')
@@ -34,11 +34,11 @@ const customsreportrows_page = toRef(authStore, 'customsreportrows_page')
 const customsreportrows_per_page = toRef(authStore, 'customsreportrows_per_page')
 const customsreportrows_sort_by = toRef(authStore, 'customsreportrows_sort_by')
 
-const decsRefs = storeToRefs(decsStore)
-const reportRows = decsRefs.reportRows || ref([])
-const loading = decsRefs.loading || ref(false)
-const error = decsRefs.error || ref(null)
-const totalCount = decsRefs.totalCount || ref(0)
+const customsReportsRefs = storeToRefs(customsReportsStore)
+const reportRows = customsReportsRefs.reportRows || ref([])
+const loading = customsReportsRefs.loading || ref(false)
+const error = customsReportsRefs.error || ref(null)
+const totalCount = customsReportsRefs.totalCount || ref(0)
 const localSearch = ref(customsreportrows_search.value || '')
 
 const isComponentMounted = ref(true)
@@ -66,7 +66,7 @@ function getCellClass(columnKey) {
 }
 
 async function loadReportRows() {
-  await decsStore.getReportRows(props.reportId)
+  await customsReportsStore.getReportRows(props.reportId)
 }
 
 const { triggerLoad, stop: stopFilterSync } = useDebouncedFilterSync({

--- a/src/lists/UploadCustomsReports_List.vue
+++ b/src/lists/UploadCustomsReports_List.vue
@@ -8,7 +8,7 @@ import { useConfirm } from 'vuetify-use-dialog'
 import TruncateTooltipCell from '@/components/TruncateTooltipCell.vue'
 import ClickableCell from '@/components/ClickableCell.vue'
 import { storeToRefs } from 'pinia'
-import { useDecsStore } from '@/stores/decs.store.js'
+import { useCustomsReportsStore } from '@/stores/customsreports.store.js'
 import { useAlertStore } from '@/stores/alert.store.js'
 import ActionDialog from '@/components/ActionDialog.vue'
 import ActionButton from '@/components/ActionButton.vue'
@@ -18,11 +18,11 @@ import { useAuthStore } from '@/stores/auth.store.js'
 import { itemsPerPageOptions } from '@/helpers/items.per.page.js'
 import router from '@/router'
 
-const decsStore = useDecsStore()
+const customsReportsStore = useCustomsReportsStore()
 const alertStore = useAlertStore()
 const authStore = useAuthStore()
 
-const { reports, loading, error } = storeToRefs(decsStore)
+const { reports, loading, error } = storeToRefs(customsReportsStore)
 const { alert } = storeToRefs(alertStore)
 
 const fileInput = ref(null)
@@ -31,7 +31,7 @@ const { actionDialogState, showActionDialog, hideActionDialog } = useActionDialo
 const confirm = useConfirm()
 
 onMounted(async () => {
-  await decsStore.getReports()
+  await customsReportsStore.getReports()
 })
 
 function openReportUploadDialog() {
@@ -48,9 +48,9 @@ async function onReportFileSelected(event) {
 
   try {
     showActionDialog('upload-report')
-    await decsStore.upload(file)
+    await customsReportsStore.upload(file)
     dispatchDecReportUploadedEvent({ fileName: file.name })
-    await decsStore.getReports()
+    await customsReportsStore.getReports()
   } catch (error) {
     const message = error?.response?.data?.message || error?.message || 'Не удалось загрузить отчёт'
     alertStore.error(message)
@@ -148,7 +148,7 @@ async function handleDeleteReport(report) {
 
     if (!confirmed) return
 
-    await decsStore.remove(report.id)
+    await customsReportsStore.remove(report.id)
   } catch (error) {
     const message = error?.response?.data?.message || error?.message || 'Не удалось удалить отчёт'
     alertStore.error(message)

--- a/src/stores/customsreports.store.js
+++ b/src/stores/customsreports.store.js
@@ -8,9 +8,9 @@ import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
 import { apiUrl } from '@/helpers/config.js'
 import { useAuthStore } from '@/stores/auth.store.js'
 
-const baseUrl = `${apiUrl}/decs`
+const baseUrl = `${apiUrl}/customsreports`
 
-export const useDecsStore = defineStore('decs', () => {
+export const useCustomsReportsStore = defineStore('customsreports', () => {
   const reports = ref([])
   const reportRows = ref([])
   const loading = ref(false)

--- a/tests/CustomsReportRows_List.spec.js
+++ b/tests/CustomsReportRows_List.spec.js
@@ -22,7 +22,7 @@ const searchRef = ref('')
 const getReportRowsMock = vi.hoisted(() => vi.fn())
 const clearMock = vi.hoisted(() => vi.fn())
 
-let decsStoreMock
+let customsReportsStoreMock
 let alertStoreMock
 let authStoreMock
 const routerPushMock = vi.hoisted(() => vi.fn())
@@ -92,8 +92,8 @@ vi.mock('pinia', async () => {
   }
 })
 
-vi.mock('@/stores/decs.store.js', () => ({
-  useDecsStore: () => decsStoreMock
+vi.mock('@/stores/customsreports.store.js', () => ({
+  useCustomsReportsStore: () => customsReportsStoreMock
 }))
 
 vi.mock('@/stores/alert.store.js', () => ({
@@ -119,7 +119,7 @@ describe('CustomsReportRows_List.vue', () => {
     alertRef.value = null
     searchRef.value = ''
 
-    decsStoreMock = {
+    customsReportsStoreMock = {
       reportRows: reportRowsRef,
       loading: loadingRef,
       error: errorRef,

--- a/tests/UploadCustomsReports_List.spec.js
+++ b/tests/UploadCustomsReports_List.spec.js
@@ -23,7 +23,7 @@ const removeMock = vi.hoisted(() => vi.fn())
 const clearMock = vi.hoisted(() => vi.fn())
 const alertErrorMock = vi.hoisted(() => vi.fn())
 
-let decsStoreMock
+let customsReportsStoreMock
 let alertStoreMock
 let authStoreMock
 const confirmMock = vi.hoisted(() => vi.fn())
@@ -87,8 +87,8 @@ vi.mock('pinia', async () => {
   }
 })
 
-vi.mock('@/stores/decs.store.js', () => ({
-  useDecsStore: () => decsStoreMock
+vi.mock('@/stores/customsreports.store.js', () => ({
+  useCustomsReportsStore: () => customsReportsStoreMock
 }))
 
 vi.mock('@/stores/alert.store.js', () => ({
@@ -117,7 +117,7 @@ describe('UploadCustomsReports_List.vue', () => {
     errorRef.value = null
     alertRef.value = null
 
-    decsStoreMock = {
+    customsReportsStoreMock = {
       reports: reportsRef,
       loading: loadingRef,
       error: errorRef,

--- a/tests/customsreports.store.spec.js
+++ b/tests/customsreports.store.spec.js
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { useDecsStore } from '@/stores/decs.store.js'
+import { useCustomsReportsStore } from '@/stores/customsreports.store.js'
 import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
 
 vi.mock('@/helpers/fetch.wrapper.js', () => ({
@@ -19,14 +19,14 @@ vi.mock('@/helpers/config.js', () => ({
   apiUrl: 'http://localhost:8080/api'
 }))
 
-describe('decs.store', () => {
+describe('customsreports.store', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
   })
 
   it('initializes with default state', () => {
-    const store = useDecsStore()
+    const store = useCustomsReportsStore()
     expect(store.reports).toEqual([])
     expect(store.reportRows).toEqual([])
     expect(store.loading).toBe(false)
@@ -34,7 +34,7 @@ describe('decs.store', () => {
   })
 
   it('uploads file using fetchWrapper.postFile', async () => {
-    const store = useDecsStore()
+    const store = useCustomsReportsStore()
     const file = new File(['content'], 'dec.xlsx', { type: 'application/vnd.ms-excel' })
     const response = { success: true }
     fetchWrapper.postFile.mockResolvedValue(response)
@@ -45,7 +45,7 @@ describe('decs.store', () => {
 
     expect(fetchWrapper.postFile).toHaveBeenCalledTimes(1)
     const [url, formData] = fetchWrapper.postFile.mock.calls[0]
-    expect(url).toBe('http://localhost:8080/api/decs/upload-report')
+    expect(url).toBe('http://localhost:8080/api/customsreports/upload-report')
     expect(formData).toBeInstanceOf(FormData)
     expect(formData.get('file')).toBe(file)
     expect(store.loading).toBe(false)
@@ -53,7 +53,7 @@ describe('decs.store', () => {
   })
 
   it('stores error and rethrows when upload fails', async () => {
-    const store = useDecsStore()
+    const store = useCustomsReportsStore()
     const file = new File(['bad'], 'dec.xlsx')
     const error = new Error('upload failed')
     fetchWrapper.postFile.mockRejectedValue(error)
@@ -64,7 +64,7 @@ describe('decs.store', () => {
   })
 
   it('fetches reports using fetchWrapper.get', async () => {
-    const store = useDecsStore()
+    const store = useCustomsReportsStore()
     const reports = [{ id: 2 }, { id: 1 }]
     fetchWrapper.get.mockResolvedValue(reports)
 
@@ -73,14 +73,14 @@ describe('decs.store', () => {
     await expect(promise).resolves.toBeUndefined()
 
     expect(fetchWrapper.get).toHaveBeenCalledTimes(1)
-    expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:8080/api/decs')
+    expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:8080/api/customsreports')
     expect(store.reports).toEqual(reports)
     expect(store.loading).toBe(false)
     expect(store.error).toBeNull()
   })
 
   it('stores error when getReports fails', async () => {
-    const store = useDecsStore()
+    const store = useCustomsReportsStore()
     const error = new Error('fetch failed')
     fetchWrapper.get.mockRejectedValue(error)
 
@@ -97,12 +97,12 @@ describe('decs.store', () => {
     fetchWrapper.delete.mockResolvedValue({})
     fetchWrapper.get.mockResolvedValue([])
 
-    const store = useDecsStore()
+    const store = useCustomsReportsStore()
 
     await store.remove(10)
 
-    expect(fetchWrapper.delete).toHaveBeenCalledWith('http://localhost:8080/api/decs/10')
-    expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:8080/api/decs')
+    expect(fetchWrapper.delete).toHaveBeenCalledWith('http://localhost:8080/api/customsreports/10')
+    expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:8080/api/customsreports')
     expect(store.loading).toBe(false)
     expect(store.error).toBeNull()
   })
@@ -111,16 +111,16 @@ describe('decs.store', () => {
     const err = { status: 404, message: 'Not found' }
     fetchWrapper.delete.mockRejectedValue(err)
 
-    const store = useDecsStore()
+    const store = useCustomsReportsStore()
 
     await expect(store.remove(999)).rejects.toEqual(err)
-    expect(fetchWrapper.delete).toHaveBeenCalledWith('http://localhost:8080/api/decs/999')
+    expect(fetchWrapper.delete).toHaveBeenCalledWith('http://localhost:8080/api/customsreports/999')
     expect(store.loading).toBe(false)
     expect(store.error).toEqual(err)
   })
 
   it('fetches report rows using fetchWrapper.get', async () => {
-    const store = useDecsStore()
+    const store = useCustomsReportsStore()
     const rows = [
       { rowNumber: 1, trackingNumber: 'TRACK001', decision: 'Выпуск разрешён' },
       { rowNumber: 2, trackingNumber: 'TRACK002', decision: 'Запрет выпуска' }
@@ -132,14 +132,14 @@ describe('decs.store', () => {
     await expect(promise).resolves.toBeUndefined()
 
     expect(fetchWrapper.get).toHaveBeenCalledTimes(1)
-    expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:8080/api/decs/5/rows?page=1&pageSize=100&sortBy=id&sortOrder=asc')
+    expect(fetchWrapper.get).toHaveBeenCalledWith('http://localhost:8080/api/customsreports/5/rows?page=1&pageSize=100&sortBy=id&sortOrder=asc')
     expect(store.reportRows).toEqual(rows)
     expect(store.loading).toBe(false)
     expect(store.error).toBeNull()
   })
 
   it('stores error when getReportRows fails', async () => {
-    const store = useDecsStore()
+    const store = useCustomsReportsStore()
     const error = new Error('fetch rows failed')
     fetchWrapper.get.mockRejectedValue(error)
 


### PR DESCRIPTION
### Motivation
- Align store module name with the API endpoint and make the purpose clearer by renaming the `decs` store to `customsreports`.

### Description
- Renamed the store module file `src/stores/decs.store.js` to `src/stores/customsreports.store.js` and changed the export to `useCustomsReportsStore` with Pinia id `customsreports` and `baseUrl` set to `${apiUrl}/customsreports`.
- Updated components to import and use `useCustomsReportsStore` instead of `useDecsStore`, and adjusted local variable names in `src/lists/UploadCustomsReports_List.vue` and `src/lists/CustomsReportRows_List.vue`.
- Updated unit tests to reflect the rename and new API paths by renaming `tests/decs.store.spec.js` to `tests/customsreports.store.spec.js` and adjusting mocks and expected URLs, and updated `tests/UploadCustomsReports_List.spec.js` and `tests/CustomsReportRows_List.spec.js` to mock the new store.

### Testing
- Ran lint with `npm run lint` and the linter completed successfully with automatic fixes applied where relevant.
- Ran the test suite with `npm test` and all tests passed (`Test Files 132 passed`, `Tests 1756 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f25999e0c8321bcf37d72ce08f99c)