### PR TITLE
Use FEACN tooltip helper and show FEACN name in AssignTnvedDialog

### DIFF
--- a/src/l2/AssignTnvedDialog.vue
+++ b/src/l2/AssignTnvedDialog.vue
@@ -7,7 +7,7 @@ import { computed, ref, watch, onUnmounted, nextTick } from 'vue'
 import ActionButton from '@/components/ActionButton.vue'
 import FeacnCodeSearch from '@/components/FeacnCodeSearch.vue'
 import FeacnCodeSearchByKeyword from '@/components/FeacnCodeSearchByKeyword.vue'
-import { getFeacnTooltip } from '@/helpers/feacn.info.helpers.js'
+import { getFeacnInfo } from '@/helpers/feacn.info.helpers.js'
 
 const props = defineProps({
   show: { type: Boolean, required: true },
@@ -53,7 +53,7 @@ const validationMessage = computed(() => {
   if (!hasCorrectFormat.value) return 'Введите 10 цифр для кода ТН ВЭД'
   if (tnvedChecking.value) return 'Проверка кода ТН ВЭД...'
   if (tnvedLookupError.value) return tnvedLookupError.value
-  if (tnvedExists.value === false) return 'Несуществующий код ТН ВЭД'
+  if (tnvedExists.value === false) return notFoundMessage
   return ''
 })
 
@@ -63,13 +63,13 @@ async function lookupTnVed(code) {
   tnvedLookupError.value = ''
   tnvedName.value = ''
   try {
-    const fetchedName = await getFeacnTooltip(code)
+    const { name: fetchedName, found } = await getFeacnInfo(code)
     // Ignore result if user has already changed the code
     if (code !== normalizedTargetTnVed.value) {
       return
     }
-    tnvedExists.value = fetchedName !== notFoundMessage
-    tnvedName.value = tnvedExists.value ? fetchedName : ''
+    tnvedExists.value = found === true
+    tnvedName.value = found === true ? fetchedName : ''
   } catch {
     // Ignore error if it relates to an outdated code
     if (code !== normalizedTargetTnVed.value) {

--- a/src/l2/AssignTnvedDialog.vue
+++ b/src/l2/AssignTnvedDialog.vue
@@ -7,7 +7,7 @@ import { computed, ref, watch, onUnmounted, nextTick } from 'vue'
 import ActionButton from '@/components/ActionButton.vue'
 import FeacnCodeSearch from '@/components/FeacnCodeSearch.vue'
 import FeacnCodeSearchByKeyword from '@/components/FeacnCodeSearchByKeyword.vue'
-import { useFeacnCodesStore } from '@/stores/feacn.codes.store.js'
+import { getFeacnTooltip } from '@/helpers/feacn.info.helpers.js'
 
 const props = defineProps({
   show: { type: Boolean, required: true },
@@ -30,8 +30,6 @@ function handleKeydown(event) {
   }
 }
 
-const feacnCodesStore = useFeacnCodesStore()
-
 const targetTnVed = ref('')
 const searchActive = ref(false)
 const keywordSearchActive = ref(false)
@@ -43,7 +41,9 @@ const hasCorrectFormat = computed(() => /^\d{10}$/.test(normalizedTargetTnVed.va
 const tnvedExists = ref(null)    // null = not checked, true/false = result
 const tnvedChecking = ref(false)
 const tnvedLookupError = ref('')
+const tnvedName = ref('')
 let lookupTimeout = null
+const notFoundMessage = 'Несуществующий код ТН ВЭД'
 
 const isTnVedValid = computed(() => hasCorrectFormat.value && tnvedExists.value === true)
 
@@ -61,20 +61,22 @@ async function lookupTnVed(code) {
   tnvedChecking.value = true
   tnvedExists.value = null
   tnvedLookupError.value = ''
+  tnvedName.value = ''
   try {
-    const result = await feacnCodesStore.getByCode(code)
+    const fetchedName = await getFeacnTooltip(code)
     // Ignore result if user has already changed the code
     if (code !== normalizedTargetTnVed.value) {
       return
     }
-    tnvedExists.value = !!result
+    tnvedExists.value = fetchedName !== notFoundMessage
+    tnvedName.value = tnvedExists.value ? fetchedName : ''
   } catch {
     // Ignore error if it relates to an outdated code
     if (code !== normalizedTargetTnVed.value) {
       return
     }
     tnvedExists.value = false
-    tnvedLookupError.value = 'Несуществующий код ТН ВЭД'
+    tnvedLookupError.value = notFoundMessage
   } finally {
     // Only clear the checking flag for the currently active code
     if (code === normalizedTargetTnVed.value) {
@@ -91,6 +93,7 @@ watch(normalizedTargetTnVed, (code) => {
   tnvedExists.value = null
   tnvedLookupError.value = ''
   tnvedChecking.value = false
+  tnvedName.value = ''
 
   if (hasCorrectFormat.value) {
     tnvedChecking.value = true
@@ -134,6 +137,7 @@ function resetState() {
   tnvedExists.value = null
   tnvedChecking.value = false
   tnvedLookupError.value = ''
+  tnvedName.value = ''
   if (lookupTimeout) {
     clearTimeout(lookupTimeout)
     lookupTimeout = null
@@ -222,9 +226,9 @@ watch(() => props.show, (visible) => {
               :iconSize="'1x'"
             />
           </div>
-          <div v-if="validationMessage" class="validation-error" data-testid="target-tnved-error">
+          <div v-if="validationMessage || tnvedName" :class="tnvedName ? 'validation-success' : 'validation-error'" data-testid="target-tnved-message">
             <v-progress-circular v-if="tnvedChecking" indeterminate :size="14" :width="2" class="mr-1" />
-            {{ validationMessage }}
+            {{ tnvedName || validationMessage }}
           </div>
         </v-card-text>
         <v-card-actions class="justify-end">
@@ -273,6 +277,16 @@ watch(() => props.show, (visible) => {
   color: #b00020;
   font-size: 0.85em;
 }
+
+.validation-success {
+  margin-top: 8px;
+  color: #1b5e20;
+  font-size: 0.85em;
+  background-color: #e8f5e9;
+  border: 1px solid #a5d6a7;
+  border-radius: 4px;
+  padding: 4px 8px;
+ }
 
 .main-window-overlay {
   position: absolute;

--- a/tests/AssignTnvedDialog.spec.js
+++ b/tests/AssignTnvedDialog.spec.js
@@ -7,12 +7,12 @@ import { mount, flushPromises } from '@vue/test-utils'
 import AssignTnvedDialog from '@/l2/AssignTnvedDialog.vue'
 import { vuetifyStubs } from './helpers/test-utils.js'
 
-const { mockGetFeacnTooltip } = vi.hoisted(() => ({
-  mockGetFeacnTooltip: vi.fn()
+const { mockGetFeacnInfo } = vi.hoisted(() => ({
+  mockGetFeacnInfo: vi.fn()
 }))
 
 vi.mock('@/helpers/feacn.info.helpers.js', () => ({
-  getFeacnTooltip: mockGetFeacnTooltip
+  getFeacnInfo: mockGetFeacnInfo
 }))
 
 vi.mock('@/components/ActionButton.vue', () => ({
@@ -66,8 +66,12 @@ function createWrapper(props = {}) {
 describe('AssignTnvedDialog', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-    mockGetFeacnTooltip.mockReset()
-    mockGetFeacnTooltip.mockResolvedValue('Тестовое наименование ТН ВЭД')
+    mockGetFeacnInfo.mockReset()
+    mockGetFeacnInfo.mockResolvedValue({
+      name: 'Тестовое наименование ТН ВЭД',
+      found: true,
+      loading: false,
+    })
   })
 
   afterEach(() => {
@@ -95,7 +99,7 @@ describe('AssignTnvedDialog', () => {
 
   it('keeps confirm disabled until lookup confirms code exists', async () => {
     // Make lookup slow — never resolve during this test
-    mockGetFeacnTooltip.mockReturnValue(new Promise(() => {}))
+    mockGetFeacnInfo.mockReturnValue(new Promise(() => {}))
     const wrapper = createWrapper()
 
     const input = wrapper.find('[data-testid="target-tnved-input"]')
@@ -135,14 +139,18 @@ describe('AssignTnvedDialog', () => {
 
     await setInputAndWaitLookup(wrapper, '1234567890')
 
-    expect(mockGetFeacnTooltip).toHaveBeenCalledWith('1234567890')
+    expect(mockGetFeacnInfo).toHaveBeenCalledWith('1234567890')
     const message = wrapper.find('[data-testid="target-tnved-message"]')
     expect(message.text()).toContain('Тестовое наименование ТН ВЭД')
     expect(message.classes()).toContain('validation-success')
   })
 
   it('disables confirm when code does not exist in catalog', async () => {
-    mockGetFeacnTooltip.mockResolvedValue('Несуществующий код ТН ВЭД')
+    mockGetFeacnInfo.mockResolvedValue({
+      name: 'Несуществующий код ТН ВЭД',
+      found: false,
+      loading: false,
+    })
     const wrapper = createWrapper()
 
     await setInputAndWaitLookup(wrapper, '9999999999')
@@ -153,7 +161,7 @@ describe('AssignTnvedDialog', () => {
   })
 
   it('disables confirm when lookup throws an error', async () => {
-    mockGetFeacnTooltip.mockRejectedValue(new Error('Network error'))
+    mockGetFeacnInfo.mockRejectedValue(new Error('Network error'))
     const wrapper = createWrapper()
 
     await setInputAndWaitLookup(wrapper, '1234567890')
@@ -217,8 +225,8 @@ describe('AssignTnvedDialog', () => {
     await confirmBtn.trigger('click')
 
     expect(wrapper.emitted('confirm')).toBeFalsy()
-    // getFeacnTooltip should never be called for non-digit input
-    expect(mockGetFeacnTooltip).not.toHaveBeenCalled()
+    // getFeacnInfo should never be called for non-digit input
+    expect(mockGetFeacnInfo).not.toHaveBeenCalled()
   })
 
   it('debounces lookup calls when input changes rapidly', async () => {
@@ -234,7 +242,7 @@ describe('AssignTnvedDialog', () => {
     await flushPromises()
 
     // Only the last value should have triggered a lookup
-    expect(mockGetFeacnTooltip).toHaveBeenCalledTimes(1)
-    expect(mockGetFeacnTooltip).toHaveBeenCalledWith('1234567892')
+    expect(mockGetFeacnInfo).toHaveBeenCalledTimes(1)
+    expect(mockGetFeacnInfo).toHaveBeenCalledWith('1234567892')
   })
 })

--- a/tests/AssignTnvedDialog.spec.js
+++ b/tests/AssignTnvedDialog.spec.js
@@ -7,14 +7,12 @@ import { mount, flushPromises } from '@vue/test-utils'
 import AssignTnvedDialog from '@/l2/AssignTnvedDialog.vue'
 import { vuetifyStubs } from './helpers/test-utils.js'
 
-const mockGetByCode = vi.fn()
+const { mockGetFeacnTooltip } = vi.hoisted(() => ({
+  mockGetFeacnTooltip: vi.fn()
+}))
 
-vi.mock('@/stores/feacn.codes.store.js', () => ({
-  useFeacnCodesStore: () => ({
-    getByCode: mockGetByCode,
-    loading: { value: false },
-    error: { value: null },
-  })
+vi.mock('@/helpers/feacn.info.helpers.js', () => ({
+  getFeacnTooltip: mockGetFeacnTooltip
 }))
 
 vi.mock('@/components/ActionButton.vue', () => ({
@@ -68,8 +66,8 @@ function createWrapper(props = {}) {
 describe('AssignTnvedDialog', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-    mockGetByCode.mockReset()
-    mockGetByCode.mockResolvedValue({ code: '1234567890', name: 'Test' })
+    mockGetFeacnTooltip.mockReset()
+    mockGetFeacnTooltip.mockResolvedValue('Тестовое наименование ТН ВЭД')
   })
 
   afterEach(() => {
@@ -92,12 +90,12 @@ describe('AssignTnvedDialog', () => {
 
     const confirmBtn = wrapper.findAll('[data-testid="v-btn"]')[1]
     expect(confirmBtn.element.disabled).toBe(true)
-    expect(wrapper.find('[data-testid="target-tnved-error"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="target-tnved-message"]').exists()).toBe(true)
   })
 
   it('keeps confirm disabled until lookup confirms code exists', async () => {
     // Make lookup slow — never resolve during this test
-    mockGetByCode.mockReturnValue(new Promise(() => {}))
+    mockGetFeacnTooltip.mockReturnValue(new Promise(() => {}))
     const wrapper = createWrapper()
 
     const input = wrapper.find('[data-testid="target-tnved-input"]')
@@ -113,7 +111,7 @@ describe('AssignTnvedDialog', () => {
 
     // Still disabled (lookup hasn't resolved)
     expect(confirmBtn.element.disabled).toBe(true)
-    expect(wrapper.find('[data-testid="target-tnved-error"]').text()).toContain('Проверка')
+    expect(wrapper.find('[data-testid="target-tnved-message"]').text()).toContain('Проверка')
   })
 
   it('enables confirm and emits trimmed 10-digit code after successful lookup', async () => {
@@ -132,26 +130,37 @@ describe('AssignTnvedDialog', () => {
     expect(wrapper.emitted('update:show')).toBeFalsy()
   })
 
+  it('shows FEACN name in success style when code is valid', async () => {
+    const wrapper = createWrapper()
+
+    await setInputAndWaitLookup(wrapper, '1234567890')
+
+    expect(mockGetFeacnTooltip).toHaveBeenCalledWith('1234567890')
+    const message = wrapper.find('[data-testid="target-tnved-message"]')
+    expect(message.text()).toContain('Тестовое наименование ТН ВЭД')
+    expect(message.classes()).toContain('validation-success')
+  })
+
   it('disables confirm when code does not exist in catalog', async () => {
-    mockGetByCode.mockResolvedValue(null)
+    mockGetFeacnTooltip.mockResolvedValue('Несуществующий код ТН ВЭД')
     const wrapper = createWrapper()
 
     await setInputAndWaitLookup(wrapper, '9999999999')
 
     const confirmBtn = wrapper.findAll('[data-testid="v-btn"]')[1]
     expect(confirmBtn.element.disabled).toBe(true)
-    expect(wrapper.find('[data-testid="target-tnved-error"]').text()).toContain('Несуществующий код ТН ВЭД')
+    expect(wrapper.find('[data-testid="target-tnved-message"]').text()).toContain('Несуществующий код ТН ВЭД')
   })
 
   it('disables confirm when lookup throws an error', async () => {
-    mockGetByCode.mockRejectedValue(new Error('Network error'))
+    mockGetFeacnTooltip.mockRejectedValue(new Error('Network error'))
     const wrapper = createWrapper()
 
     await setInputAndWaitLookup(wrapper, '1234567890')
 
     const confirmBtn = wrapper.findAll('[data-testid="v-btn"]')[1]
     expect(confirmBtn.element.disabled).toBe(true)
-    expect(wrapper.find('[data-testid="target-tnved-error"]').text()).toContain('Несуществующий код ТН ВЭД')
+    expect(wrapper.find('[data-testid="target-tnved-message"]').text()).toContain('Несуществующий код ТН ВЭД')
   })
 
   it('opens FEACN tree search overlay and applies selected code', async () => {
@@ -208,8 +217,8 @@ describe('AssignTnvedDialog', () => {
     await confirmBtn.trigger('click')
 
     expect(wrapper.emitted('confirm')).toBeFalsy()
-    // getByCode should never be called for non-digit input
-    expect(mockGetByCode).not.toHaveBeenCalled()
+    // getFeacnTooltip should never be called for non-digit input
+    expect(mockGetFeacnTooltip).not.toHaveBeenCalled()
   })
 
   it('debounces lookup calls when input changes rapidly', async () => {
@@ -225,7 +234,7 @@ describe('AssignTnvedDialog', () => {
     await flushPromises()
 
     // Only the last value should have triggered a lookup
-    expect(mockGetByCode).toHaveBeenCalledTimes(1)
-    expect(mockGetByCode).toHaveBeenCalledWith('1234567892')
+    expect(mockGetFeacnTooltip).toHaveBeenCalledTimes(1)
+    expect(mockGetFeacnTooltip).toHaveBeenCalledWith('1234567892')
   })
 })


### PR DESCRIPTION
### Motivation

- Simplify FEACN code lookup by replacing the store-based `getByCode` call with a dedicated helper `getFeacnTooltip` to return a human-readable name or not-found indicator. 
- Provide clearer user feedback by displaying the FEACN name on successful lookup and a distinct success style for valid codes.

### Description

- Replaced dependency on `useFeacnCodesStore` with `getFeacnTooltip` from `@/helpers/feacn.info.helpers.js` and updated the async lookup flow in `AssignTnvedDialog.vue` to derive existence from the returned tooltip string. 
- Added `tnvedName` state and `notFoundMessage` constant, updated `lookupTnVed` and watchers to set `tnvedName`, and adjusted error handling to use the new not-found message.
- Unified the validation/message area to use a single element (`data-testid="target-tnved-message"`) that shows either the success name or validation/error text and added a `validation-success` CSS class with styles for positive feedback. 
- Updated unit tests in `tests/AssignTnvedDialog.spec.js` to mock `getFeacnTooltip`, reflect the new message element and class, and added a test to verify the FEACN name is shown on successful lookup.

### Testing

- Ran the updated unit spec `tests/AssignTnvedDialog.spec.js` with `vitest`, which includes debounce and lookup scenarios, overlay behavior, and the new success-message case; all tests passed. 
- Verified the lookup debounce behavior and that `getFeacnTooltip` is not called for invalid non-digit input via unit tests, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51009e1848321bdb4317adcaa0127)