### PR TITLE
Replace transfer register selector with duplicate-check flag

### DIFF
--- a/src/dialogs/Register_EditDialog.vue
+++ b/src/dialogs/Register_EditDialog.vue
@@ -20,7 +20,6 @@ import ActionDialog from '@/components/ActionDialog.vue'
 import ErrorDialog from '@/components/ErrorDialog.vue'
 import { useActionDialog } from '@/composables/useActionDialog.js'
 import { useAlertStore } from '@/stores/alert.store.js'
-import { generateRegisterName } from '@/helpers/parcels.list.helpers.js'
 import AirportSelectField from '@/components/AirportSelectField.vue'
 import { OP_MODE_PAPERWORK, getRegisterNouns } from '@/helpers/op.mode.js'
 
@@ -33,7 +32,7 @@ const props = defineProps({
 const alertStore = useAlertStore()
 
 const registersStore = useRegistersStore()
-const { item, uploadFile, items, ops } = storeToRefs(registersStore)
+const { item, uploadFile, ops } = storeToRefs(registersStore)
 
 const countriesStore = useCountriesStore()
 const { countries } = storeToRefs(countriesStore)
@@ -77,22 +76,6 @@ const procedureCodeLoaded = ref(false)
 const isComponentMounted = ref(true)
 const isInitializing = ref(true)
 const isSubmitting = ref(false)
-const transferRegisterId = ref('')
-
-const registerOptions = computed(() => {
-  if (!Array.isArray(items.value)) return []
-
-  // Only include registers of the same register type as the one we are editing/creating for
-  const registerType = item.value?.registerType ?? null
-  if (!registerType) return []
-
-  return items.value
-    .filter((register) => register && typeof register === 'object' && (register.registerType == registerType))
-    .map((register) => ({
-      id: register.id,
-      name: generateRegisterName(register.dealNumber, register.fileName)
-    }))
-})
 
 const airportOptions = computed(() => (Array.isArray(airports.value) ? airports.value : []))
 const warehouseOptions = computed(() => {
@@ -215,11 +198,6 @@ watch(
         item.value.warehouseId = 0
       }
     } else {
-      try {
-        await registersStore.getAll()
-      } catch (error) {
-        alertStore.error(`Не удалось загрузить список ${registerNouns.value.genitivePlural}: ` + (error?.message || String(error)))
-      }
       // Set default values for new records
       if (item.value.customsProcedureCode == null) {
         item.value.customsProcedureCode = filteredCustomsProcedures.value[0]?.value ?? null
@@ -394,14 +372,6 @@ function handleProcedureChange(e) {
   updateDirection()
 }
 
-function onLookupForReimportChange(e) {
-  // Field may emit a boolean or a DOM event
-  const checked = typeof e === 'boolean' ? e : (e?.target?.checked ?? false)
-  if (checked) {
-    transferRegisterId.value = ''
-  }
-}
-
 function getTitle() {
   return props.create
     ? `Загрузка ${registerNouns.value.genitiveSingular}`
@@ -472,14 +442,11 @@ async function onSubmit(values) {
     if (props.create) {
       showActionDialog('upload-register')
       try {
-        const sourceRegisterId = transferRegisterId.value === ''
-          ? 0
-          : parseInt(transferRegisterId.value, 10)
         const result = await registersStore.upload(
           uploadFile.value,
           item.value.registerType,
           item.value.customsProcedureCode,
-          Number.isNaN(sourceRegisterId) ? 0 : sourceRegisterId,
+          Boolean(values.checkForDuplicates),
           Boolean(values.lookupForReimport)
         )
         if (!isComponentMounted.value) return
@@ -802,24 +769,18 @@ function getCustomerName(customerId) {
 
         <div class="form-row" v-if="props.create && props.mode === OP_MODE_PAPERWORK">
           <div class="form-group">
-            <label for="transferRegisterId" class="label">Перенести статусы из {{ registerNouns.genitiveSingular }}:</label>
-            <Field name="lookupForReimport" v-slot="{ value }">
-              <select
-                id="transferRegisterId"
-                class="form-control input"
-                v-model="transferRegisterId"
-                :disabled="value"
-              >
-                <option value="">Не выбрано</option>
-                <option
-                  v-for="register in registerOptions"
-                  :key="register.id"
-                  :value="register.id"
-                >
-                  {{ register.name }}
-                </option>
-              </select>
-            </Field>
+            <label for="checkForDuplicates" class="custom-checkbox">
+              <Field
+                id="checkForDuplicates"
+                type="checkbox"
+                name="checkForDuplicates"
+                :value="true"
+                :unchecked-value="false"
+                class="custom-checkbox-input"
+              />
+              <span class="custom-checkbox-box"></span>
+              <span class="label custom-checkbox-label">Проверить на дубликаты</span>
+            </label>
           </div>
 
           <div class="form-group" v-if="props.mode === OP_MODE_PAPERWORK">
@@ -832,7 +793,6 @@ function getCustomerName(customerId) {
                 :unchecked-value="false"
                 class="custom-checkbox-input"
                 :disabled="!isRe"
-                @change="onLookupForReimportChange"
               />
               <span class="custom-checkbox-box"></span>
               <span class="label custom-checkbox-label">Для реимпорта использовать предшествующие данные</span>

--- a/src/stores/registers.store.js
+++ b/src/stores/registers.store.js
@@ -146,7 +146,7 @@ export const useRegistersStore = defineStore('registers', () => {
     }
   }
 
-  async function upload(file, registerType, customsProcedure, sourceRegisterId = 0, transfer2Reimport = false) {
+  async function upload(file, registerType, customsProcedure, checkForDuplicates, transfer2Reimport = false) {
     loading.value = true
     error.value = null
     try {
@@ -157,7 +157,7 @@ export const useRegistersStore = defineStore('registers', () => {
       const params = new URLSearchParams()
       params.append('registerType', registerType)
       params.append('customsProcedure', customsProcedure)
-      params.append('sourceRegisterId', sourceRegisterId)
+      params.append('checkForDuplicates', checkForDuplicates ? 'true' : 'false')
       params.append('transfer2Reimport', transfer2Reimport ? 'true' : 'false')
       
       const url = `${baseUrl}/upload?${params.toString()}`

--- a/tests/Register_EditDialog.spec.js
+++ b/tests/Register_EditDialog.spec.js
@@ -651,7 +651,6 @@ describe('Register_EditDialog', () => {
   it('handles create mode with upload', async () => {
     registersStore.uploadFile.value = new File(['data'], 'test.xlsx')
     mockItem.value = { ...baseRegisterItem, fileName: 'test.xlsx', companyId: 2 }
-    registerItems.value = []
 
     const Parent = {
       template: '<Suspense><RegisterEditDialog :create="true" /></Suspense>',
@@ -663,75 +662,42 @@ describe('Register_EditDialog', () => {
     await resolveAll()
 
     expect(getById).not.toHaveBeenCalled()
-    expect(getAll).toHaveBeenCalled()
     expect(wrapper.find('h1').text()).toBe('Загрузка реестра')
     expect(wrapper.find('button[type="submit"]').text()).toContain('Загрузить')
 
     const dialog = wrapper.findComponent(RegisterEditDialog)
     await dialog.vm.onSubmit({}, { setErrors: () => {} })
     await resolveAll()
-    expect(upload).toHaveBeenCalledWith(registersStore.uploadFile.value, mockItem.value.companyId, mockItem.value.customsProcedureCode, 0, false)
+    expect(upload).toHaveBeenCalledWith(registersStore.uploadFile.value, mockItem.value.companyId, mockItem.value.customsProcedureCode, false, false)
     expect(router.push).toHaveBeenCalledWith('/registers?mode=modePaperwork')
   })
 
-  it('still renders create dialog when register list fetch fails', async () => {
-    const loadError = new Error('load failed')
-    getAll.mockRejectedValueOnce(loadError)
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-    try {
-      const Parent = {
-        template: '<Suspense><RegisterEditDialog :create="true" /></Suspense>',
-        components: { RegisterEditDialog }
-      }
-      const wrapper = mount(Parent, {
-        global: { stubs: { ...defaultGlobalStubs, Form: FormStub, Field: FieldStub, ErrorDialog: ErrorDialogStub } }
-      })
-
-      await resolveAll()
-
-      expect(getAll).toHaveBeenCalled()
-      expect(wrapper.find('h1').text()).toBe('Загрузка реестра')
-      const selector = wrapper.find('select#transferRegisterId')
-      expect(selector.exists()).toBe(true)
-      expect(selector.findAll('option')).toHaveLength(1)
-    } finally {
-      consoleErrorSpy.mockRestore()
-    }
-  })
-
-  it('renders transfer register selector with generated names', async () => {
-    registerItems.value = [
-      { id: 10, dealNumber: 'D-100', fileName: 'reg-100.xlsx', registerType: 2, companyId: 2 },
-      { id: 11, dealNumber: '', fileName: 'reg-empty.xlsx', registerType: 2, companyId: 2 }
-    ]
-
+  it('renders checkForDuplicates checkbox in create mode only', async () => {
     const Parent = {
       template: '<Suspense><RegisterEditDialog :create="true" /></Suspense>',
       components: { RegisterEditDialog }
     }
-    const wrapper = mount(Parent, {
+    const createWrapper = mount(Parent, {
       global: { stubs: { ...defaultGlobalStubs, Form: FormStub, Field: FieldStub, ErrorDialog: ErrorDialogStub } }
     })
 
     await resolveAll()
+    expect(createWrapper.find('input#checkForDuplicates').exists()).toBe(true)
 
-    const selector = wrapper.find('select#transferRegisterId')
-    expect(selector.exists()).toBe(true)
-
-    const optionTexts = selector.findAll('option').map((option) => option.text())
-    expect(optionTexts).toContain('Не выбрано')
-    expect(optionTexts).toContain('Реестр для сделки D-100')
-    expect(optionTexts).toContain('Реестр для сделки без номера (файл: reg-empty.xlsx)')
+    const EditParent = {
+      template: '<Suspense><RegisterEditDialog :id="1" :create="false" /></Suspense>',
+      components: { RegisterEditDialog }
+    }
+    const editWrapper = mount(EditParent, {
+      global: { stubs: { ...defaultGlobalStubs, Form: FormStub, Field: FieldStub, ErrorDialog: ErrorDialogStub } }
+    })
+    await resolveAll()
+    expect(editWrapper.find('input#checkForDuplicates').exists()).toBe(false)
   })
 
-  it('passes selected register id to upload when provided', async () => {
-    registerItems.value = [
-      { id: 20, dealNumber: 'D-200', fileName: 'reg-200.xlsx', companyId: 3, registerType: 3 }
-    ]
+  it('passes checkForDuplicates flag to upload when selected', async () => {
     registersStore.uploadFile.value = new File(['data'], 'test.xlsx')
     mockItem.value = { ...baseRegisterItem, fileName: 'test.xlsx', companyId: 3, registerType: 3 }
-
     const Parent = {
       template: '<Suspense><RegisterEditDialog :create="true" /></Suspense>',
       components: { RegisterEditDialog }
@@ -741,22 +707,20 @@ describe('Register_EditDialog', () => {
     })
 
     await resolveAll()
-
-    const selector = wrapper.find('select#transferRegisterId')
-    await selector.setValue('20')
+    const checkForDuplicates = wrapper.find('input#checkForDuplicates')
+    await checkForDuplicates.setValue(true)
 
     const dialog = wrapper.findComponent(RegisterEditDialog)
-    await dialog.vm.onSubmit({}, { setErrors: () => {} })
+    await dialog.vm.onSubmit({ checkForDuplicates: true }, { setErrors: () => {} })
     await resolveAll()
 
-    expect(upload).toHaveBeenCalledWith(registersStore.uploadFile.value, mockItem.value.companyId, mockItem.value.customsProcedureCode, 20, false)
+    expect(upload).toHaveBeenCalledWith(registersStore.uploadFile.value, mockItem.value.companyId, mockItem.value.customsProcedureCode, true, false)
   })
 
   it('handles create mode with upload result object', async () => {
     upload.mockResolvedValueOnce({ success: true, registerId: 42, ErrMsg: '' })
     registersStore.uploadFile.value = new File(['data'], 'test.xlsx')
     mockItem.value = { ...baseRegisterItem, fileName: 'test.xlsx', registerType: 2, companyId: 2 }
-    registerItems.value = []
     const formValues = { dealNumber: 'D42', invoiceNumber: 'INV42' }
 
     const Parent = {
@@ -773,7 +737,7 @@ describe('Register_EditDialog', () => {
     await resolveAll()
     
     // Verify upload was called
-    expect(upload).toHaveBeenCalledWith(registersStore.uploadFile.value, mockItem.value.companyId, mockItem.value.customsProcedureCode, 0, false)
+    expect(upload).toHaveBeenCalledWith(registersStore.uploadFile.value, mockItem.value.companyId, mockItem.value.customsProcedureCode, false, false)
     
     // Verify update was called with the Id from the Reference object and the sanitized form values
     expect(update).toHaveBeenCalledWith(42, expect.objectContaining({
@@ -913,7 +877,7 @@ describe('Register_EditDialog', () => {
     await resolveAll()
 
     // Verify upload was called
-    expect(upload).toHaveBeenCalledWith(registersStore.uploadFile.value, mockItem.value.companyId, mockItem.value.customsProcedureCode, 0, false)
+    expect(upload).toHaveBeenCalledWith(registersStore.uploadFile.value, mockItem.value.companyId, mockItem.value.customsProcedureCode, false, false)
     
 
     // Update may be attempted; ensure at least the upload was triggered and the dialog flow completed

--- a/tests/registers.store.spec.js
+++ b/tests/registers.store.spec.js
@@ -569,49 +569,29 @@ describe('registers store', () => {
       fetchWrapper.postFile.mockResolvedValue({ id: 1 })
 
       const store = useRegistersStore()
-      await store.upload(file, customerId, customsProcedure)
+      await store.upload(file, customerId, customsProcedure, false)
 
       expect(fetchWrapper.postFile).toHaveBeenCalled()
       expect(fetchWrapper.postFile.mock.calls[0][0]).toBe(
-        `${apiUrl}/registers/upload?registerType=123&customsProcedure=1&sourceRegisterId=0&transfer2Reimport=false`
+        `${apiUrl}/registers/upload?registerType=123&customsProcedure=1&checkForDuplicates=false&transfer2Reimport=false`
       )
       const formData = fetchWrapper.postFile.mock.calls[0][1]
       expect(formData instanceof FormData).toBe(true)
       expect(formData.get('file')).toBe(file)
     })
 
-    it('uploads file with sourceRegisterId parameter', async () => {
+    it('uploads file with checkForDuplicates=true', async () => {
       const file = new File(['data'], 'test.xlsx')
       const customerId = 123
       const customsProcedure = 2
-      const sourceRegisterId = 777
       fetchWrapper.postFile.mockResolvedValue({ id: 2 })
 
       const store = useRegistersStore()
-      await store.upload(file, customerId, customsProcedure, sourceRegisterId)
+      await store.upload(file, customerId, customsProcedure, true)
 
       expect(fetchWrapper.postFile).toHaveBeenCalled()
       expect(fetchWrapper.postFile.mock.calls[0][0]).toBe(
-        `${apiUrl}/registers/upload?registerType=123&customsProcedure=2&sourceRegisterId=777&transfer2Reimport=false`
-      )
-      const formData = fetchWrapper.postFile.mock.calls[0][1]
-      expect(formData instanceof FormData).toBe(true)
-      expect(formData.get('file')).toBe(file)
-    })
-
-    it('uploads file with sourceRegisterId zero explicitly set', async () => {
-      const file = new File(['data'], 'test.xlsx')
-      const customerId = 123
-      const customsProcedure = 1
-      const sourceRegisterId = 0
-      fetchWrapper.postFile.mockResolvedValue({ id: 3 })
-
-      const store = useRegistersStore()
-      await store.upload(file, customerId, customsProcedure, sourceRegisterId)
-
-      expect(fetchWrapper.postFile).toHaveBeenCalled()
-      expect(fetchWrapper.postFile.mock.calls[0][0]).toBe(
-        `${apiUrl}/registers/upload?registerType=123&customsProcedure=1&sourceRegisterId=0&transfer2Reimport=false`
+        `${apiUrl}/registers/upload?registerType=123&customsProcedure=2&checkForDuplicates=true&transfer2Reimport=false`
       )
       const formData = fetchWrapper.postFile.mock.calls[0][1]
       expect(formData instanceof FormData).toBe(true)
@@ -622,14 +602,14 @@ describe('registers store', () => {
       const file = new File(['data'], 'test.xlsx')
       const customerId = 123
       const customsProcedure = 1
-      fetchWrapper.postFile.mockResolvedValue({ id: 4 })
+      fetchWrapper.postFile.mockResolvedValue({ id: 3 })
 
       const store = useRegistersStore()
-      await store.upload(file, customerId, customsProcedure, 0, true)
+      await store.upload(file, customerId, customsProcedure, false, true)
 
       expect(fetchWrapper.postFile).toHaveBeenCalled()
       expect(fetchWrapper.postFile.mock.calls[0][0]).toBe(
-        `${apiUrl}/registers/upload?registerType=123&customsProcedure=1&sourceRegisterId=0&transfer2Reimport=true`
+        `${apiUrl}/registers/upload?registerType=123&customsProcedure=1&checkForDuplicates=false&transfer2Reimport=true`
       )
       const formData = fetchWrapper.postFile.mock.calls[0][1]
       expect(formData instanceof FormData).toBe(true)
@@ -640,15 +620,14 @@ describe('registers store', () => {
       const file = new File(['data'], 'test.xlsx')
       const customerId = 123
       const customsProcedure = 3
-      const sourceRegisterId = 777
-      fetchWrapper.postFile.mockResolvedValue({ id: 5 })
+      fetchWrapper.postFile.mockResolvedValue({ id: 4 })
 
       const store = useRegistersStore()
-      await store.upload(file, customerId, customsProcedure, sourceRegisterId, true)
+      await store.upload(file, customerId, customsProcedure, true, true)
 
       expect(fetchWrapper.postFile).toHaveBeenCalled()
       expect(fetchWrapper.postFile.mock.calls[0][0]).toBe(
-        `${apiUrl}/registers/upload?registerType=123&customsProcedure=3&sourceRegisterId=777&transfer2Reimport=true`
+        `${apiUrl}/registers/upload?registerType=123&customsProcedure=3&checkForDuplicates=true&transfer2Reimport=true`
       )
       const formData = fetchWrapper.postFile.mock.calls[0][1]
       expect(formData instanceof FormData).toBe(true)
@@ -661,7 +640,7 @@ describe('registers store', () => {
       fetchWrapper.postFile.mockRejectedValue(new Error('fail'))
 
       const store = useRegistersStore()
-      await expect(store.upload(file, registerType, 1)).rejects.toThrow('fail')
+      await expect(store.upload(file, registerType, 1, false)).rejects.toThrow('fail')
       expect(store.error).toBeTruthy()
       expect(store.loading).toBe(false)
     })


### PR DESCRIPTION
### Motivation
- Simplify upload UX by removing the transfer-from-register selector and adding an explicit duplicate-check option when creating a register. 
- Align upload API with new behavior by passing a boolean `checkForDuplicates` instead of a `sourceRegisterId`.
- Update unit tests to reflect the new UI and store contract and keep coverage for affected modules high.

### Description
- Removed the `transferRegisterId` selector and related logic from `Register_EditDialog.vue` and replaced it with a create-mode checkbox `checkForDuplicates` (label: "Проверить на дубликаты").
- Updated `Register_EditDialog.vue` to pass `Boolean(values.checkForDuplicates)` to `registersStore.upload(...)` and removed code that used `transferRegisterId` and `registerOptions`.
- Modified `src/stores/registers.store.js` `upload` signature to `upload(file, registerType, customsProcedure, checkForDuplicates, transfer2Reimport = false)` and updated the request query to include `checkForDuplicates` instead of `sourceRegisterId`.
- Updated unit tests in `tests/Register_EditDialog.spec.js` to assert checkbox visibility and that `upload` receives the new `checkForDuplicates` boolean, and updated `tests/registers.store.spec.js` to validate the new upload URL/query parameter combinations.
- Removed an unused helper import that was only used for the removed selector.

### Testing
- Ran lint with `npm run lint` and it completed successfully.
- Ran unit tests for the changed areas with `npm run test -- tests/Register_EditDialog.spec.js tests/registers.store.spec.js` and all tests passed (116 tests across targeted files; 2 test files passed).
- Ran coverage for the same test set with `npm run coverage -- tests/Register_EditDialog.spec.js tests/registers.store.spec.js` and the targeted store file shows high coverage (example: `registers.store.js` statements coverage ~95.85% in the targeted run).
- No automated failures encountered in the modified test suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc381d9ef08321a978cb839d297b13)