### PR TITLE
fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@
 
 name: ci
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/maxirmx/logibooks.ui/security/code-scanning/1](https://github.com/maxirmx/logibooks.ui/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ci.yml` at the workflow root (right after `name:` and before `on:`), so it applies to all jobs unless overridden.  
For this workflow, the minimal safe baseline is:

- `contents: read` (required for checkout and general repo read access)

No additional write scopes are required by the shown steps. This preserves current functionality while enforcing least privilege for `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
