### PR TITLE
Handle modifier-key clicks in ClickableCell

### DIFF
--- a/src/components/ClickableCell.vue
+++ b/src/components/ClickableCell.vue
@@ -14,8 +14,8 @@ const props = defineProps({
 
 const emit = defineEmits(['click'])
 
-function handleClick() {
-  if (props.disabled) {
+function handleClick(event) {
+  if (props.disabled || event.shiftKey || event.ctrlKey || event.metaKey) {
     return
   }
   emit('click', props.item)

--- a/tests/ClickableCell.spec.js
+++ b/tests/ClickableCell.spec.js
@@ -127,6 +127,33 @@ describe('ClickableCell', () => {
       expect(wrapper.emitted('click')).toBeFalsy()
       expect(span.classes()).toContain('clickable-cell-disabled')
     })
+
+    it('does not emit click event when shift is pressed', async () => {
+      const wrapper = createWrapper()
+      const span = wrapper.find('span')
+
+      await span.trigger('click', { shiftKey: true })
+
+      expect(wrapper.emitted('click')).toBeFalsy()
+    })
+
+    it('does not emit click event when control is pressed', async () => {
+      const wrapper = createWrapper()
+      const span = wrapper.find('span')
+
+      await span.trigger('click', { ctrlKey: true })
+
+      expect(wrapper.emitted('click')).toBeFalsy()
+    })
+
+    it('does not emit click event when command is pressed', async () => {
+      const wrapper = createWrapper()
+      const span = wrapper.find('span')
+
+      await span.trigger('click', { metaKey: true })
+
+      expect(wrapper.emitted('click')).toBeFalsy()
+    })
   })
 
   describe('props validation', () => {


### PR DESCRIPTION
### Motivation
- Allow parent components to handle modifier-key clicks (Shift, Ctrl, Command/Meta) instead of the cell consuming the event.
- Preserve existing behavior of ignoring clicks when `disabled` is true while enabling standard modifier-click UX (e.g., multi-select or open-in-new-tab) at the parent level.

### Description
- Change `handleClick` signature to accept the event and return early when `props.disabled || event.shiftKey || event.ctrlKey || event.metaKey` in `src/components/ClickableCell.vue`.
- Add unit tests in `tests/ClickableCell.spec.js` to assert that `click` is not emitted when `shiftKey`, `ctrlKey`, or `metaKey` are present.
- Keep existing tests and disabled-state behavior intact and unchanged.

### Testing
- Ran unit tests with `npm run test` and the suite completed successfully with all tests passing (including the updated `ClickableCell` tests). 
- Ran linter with `npm run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c190744a7c8321aa900bda4fe5923b)