### PR TITLE
Add productName parcel filter ("Название продукта") and include in parcels API params

### DIFF
--- a/src/components/ParcelFilterSelectors.vue
+++ b/src/components/ParcelFilterSelectors.vue
@@ -13,6 +13,7 @@ const props = defineProps({
   parcelsCheckStatusFc: { type: [String, Number], default: null },
   localTnvedSearch: { type: String, default: '' },
   localParcelNumberSearch: { type: String, default: '' },
+  localProductNameSearch: { type: String, default: '' },
 })
 
 const emit = defineEmits([
@@ -21,6 +22,7 @@ const emit = defineEmits([
   'update:parcelsCheckStatusFc',
   'update:localTnvedSearch',
   'update:localParcelNumberSearch',
+  'update:localProductNameSearch',
 ])
 
 const disabledState = computed(() => {
@@ -57,6 +59,11 @@ const localTnvedSearchModel = computed({
 const localParcelNumberSearchModel = computed({
   get: () => props.localParcelNumberSearch,
   set: (value) => emit('update:localParcelNumberSearch', value),
+})
+
+const localProductNameSearchModel = computed({
+  get: () => props.localProductNameSearch,
+  set: (value) => emit('update:localProductNameSearch', value),
 })
 </script>
 
@@ -99,6 +106,13 @@ const localParcelNumberSearchModel = computed({
       label="Номер посылки"
       density="compact"
       style="min-width: 200px;"
+      :disabled="disabledState.textFieldsDisabled"
+    />
+    <v-text-field
+      v-model="localProductNameSearchModel"
+      label="Название продукта"
+      density="compact"
+      style="min-width: 220px;"
       :disabled="disabledState.textFieldsDisabled"
     />
   </div>

--- a/src/components/ProductLinkWithActions.vue
+++ b/src/components/ProductLinkWithActions.vue
@@ -69,6 +69,7 @@ function handleSelectClick() {
       parcels_check_status_fc: authStore.parcels_check_status_fc?.value ?? authStore.parcels_check_status_fc,
       parcels_tnved: authStore.parcels_tnved?.value ?? authStore.parcels_tnved,
       parcels_number: authStore.parcels_number?.value ?? authStore.parcels_number,
+      parcels_product_name: authStore.parcels_product_name?.value ?? authStore.parcels_product_name,
       parcels_page: authStore.parcels_page?.value ?? authStore.parcels_page,
       parcels_per_page: authStore.parcels_per_page?.value ?? authStore.parcels_per_page
     }

--- a/src/lists/OzonParcels_List.vue
+++ b/src/lists/OzonParcels_List.vue
@@ -76,11 +76,13 @@ const {
   parcels_check_status_fc,
   parcels_tnved,
   parcels_number,
+  parcels_product_name,
   selectedParcelId,
 } = storeToRefs(authStore)
 
 const localTnvedSearch = ref(parcels_tnved.value || '')
 const localParcelNumberSearch = ref(parcels_number.value || '')
+const localProductNameSearch = ref(parcels_product_name.value || '')
 
 function parseSelectedParcelIdFromQuery(value) {
   const rawValue = Array.isArray(value) ? value[0] : value
@@ -254,7 +256,8 @@ const {
 const { triggerLoad, stop: stopFilterSync } = useDebouncedFilterSync({
   filters: [
     { local: localTnvedSearch, store: parcels_tnved },
-    { local: localParcelNumberSearch, store: parcels_number }
+    { local: localParcelNumberSearch, store: parcels_number },
+    { local: localProductNameSearch, store: parcels_product_name }
   ],
   loadFn: loadOrdersWrapper,
   isComponentMounted
@@ -502,6 +505,7 @@ function getGenericTemplateHeaders() {
         v-model:parcels-check-status-fc="parcels_check_status_fc"
         v-model:local-tnved-search="localTnvedSearch"
         v-model:local-parcel-number-search="localParcelNumberSearch"
+        v-model:local-product-name-search="localProductNameSearch"
         :status-options="statusOptions"
         :check-status-options-sw="checkStatusOptionsSw"
         :check-status-options-fc="checkStatusOptionsFc"

--- a/src/lists/Wbr2Parcels_List.vue
+++ b/src/lists/Wbr2Parcels_List.vue
@@ -76,11 +76,13 @@ const {
   parcels_check_status_fc,
   parcels_tnved,
   parcels_number,
+  parcels_product_name,
   selectedParcelId
 } = storeToRefs(authStore)
 
 const localTnvedSearch = ref(parcels_tnved.value || '')
 const localParcelNumberSearch = ref(parcels_number.value || '')
+const localProductNameSearch = ref(parcels_product_name.value || '')
 
 function parseSelectedParcelIdFromQuery(value) {
   const rawValue = Array.isArray(value) ? value[0] : value
@@ -253,7 +255,8 @@ const {
 const { triggerLoad, stop: stopFilterSync } = useDebouncedFilterSync({
   filters: [
     { local: localTnvedSearch, store: parcels_tnved },
-    { local: localParcelNumberSearch, store: parcels_number }
+    { local: localParcelNumberSearch, store: parcels_number },
+    { local: localProductNameSearch, store: parcels_product_name }
   ],
   loadFn: loadOrdersWrapper,
   isComponentMounted
@@ -511,6 +514,7 @@ function getGenericTemplateHeaders() {
         v-model:parcels-check-status-fc="parcels_check_status_fc"
         v-model:local-tnved-search="localTnvedSearch"
         v-model:local-parcel-number-search="localParcelNumberSearch"
+        v-model:local-product-name-search="localProductNameSearch"
         :status-options="statusOptions"
         :check-status-options-sw="checkStatusOptionsSw"
         :check-status-options-fc="checkStatusOptionsFc"

--- a/src/lists/WbrParcels_List.vue
+++ b/src/lists/WbrParcels_List.vue
@@ -77,11 +77,13 @@ const {
   parcels_check_status_fc,
   parcels_tnved,
   parcels_number,
+  parcels_product_name,
   selectedParcelId
 } = storeToRefs(authStore)
 
 const localTnvedSearch = ref(parcels_tnved.value || '')
 const localParcelNumberSearch = ref(parcels_number.value || '')
+const localProductNameSearch = ref(parcels_product_name.value || '')
 
 function parseSelectedParcelIdFromQuery(value) {
   const rawValue = Array.isArray(value) ? value[0] : value
@@ -254,7 +256,8 @@ const {
 const { triggerLoad, stop: stopFilterSync } = useDebouncedFilterSync({
   filters: [
     { local: localTnvedSearch, store: parcels_tnved },
-    { local: localParcelNumberSearch, store: parcels_number }
+    { local: localParcelNumberSearch, store: parcels_number },
+    { local: localProductNameSearch, store: parcels_product_name }
   ],
   loadFn: loadOrdersWrapper,
   isComponentMounted
@@ -509,6 +512,7 @@ function getGenericTemplateHeaders() {
         v-model:parcels-check-status-fc="parcels_check_status_fc"
         v-model:local-tnved-search="localTnvedSearch"
         v-model:local-parcel-number-search="localParcelNumberSearch"
+        v-model:local-product-name-search="localProductNameSearch"
         :status-options="statusOptions"
         :check-status-options-sw="checkStatusOptionsSw"
         :check-status-options-fc="checkStatusOptionsFc"

--- a/src/stores/auth.store.js
+++ b/src/stores/auth.store.js
@@ -99,6 +99,7 @@ export const useAuthStore = defineStore('auth', () => {
   const parcels_check_status_fc = ref(null)
   const parcels_tnved = ref('')
   const parcels_number = ref('')
+  const parcels_product_name = ref('')
   const parcelstatuses_per_page = ref(100)
   const parcelstatuses_search = ref('')
   const parcelstatuses_sort_by = ref(['id'])
@@ -239,6 +240,7 @@ export const useAuthStore = defineStore('auth', () => {
         if (snap.parcels_check_status_fc != null) parcels_check_status_fc.value = snap.parcels_check_status_fc
         if (snap.parcels_tnved != null) parcels_tnved.value = snap.parcels_tnved
         if (snap.parcels_number != null) parcels_number.value = snap.parcels_number
+        if (snap.parcels_product_name != null) parcels_product_name.value = snap.parcels_product_name
         if (snap.parcels_page != null) parcels_page.value = snap.parcels_page
         if (snap.parcels_per_page != null) parcels_per_page.value = snap.parcels_per_page
 
@@ -298,6 +300,7 @@ export const useAuthStore = defineStore('auth', () => {
     parcels_check_status_fc,
     parcels_tnved,
     parcels_number,
+    parcels_product_name,
     parcelstatuses_per_page,
     parcelstatuses_search,
     parcelstatuses_sort_by,

--- a/src/stores/parcels.store.js
+++ b/src/stores/parcels.store.js
@@ -39,6 +39,10 @@ export function buildParcelsFilterParams(authStore, additionalParams = {}) {
     params.append('number', authStore.parcels_number)
   }
 
+  if (authStore.parcels_product_name) {
+    params.append('productName', authStore.parcels_product_name)
+  }
+
   return params
 }
 

--- a/tests/ParcelFilterSelectors.spec.js
+++ b/tests/ParcelFilterSelectors.spec.js
@@ -18,6 +18,7 @@ describe('ParcelFilterSelectors', () => {
       parcelsCheckStatusFc: null,
       localTnvedSearch: '',
       localParcelNumberSearch: '',
+      localProductNameSearch: '',
       ...props,
     },
     global: {
@@ -41,7 +42,7 @@ describe('ParcelFilterSelectors', () => {
     const textFieldNodes = wrapper.findAll('.v-text-field-stub')
 
     expect(selectNodes).toHaveLength(3)
-    expect(textFieldNodes).toHaveLength(2)
+    expect(textFieldNodes).toHaveLength(3)
 
     selectNodes.forEach((node) => {
       expect(node.attributes('data-disabled')).toBe(String(expectedSelectDisabled))
@@ -81,6 +82,7 @@ describe('ParcelFilterSelectors', () => {
     wrapper.vm.parcelsCheckStatusFcModel = 'fc'
     wrapper.vm.localTnvedSearchModel = '1234'
     wrapper.vm.localParcelNumberSearchModel = 'ABC'
+    wrapper.vm.localProductNameSearchModel = 'Product X'
 
     await wrapper.vm.$nextTick()
 
@@ -89,6 +91,7 @@ describe('ParcelFilterSelectors', () => {
     expect(wrapper.emitted('update:parcelsCheckStatusFc')?.[0]).toEqual(['fc'])
     expect(wrapper.emitted('update:localTnvedSearch')?.[0]).toEqual(['1234'])
     expect(wrapper.emitted('update:localParcelNumberSearch')?.[0]).toEqual(['ABC'])
+    expect(wrapper.emitted('update:localProductNameSearch')?.[0]).toEqual(['Product X'])
   })
   it('keeps controls disabled when multiple blocking flags are active', () => {
     const wrapper = mountComponent({ runningAction: true, loading: true, isInitializing: true })

--- a/tests/Parcels_HeaderActions.spec.js
+++ b/tests/Parcels_HeaderActions.spec.js
@@ -118,6 +118,7 @@ function setupStores() {
     parcels_check_status_fc: ref(null),
     parcels_tnved: ref(''),
     parcels_number: ref(''),
+    parcels_product_name: ref(''),
     selectedParcelId: ref(null),
     isSrLogistPlus: ref(true)
   }
@@ -154,6 +155,7 @@ vi.mock('pinia', async () => {
             parcels_check_status_fc: stores.auth.parcels_check_status_fc,
             parcels_tnved: stores.auth.parcels_tnved,
             parcels_number: stores.auth.parcels_number,
+            parcels_product_name: stores.auth.parcels_product_name,
             selectedParcelId: stores.auth.selectedParcelId,
             isSrLogistPlus: stores.auth.isSrLogistPlus
           }

--- a/tests/ProductLinkWithActions.spec.js
+++ b/tests/ProductLinkWithActions.spec.js
@@ -304,6 +304,7 @@ describe('ProductLinkWithActions', () => {
     mockAuthStore.parcels_check_status_fc = null
     mockAuthStore.parcels_tnved = ''
     mockAuthStore.parcels_number = ''
+    mockAuthStore.parcels_product_name = 'Headphones'
     mockAuthStore.parcels_page = 1
     mockAuthStore.parcels_per_page = 100
 
@@ -331,6 +332,7 @@ describe('ProductLinkWithActions', () => {
     expect(snap.parcels_check_status_fc).toEqual(mockAuthStore.parcels_check_status_fc)
     expect(snap.parcels_tnved).toEqual(mockAuthStore.parcels_tnved)
     expect(snap.parcels_number).toEqual(mockAuthStore.parcels_number)
+    expect(snap.parcels_product_name).toEqual(mockAuthStore.parcels_product_name)
     expect(snap.parcels_page).toEqual(mockAuthStore.parcels_page)
     expect(snap.parcels_per_page).toEqual(mockAuthStore.parcels_per_page)
   })

--- a/tests/authStore.spec.js
+++ b/tests/authStore.spec.js
@@ -516,6 +516,7 @@ describe('auth store', () => {
         parcels_check_status_fc: 'verified',
         parcels_tnved: '1234567890',
         parcels_number: 'TEST-123',
+        parcels_product_name: 'Phone',
         parcels_page: 2,
         parcels_per_page: 50
       }
@@ -536,6 +537,7 @@ describe('auth store', () => {
       expect(store.parcels_check_status_fc).toBe(snapshot.parcels_check_status_fc)
       expect(store.parcels_tnved).toBe(snapshot.parcels_tnved)
       expect(store.parcels_number).toBe(snapshot.parcels_number)
+      expect(store.parcels_product_name).toBe(snapshot.parcels_product_name)
       expect(store.parcels_page).toBe(snapshot.parcels_page)
       expect(store.parcels_per_page).toBe(snapshot.parcels_per_page)
       

--- a/tests/parcels.store.spec.js
+++ b/tests/parcels.store.spec.js
@@ -32,7 +32,8 @@ const mockAuthStore = {
   parcels_check_status_sw: null,
   parcels_check_status_fc: null,
   parcels_tnved: '',
-  parcels_number: ''
+  parcels_number: '',
+  parcels_product_name: ''
 }
 
 vi.mock('@/stores/auth.store.js', () => ({
@@ -52,6 +53,7 @@ describe('parcels store', () => {
     mockAuthStore.parcels_check_status_fc = null
     mockAuthStore.parcels_tnved = ''
     mockAuthStore.parcels_number = ''
+    mockAuthStore.parcels_product_name = ''
   })
 
   it('fetches data with default parameters from auth store', async () => {
@@ -116,15 +118,28 @@ describe('parcels store', () => {
     )
   })
 
-  it('fetches data with combined tnved and number filtering', async () => {
+  it('fetches data with combined tnved, number and product name filtering', async () => {
     mockAuthStore.parcels_tnved = 'AA'
     mockAuthStore.parcels_number = 'OZON456'
+    mockAuthStore.parcels_product_name = 'Notebook'
     
     fetchWrapper.get.mockResolvedValue({ items: [], pagination: {} })
     const store = useParcelsStore()
     await store.getAll(2)
     expect(fetchWrapper.get).toHaveBeenCalledWith(
-      `${apiUrl}/parcels?registerId=2&page=1&pageSize=100&sortBy=id&sortOrder=asc&tnVed=AA&number=OZON456`
+      `${apiUrl}/parcels?registerId=2&page=1&pageSize=100&sortBy=id&sortOrder=asc&tnVed=AA&number=OZON456&productName=Notebook`
+    )
+  })
+
+
+  it('fetches data with product name filtering', async () => {
+    mockAuthStore.parcels_product_name = 'Телефон'
+
+    fetchWrapper.get.mockResolvedValue({ items: [], pagination: {} })
+    const store = useParcelsStore()
+    await store.getAll(4)
+    expect(fetchWrapper.get).toHaveBeenCalledWith(
+      `${apiUrl}/parcels?registerId=4&page=1&pageSize=100&sortBy=id&sortOrder=asc&productName=%D0%A2%D0%B5%D0%BB%D0%B5%D1%84%D0%BE%D0%BD`
     )
   })
 


### PR DESCRIPTION
### Motivation
- Backend now accepts an additional search/filter parameter `productName` and the UI must expose a text field for it and pass it through to parcel queries.
- Filters persisted for extension flows should include the new product-name so the user view is restored correctly after external interactions.

### Description
- Added a new text field `localProductNameSearch` to `ParcelFilterSelectors` with label "Название продукта" and full `v-model` emit support (`update:localProductNameSearch`).
- Wired `parcels_product_name` into the auth store snapshot persistence/restoration and included it in the extension snapshot saved by `ProductLinkWithActions`.
- Propagated the new filter through the parcel list pages (WBR, WBR2, OZON) by adding a local ref, syncing it via `useDebouncedFilterSync`, and binding it to the selectors.
- Updated `buildParcelsFilterParams` to append `productName` to the `/parcels` query params and adjusted unit tests to cover the new behavior and snapshot fields.

### Testing
- Ran `npm run lint` and ESLint auto-fix, which completed successfully.
- Ran targeted unit tests for the modified areas with `npm run test -- tests/ParcelFilterSelectors.spec.js tests/parcels.store.spec.js tests/authStore.spec.js tests/ProductLinkWithActions.spec.js`, and all tests passed.
- Ran coverage for the targeted tests with `npm run coverage` for the same test set and the run completed successfully.
- Ran the full test suite with `npm run test` and observed all tests passing locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adf5765e4c8321964b796ba7677f8a)