### PR TITLE
feat: search by box/parcel id in scan monitor

### DIFF
--- a/src/assets/styles/scanjob-monitor.css
+++ b/src/assets/styles/scanjob-monitor.css
@@ -138,6 +138,11 @@
   height: 36px !important;
 }
 
+.scanjob-monitor-parcels-table .selected-parcel-row > td,
+.scanjob-monitor-parcels-table .selected-parcel-row .v-data-table__td {
+  background-color: #b7d5fe !important;
+}
+
 .scanjob-monitor-parcel-progress-panel {
   display: inline-grid;
   grid-template-columns: repeat(2, minmax(120px, 1fr));

--- a/src/dialogs/Scanjob_Monitor.vue
+++ b/src/dialogs/Scanjob_Monitor.vue
@@ -23,7 +23,8 @@ import {
 } from '@/helpers/parcel.defect.helpers.js'
 import {
   isUnassignedMonitorBox,
-  scanjobMonitorArea
+  scanjobMonitorArea,
+  scanjobMonitorTargetKind
 } from '@/helpers/scanjob.monitor.helpers.js'
 import '@/assets/styles/scanjob-monitor.css'
 
@@ -68,6 +69,9 @@ const autoFollowEnabled = ref(true)
 const defectActionRunning = ref(false)
 const scanjobLoaded = ref(false)
 const loadedScanjobId = ref(null)
+const jumpNumber = ref('')
+const jumpLoading = ref(false)
+const selectedParcelId = ref(null)
 
 let pendingSnapshot = null
 let throttleTimer = null
@@ -125,6 +129,9 @@ const autoFollowActionIcon = computed(() => (
 ))
 const autoFollowActionTooltip = computed(() => (
   autoFollowEnabled.value ? 'Отключить автослежение' : 'Включить автослежение'
+))
+const isJumpDisabled = computed(() => (
+  isLoading.value || jumpLoading.value || !jumpNumber.value.trim()
 ))
 
 function close() {
@@ -211,6 +218,7 @@ function updateMonitorRoute(scope, { replace = false } = {}) {
 }
 
 function navigateToRegisterMonitor({ replace = false } = {}) {
+  selectedParcelId.value = null
   return updateMonitorRoute({ area: scanjobMonitorArea.Boxes }, { replace })
 }
 
@@ -227,6 +235,7 @@ function navigateToBoxMonitor(box, { replace = false } = {}) {
     return Promise.resolve(false)
   }
 
+  selectedParcelId.value = null
   return updateMonitorRoute({
     area: isUnassigned ? scanjobMonitorArea.Unassigned : scanjobMonitorArea.Box,
     boxId: isUnassigned ? null : boxId,
@@ -342,6 +351,14 @@ function buildScope(area, boxId = null, bucketIndex = null) {
   return scope
 }
 
+function scopesAreEqual(left, right) {
+  const normalizedLeft = normalizeMonitorScope(left)
+  const normalizedRight = normalizeMonitorScope(right)
+  return Number(normalizedLeft.area) === Number(normalizedRight.area)
+    && toNumberOrNull(normalizedLeft.boxId) === toNumberOrNull(normalizedRight.boxId)
+    && (toNumberOrNull(normalizedLeft.bucketIndex) ?? null) === (toNumberOrNull(normalizedRight.bucketIndex) ?? null)
+}
+
 function currentArea() {
   return selectedArea.value
 }
@@ -439,6 +456,86 @@ function normalizeMonitorScope(scope = {}) {
     area: scanjobMonitorArea.Boxes,
     boxId: null,
     bucketIndex: null
+  }
+}
+
+function getMonitorTargetErrorMessage(error) {
+  return error?.message || 'Ошибка при поиске посылки или коробки'
+}
+
+async function navigateToResolvedScope(scope, { reloadIfSame = false } = {}) {
+  const normalizedScope = normalizeMonitorScope(scope)
+
+  if (scopesAreEqual(normalizedScope, getCurrentScope())) {
+    if (reloadIfSame) {
+      await refreshCurrentScopeSnapshot()
+    }
+    return false
+  }
+
+  return updateMonitorRoute(normalizedScope)
+}
+
+async function handleJumpToNumber() {
+  if (jumpLoading.value || isLoading.value) {
+    return
+  }
+
+  const number = jumpNumber.value.trim()
+  if (!number) {
+    alertStore.error('Введите номер посылки или коробки')
+    return
+  }
+
+  jumpLoading.value = true
+  try {
+    const target = await scanJobsStore.resolveMonitorTarget(props.scanjobId, number)
+    const kind = Number(target?.kind)
+
+    if (kind === scanjobMonitorTargetKind.Box) {
+      const boxId = toNumberOrNull(target?.boxId)
+      if (boxId == null) {
+        alertStore.error(`Посылка или коробка с номером «${number}» не найдена`)
+        return
+      }
+
+      selectedParcelId.value = null
+      await navigateToResolvedScope({
+        area: scanjobMonitorArea.Box,
+        boxId,
+        bucketIndex: null
+      })
+      return
+    }
+
+    if (kind === scanjobMonitorTargetKind.Parcel) {
+      const parcelId = toNumberOrNull(target?.parcelId)
+      const targetScope = normalizeMonitorScope({
+        area: target?.area,
+        boxId: target?.boxId,
+        bucketIndex: target?.bucketIndex
+      })
+
+      if (parcelId == null || targetScope.area === scanjobMonitorArea.Boxes) {
+        alertStore.error(`Посылка или коробка с номером «${number}» не найдена`)
+        return
+      }
+
+      selectedParcelId.value = parcelId
+      await navigateToResolvedScope(targetScope, { reloadIfSame: true })
+      return
+    }
+
+    selectedParcelId.value = null
+    alertStore.error(`Посылка или коробка с номером «${number}» не найдена`)
+  } catch (error) {
+    if (isComponentMounted.value) {
+      alertStore.error(getMonitorTargetErrorMessage(error))
+    }
+  } finally {
+    if (isComponentMounted.value) {
+      jumpLoading.value = false
+    }
   }
 }
 
@@ -933,6 +1030,33 @@ defineExpose({
 
     <hr class="hr" />
 
+    <form class="scanjob-monitor-jump" data-testid="scanjob-monitor-jump" @submit.prevent="handleJumpToNumber">
+      <label class="scanjob-monitor-jump-label" for="scanjob-monitor-jump-input">
+        Перейти к посылке или коробке по номеру:
+      </label>
+      <input
+        id="scanjob-monitor-jump-input"
+        v-model="jumpNumber"
+        class="form-control scanjob-monitor-jump-input"
+        type="text"
+        autocomplete="off"
+        data-testid="scanjob-monitor-jump-input"
+        :disabled="isLoading || jumpLoading"
+      />
+      <ActionButton
+        :item="{}"
+        icon="fa-solid fa-check-double"
+        icon-size="2x"
+        tooltip-text="Перейти"
+        aria-label="Перейти"
+        title="Перейти"
+        data-testid="scanjob-monitor-jump-action"
+        :disabled="isJumpDisabled"
+        @click="handleJumpToNumber"
+      />
+      <span v-if="jumpLoading" class="spinner-border spinner-border-m" data-testid="scanjob-monitor-jump-loading"></span>
+    </form>
+
     <div class="scanjob-monitor-panel">
       <div v-if="isLoading && !visibleSnapshot" class="monitor-empty" data-testid="scanjob-monitor-loading">
         <span class="spinner-border spinner-border-m"></span>
@@ -966,6 +1090,7 @@ defineExpose({
           :register-type="visibleSnapshot?.registerType ?? 0"
           :loading="isLoading"
           :defect-action-loading="defectActionRunning"
+          :selected-parcel-id="selectedParcelId"
           @edit-parcel="editParcel"
           @set-defect="setParcelDefect"
           @clear-defect="clearParcelDefect"
@@ -983,6 +1108,25 @@ defineExpose({
 <style scoped>
 .scanjob-monitor-panel {
   min-height: 320px;
+}
+
+.scanjob-monitor-jump {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.scanjob-monitor-jump-label {
+  flex: 0 1 auto;
+  margin-bottom: 0;
+  font-weight: 600;
+}
+
+.scanjob-monitor-jump-input {
+  flex: 1 1 220px;
+  max-width: 360px;
 }
 
 .monitor-summary-action {

--- a/src/dialogs/Scanjob_Monitor.vue
+++ b/src/dialogs/Scanjob_Monitor.vue
@@ -495,7 +495,7 @@ async function handleJumpToNumber() {
     if (kind === scanjobMonitorTargetKind.Box) {
       const boxId = toNumberOrNull(target?.boxId)
       if (boxId == null) {
-        alertStore.error(`Посылка или коробка с номером «${number}» не найдена`)
+        alertStore.error(`Посылка или коробка не найдена`)
         return
       }
 
@@ -517,7 +517,7 @@ async function handleJumpToNumber() {
       })
 
       if (parcelId == null || targetScope.area === scanjobMonitorArea.Boxes) {
-        alertStore.error(`Посылка или коробка с номером «${number}» не найдена`)
+        alertStore.error(`Посылка или коробка не найдена`)
         return
       }
 
@@ -527,7 +527,7 @@ async function handleJumpToNumber() {
     }
 
     selectedParcelId.value = null
-    alertStore.error(`Посылка или коробка с номером «${number}» не найдена`)
+    alertStore.error(`Посылка или коробка не найдена`)
   } catch (error) {
     if (isComponentMounted.value) {
       alertStore.error(getMonitorTargetErrorMessage(error))

--- a/src/dialogs/Scanjob_Monitor.vue
+++ b/src/dialogs/Scanjob_Monitor.vue
@@ -985,6 +985,33 @@ defineExpose({
         <div v-if="isLoading" class="header-actions header-actions-group">
             <span class="spinner-border spinner-border-m"></span>
         </div>
+        <form class="header-actions header-actions-group scanjob-monitor-jump" data-testid="scanjob-monitor-jump" @submit.prevent="handleJumpToNumber">
+          <v-text-field
+            id="scanjob-monitor-jump-input"
+            v-model="jumpNumber"
+            density="compact"
+            class="scanjob-monitor-jump-input"
+            label="Перейти к посылке или коробке"
+            variant="outlined"
+            hide-details
+            autocomplete="off"
+            data-testid="scanjob-monitor-jump-input"
+            :disabled="isLoading || jumpLoading"
+            @keydown.enter="handleJumpToNumber"
+          />
+          <ActionButton
+            :item="{}"
+            icon="fa-solid fa-angles-right"
+            icon-size="2x"
+            tooltip-text="Перейти"
+            aria-label="Перейти"
+            title="Перейти"
+            data-testid="scanjob-monitor-jump-action"
+            :disabled="isJumpDisabled"
+            @click="handleJumpToNumber"
+          />
+          <span v-if="jumpLoading" class="spinner-border spinner-border-m" data-testid="scanjob-monitor-jump-loading"></span>
+        </form>
         <div class="header-actions header-actions-group">
           <ActionButton
             :item="{}"
@@ -1029,33 +1056,6 @@ defineExpose({
     </div>
 
     <hr class="hr" />
-
-    <form class="scanjob-monitor-jump" data-testid="scanjob-monitor-jump" @submit.prevent="handleJumpToNumber">
-      <label class="scanjob-monitor-jump-label" for="scanjob-monitor-jump-input">
-        Перейти к посылке или коробке по номеру:
-      </label>
-      <input
-        id="scanjob-monitor-jump-input"
-        v-model="jumpNumber"
-        class="form-control scanjob-monitor-jump-input"
-        type="text"
-        autocomplete="off"
-        data-testid="scanjob-monitor-jump-input"
-        :disabled="isLoading || jumpLoading"
-      />
-      <ActionButton
-        :item="{}"
-        icon="fa-solid fa-check-double"
-        icon-size="2x"
-        tooltip-text="Перейти"
-        aria-label="Перейти"
-        title="Перейти"
-        data-testid="scanjob-monitor-jump-action"
-        :disabled="isJumpDisabled"
-        @click="handleJumpToNumber"
-      />
-      <span v-if="jumpLoading" class="spinner-border spinner-border-m" data-testid="scanjob-monitor-jump-loading"></span>
-    </form>
 
     <div class="scanjob-monitor-panel">
       <div v-if="isLoading && !visibleSnapshot" class="monitor-empty" data-testid="scanjob-monitor-loading">
@@ -1111,22 +1111,11 @@ defineExpose({
 }
 
 .scanjob-monitor-jump {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-bottom: 12px;
-}
-
-.scanjob-monitor-jump-label {
-  flex: 0 1 auto;
-  margin-bottom: 0;
-  font-weight: 600;
+  gap: 8px;
 }
 
 .scanjob-monitor-jump-input {
-  flex: 1 1 220px;
-  max-width: 360px;
+  min-width: 300px;
 }
 
 .monitor-summary-action {

--- a/src/dialogs/Scanjob_Ozon_Parcels_Monitor_Table.vue
+++ b/src/dialogs/Scanjob_Ozon_Parcels_Monitor_Table.vue
@@ -7,7 +7,8 @@ defineOptions({ name: 'Scanjob_Ozon_Parcels_Monitor_Table' })
 defineProps({
   parcels: { type: Array, default: () => [] },
   loading: { type: Boolean, default: false },
-  defectActionLoading: { type: Boolean, default: false }
+  defectActionLoading: { type: Boolean, default: false },
+  selectedParcelId: { type: [Number, String], default: null }
 })
 
 defineEmits(['edit-parcel', 'set-defect', 'clear-defect'])
@@ -19,6 +20,7 @@ defineEmits(['edit-parcel', 'set-defect', 'clear-defect'])
     :parcels="parcels"
     :loading="loading"
     :defect-action-loading="defectActionLoading"
+    :selected-parcel-id="selectedParcelId"
     @edit-parcel="$emit('edit-parcel', $event)"
     @set-defect="$emit('set-defect', $event)"
     @clear-defect="$emit('clear-defect', $event)"

--- a/src/dialogs/Scanjob_Parcels_Monitor.vue
+++ b/src/dialogs/Scanjob_Parcels_Monitor.vue
@@ -26,7 +26,8 @@ const props = defineProps({
   box: { type: Object, default: null },
   registerType: { type: Number, default: 0 },
   loading: { type: Boolean, default: false },
-  defectActionLoading: { type: Boolean, default: false }
+  defectActionLoading: { type: Boolean, default: false },
+  selectedParcelId: { type: [Number, String], default: null }
 })
 
 const emit = defineEmits(['edit-parcel', 'set-defect', 'clear-defect'])
@@ -102,6 +103,7 @@ function clearDefect(item) {
           :parcels="parcels"
           :loading="props.loading"
           :defect-action-loading="props.defectActionLoading"
+          :selected-parcel-id="props.selectedParcelId"
           @edit-parcel="editParcel"
           @set-defect="setDefect"
           @clear-defect="clearDefect"
@@ -113,6 +115,7 @@ function clearDefect(item) {
           :parcels="parcels"
           :loading="props.loading"
           :defect-action-loading="props.defectActionLoading"
+          :selected-parcel-id="props.selectedParcelId"
           @edit-parcel="editParcel"
           @set-defect="setDefect"
           @clear-defect="clearDefect"

--- a/src/dialogs/Scanjob_Parcels_Monitor_Table.vue
+++ b/src/dialogs/Scanjob_Parcels_Monitor_Table.vue
@@ -3,7 +3,7 @@
 // All rights reserved.
 // This file is a part of Logibooks ui application
 
-import { computed } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useAuthStore } from '@/stores/auth.store.js'
 import ActionButton from '@/components/ActionButton.vue'
@@ -32,7 +32,8 @@ const props = defineProps({
   headers: { type: Array, required: true },
   parcels: { type: Array, default: () => [] },
   loading: { type: Boolean, default: false },
-  defectActionLoading: { type: Boolean, default: false }
+  defectActionLoading: { type: Boolean, default: false },
+  selectedParcelId: { type: [Number, String], default: null }
 })
 
 const emit = defineEmits(['edit-parcel', 'set-defect', 'clear-defect'])
@@ -48,6 +49,8 @@ const {
 const canFollowParcelEditRoute = computed(() => hasLogistRole?.value === true)
 const isParcelCellDisabled = computed(() => props.loading || !canFollowParcelEditRoute.value)
 const areDefectActionsBusy = computed(() => props.loading || props.defectActionLoading)
+const selectedParcelIdNumber = computed(() => toNumberOrNull(props.selectedParcelId))
+const dataTableRef = ref(null)
 
 function editParcel(item) {
   if (isParcelCellDisabled.value) {
@@ -89,15 +92,133 @@ function clearDefect(item) {
   emit('clear-defect', item)
 }
 
+function toNumberOrNull(value) {
+  if (value == null || value === '') {
+    return null
+  }
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function getParcelId(item) {
+  return toNumberOrNull(item?.parcelId ?? item?.id)
+}
+
+function comparePrimitiveValues(left, right) {
+  if (left == null && right == null) return 0
+  if (left == null) return -1
+  if (right == null) return 1
+
+  if (typeof left === 'number' && typeof right === 'number') {
+    return left - right
+  }
+
+  return String(left).localeCompare(String(right), 'ru', {
+    numeric: true,
+    sensitivity: 'accent'
+  })
+}
+
+function getSortedParcels() {
+  const sortRules = Array.isArray(scanjobmonitor_parcels_sort_by.value)
+    ? scanjobmonitor_parcels_sort_by.value
+    : []
+
+  if (sortRules.length === 0) {
+    return props.parcels
+  }
+
+  const headersByKey = new Map(props.headers.map((header) => [header.key, header]))
+  return [...props.parcels].sort((left, right) => {
+    for (const rule of sortRules) {
+      const key = rule?.key
+      if (!key) {
+        continue
+      }
+
+      const header = headersByKey.get(key)
+      const customSort = typeof header?.sort === 'function'
+        ? header.sort(left?.[key], right?.[key])
+        : comparePrimitiveValues(left?.[key], right?.[key])
+
+      if (customSort !== 0) {
+        return rule.order === 'desc' ? -customSort : customSort
+      }
+    }
+
+    return comparePrimitiveValues(getParcelId(left), getParcelId(right))
+  })
+}
+
+function moveToSelectedParcelPage() {
+  const selectedId = selectedParcelIdNumber.value
+  if (selectedId == null) {
+    return
+  }
+
+  const perPage = Number(scanjobmonitor_parcels_per_page.value)
+  if (!Number.isFinite(perPage) || perPage <= 0) {
+    return
+  }
+
+  const selectedIndex = getSortedParcels().findIndex((parcel) => getParcelId(parcel) === selectedId)
+  if (selectedIndex < 0) {
+    return
+  }
+
+  scanjobmonitor_parcels_page.value = Math.floor(selectedIndex / perPage) + 1
+}
+
+async function scrollToSelectedParcel() {
+  const selectedId = selectedParcelIdNumber.value
+  if (selectedId == null) {
+    return
+  }
+
+  await nextTick()
+  const tableElement = dataTableRef.value?.$el ?? dataTableRef.value
+  const selectedRows = tableElement?.querySelectorAll?.('.selected-parcel-row')
+  const selectedRow = selectedRows?.[selectedRows.length - 1]
+  selectedRow?.scrollIntoView?.({
+    behavior: 'smooth',
+    block: 'center',
+    inline: 'nearest'
+  })
+}
+
+function getRowProps(data) {
+  const item = data?.item ?? data
+  return getParcelId(item) === selectedParcelIdNumber.value
+    ? { class: 'selected-parcel-row' }
+    : {}
+}
+
+watch(
+  () => [
+    props.selectedParcelId,
+    props.parcels,
+    scanjobmonitor_parcels_per_page.value,
+    scanjobmonitor_parcels_sort_by.value
+  ],
+  async () => {
+    moveToSelectedParcelPage()
+    await scrollToSelectedParcel()
+  },
+  { immediate: true, deep: true }
+)
+
 </script>
 
 <template>
   <v-data-table
+    ref="dataTableRef"
     v-model:items-per-page="scanjobmonitor_parcels_per_page"
     v-model:page="scanjobmonitor_parcels_page"
     v-model:sort-by="scanjobmonitor_parcels_sort_by"
     :headers="props.headers"
     :items="props.parcels"
+    :row-props="getRowProps"
     :items-per-page-options="itemsPerPageOptions"
     items-per-page-text="Посылок на странице"
     page-text="{0}-{1} из {2}"

--- a/src/dialogs/Scanjob_Wbr2_Parcels_Monitor_Table.vue
+++ b/src/dialogs/Scanjob_Wbr2_Parcels_Monitor_Table.vue
@@ -7,7 +7,8 @@ defineOptions({ name: 'Scanjob_Wbr2_Parcels_Monitor_Table' })
 defineProps({
   parcels: { type: Array, default: () => [] },
   loading: { type: Boolean, default: false },
-  defectActionLoading: { type: Boolean, default: false }
+  defectActionLoading: { type: Boolean, default: false },
+  selectedParcelId: { type: [Number, String], default: null }
 })
 
 defineEmits(['edit-parcel', 'set-defect', 'clear-defect'])
@@ -19,6 +20,7 @@ defineEmits(['edit-parcel', 'set-defect', 'clear-defect'])
     :parcels="parcels"
     :loading="loading"
     :defect-action-loading="defectActionLoading"
+    :selected-parcel-id="selectedParcelId"
     @edit-parcel="$emit('edit-parcel', $event)"
     @set-defect="$emit('set-defect', $event)"
     @clear-defect="$emit('clear-defect', $event)"

--- a/src/dialogs/Scanjob_Wbr_Parcels_Monitor_Table.vue
+++ b/src/dialogs/Scanjob_Wbr_Parcels_Monitor_Table.vue
@@ -7,7 +7,8 @@ defineOptions({ name: 'Scanjob_Wbr_Parcels_Monitor_Table' })
 defineProps({
   parcels: { type: Array, default: () => [] },
   loading: { type: Boolean, default: false },
-  defectActionLoading: { type: Boolean, default: false }
+  defectActionLoading: { type: Boolean, default: false },
+  selectedParcelId: { type: [Number, String], default: null }
 })
 
 defineEmits(['edit-parcel', 'set-defect', 'clear-defect'])
@@ -19,6 +20,7 @@ defineEmits(['edit-parcel', 'set-defect', 'clear-defect'])
     :parcels="parcels"
     :loading="loading"
     :defect-action-loading="defectActionLoading"
+    :selected-parcel-id="selectedParcelId"
     @edit-parcel="$emit('edit-parcel', $event)"
     @set-defect="$emit('set-defect', $event)"
     @clear-defect="$emit('clear-defect', $event)"

--- a/src/helpers/scanjob.monitor.helpers.js
+++ b/src/helpers/scanjob.monitor.helpers.js
@@ -81,6 +81,12 @@ export const scanjobMonitorArea = {
   NotInRegister: 3
 }
 
+export const scanjobMonitorTargetKind = {
+  None: 0,
+  Box: 1,
+  Parcel: 2
+}
+
 export const scannedItemSource = {
   Unknown: 0,
   ParcelSticker: 10,

--- a/src/init.app.js
+++ b/src/init.app.js
@@ -64,7 +64,8 @@ import {
   faLinkSlash,
   faPersonCircleXmark,
   faPersonCircleCheck,
-  faXmarksLines
+  faXmarksLines,
+  faAnglesRight
 } from '@fortawesome/free-solid-svg-icons'
 
 library.add(
@@ -121,7 +122,8 @@ library.add(
   faLinkSlash,
   faPersonCircleXmark,
   faPersonCircleCheck,
-  faXmarksLines
+  faXmarksLines,
+  faAnglesRight
 )
 
 import 'vuetify/styles'

--- a/src/stores/scanjobs.store.js
+++ b/src/stores/scanjobs.store.js
@@ -317,6 +317,18 @@ export const useScanjobsStore = defineStore('scanjobs', () => {
     }
   }
 
+  async function resolveMonitorTarget(scanJobId, number) {
+    monitorError.value = null
+
+    try {
+      const params = new URLSearchParams({ number: String(number ?? '') })
+      return await fetchWrapper.get(`${baseUrl}/${scanJobId}/monitor/resolve?${params.toString()}`)
+    } catch (err) {
+      monitorError.value = err
+      throw err
+    }
+  }
+
   async function startMonitor(scanJobId, {
     area = scanjobMonitorArea.Boxes,
     boxId = null,
@@ -608,6 +620,7 @@ export const useScanjobsStore = defineStore('scanjobs', () => {
     ensureOpsLoaded,
     getOpsLabel,
     loadMonitorSnapshot,
+    resolveMonitorTarget,
     startMonitor,
     clearMonitor,
     stopMonitor,

--- a/tests/Scanjob_Monitor.spec.js
+++ b/tests/Scanjob_Monitor.spec.js
@@ -552,36 +552,42 @@ describe('Scanjob_Monitor.vue', () => {
   })
 
   it('marks and scrolls resolved parcel in current box', async () => {
-    const scrollIntoView = vi.fn()
-    window.HTMLElement.prototype.scrollIntoView = scrollIntoView
-    loadMonitorSnapshot.mockResolvedValue(boxSnapshot)
-    resolveMonitorTarget.mockResolvedValueOnce({
-      kind: 2,
-      area: 1,
-      boxId: 7,
-      bucketIndex: null,
-      parcelId: 71,
-      number: 'P-71',
-      boxCode: 'BOX-7',
-      parcelNumber: 'P-71'
-    })
-    const wrapper = mount(ScanjobMonitor, {
-      props: { scanjobId: 42, monitorScope: box7MonitorScope },
-      global: { stubs: monitorGlobalStubs }
-    })
+    const scrollIntoView = vi
+      .spyOn(window.HTMLElement.prototype, 'scrollIntoView')
+      .mockImplementation(() => {})
 
-    await flushPromises()
-    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('P-71')
-    await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
-    await flushPromises()
+    try {
+      loadMonitorSnapshot.mockResolvedValue(boxSnapshot)
+      resolveMonitorTarget.mockResolvedValueOnce({
+        kind: 2,
+        area: 1,
+        boxId: 7,
+        bucketIndex: null,
+        parcelId: 71,
+        number: 'P-71',
+        boxCode: 'BOX-7',
+        parcelNumber: 'P-71'
+      })
+      const wrapper = mount(ScanjobMonitor, {
+        props: { scanjobId: 42, monitorScope: box7MonitorScope },
+        global: { stubs: monitorGlobalStubs }
+      })
 
-    expect(loadMonitorSnapshot).toHaveBeenLastCalledWith(42, { area: 1, boxId: 7 })
-    expect(wrapper.find('.selected-parcel-row').exists()).toBe(true)
-    expect(scrollIntoView).toHaveBeenCalledWith({
-      behavior: 'smooth',
-      block: 'center',
-      inline: 'nearest'
-    })
+      await flushPromises()
+      await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('P-71')
+      await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
+      await flushPromises()
+
+      expect(loadMonitorSnapshot).toHaveBeenLastCalledWith(42, { area: 1, boxId: 7 })
+      expect(wrapper.find('.selected-parcel-row').exists()).toBe(true)
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'center',
+        inline: 'nearest'
+      })
+    } finally {
+      scrollIntoView.mockRestore()
+    }
   })
 
   it('alerts when jump target is not found', async () => {

--- a/tests/Scanjob_Monitor.spec.js
+++ b/tests/Scanjob_Monitor.spec.js
@@ -610,6 +610,262 @@ describe('Scanjob_Monitor.vue', () => {
     expect(alertError).toHaveBeenCalledWith('Посылка или коробка с номером «MISSING» не найдена')
   })
 
+  it('alerts when jump input is empty', async () => {
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    // Input is empty; button is disabled, so trigger via keydown.enter on the input field
+    const form = wrapper.get('[data-testid="scanjob-monitor-jump"]')
+    await form.trigger('submit')
+    await flushPromises()
+
+    expect(alertError).toHaveBeenCalledWith('Введите номер посылки или коробки')
+    expect(resolveMonitorTarget).not.toHaveBeenCalled()
+  })
+
+  it('does not call resolveMonitorTarget when isLoading is true', async () => {
+    monitorLoading.value = true
+
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('BOX-7')
+    await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
+    await flushPromises()
+
+    expect(resolveMonitorTarget).not.toHaveBeenCalled()
+  })
+
+  it('disables jump action button when input is empty', async () => {
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+
+    const jumpAction = wrapper.get('[data-testid="scanjob-monitor-jump-action"]')
+    expect(jumpAction.attributes('disabled')).toBeDefined()
+  })
+
+  it('enables jump action button when input has text', async () => {
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('BOX-7')
+
+    const jumpAction = wrapper.get('[data-testid="scanjob-monitor-jump-action"]')
+    expect(jumpAction.attributes('disabled')).toBeUndefined()
+  })
+
+  it('shows jump loading spinner while resolving', async () => {
+    let resolveTarget
+    resolveMonitorTarget.mockReturnValueOnce(new Promise((resolve) => { resolveTarget = resolve }))
+
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('BOX-7')
+    await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="scanjob-monitor-jump-loading"]').exists()).toBe(true)
+
+    resolveTarget({ kind: 0 })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="scanjob-monitor-jump-loading"]').exists()).toBe(false)
+  })
+
+  it('alerts when resolved box target has null boxId', async () => {
+    resolveMonitorTarget.mockResolvedValueOnce({
+      kind: 1,
+      area: 1,
+      boxId: null,
+      parcelId: null,
+      number: 'BADBOX'
+    })
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('BADBOX')
+    await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
+    await flushPromises()
+
+    expect(alertError).toHaveBeenCalledWith('Посылка или коробка с номером «BADBOX» не найдена')
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('alerts when resolved parcel target has null parcelId', async () => {
+    resolveMonitorTarget.mockResolvedValueOnce({
+      kind: 2,
+      area: 1,
+      boxId: 7,
+      bucketIndex: null,
+      parcelId: null,
+      number: 'BADPARCEL'
+    })
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('BADPARCEL')
+    await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
+    await flushPromises()
+
+    expect(alertError).toHaveBeenCalledWith('Посылка или коробка с номером «BADPARCEL» не найдена')
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('alerts when resolved parcel target scope is Boxes area', async () => {
+    resolveMonitorTarget.mockResolvedValueOnce({
+      kind: 2,
+      area: 0,
+      boxId: null,
+      bucketIndex: null,
+      parcelId: 55,
+      number: 'P-55'
+    })
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('P-55')
+    await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
+    await flushPromises()
+
+    expect(alertError).toHaveBeenCalledWith('Посылка или коробка с номером «P-55» не найдена')
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('shows error alert when resolveMonitorTarget throws with a message', async () => {
+    resolveMonitorTarget.mockRejectedValueOnce(new Error('Network failure'))
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('BOX-7')
+    await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
+    await flushPromises()
+
+    expect(alertError).toHaveBeenCalledWith('Network failure')
+  })
+
+  it('shows fallback error message when resolveMonitorTarget throws without message', async () => {
+    resolveMonitorTarget.mockRejectedValueOnce({})
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('BOX-7')
+    await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
+    await flushPromises()
+
+    expect(alertError).toHaveBeenCalledWith('Ошибка при поиске посылки или коробки')
+  })
+
+  it('submits jump form on Enter key press', async () => {
+    resolveMonitorTarget.mockResolvedValueOnce({
+      kind: 1,
+      area: 1,
+      boxId: 7,
+      bucketIndex: null,
+      parcelId: null,
+      number: 'BOX-7'
+    })
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    const input = wrapper.get('[data-testid="scanjob-monitor-jump-input"]')
+    await input.setValue('BOX-7')
+    await input.trigger('keydown.enter')
+    await flushPromises()
+
+    expect(resolveMonitorTarget).toHaveBeenCalledWith(42, 'BOX-7')
+  })
+
+  it('clears selectedParcelId when navigating back to register monitor', async () => {
+    loadMonitorSnapshot.mockResolvedValue(boxSnapshot)
+    resolveMonitorTarget.mockResolvedValueOnce({
+      kind: 2,
+      area: 1,
+      boxId: 7,
+      bucketIndex: null,
+      parcelId: 71,
+      number: 'P-71'
+    })
+
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42, monitorScope: box7MonitorScope },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('P-71')
+    await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.selected-parcel-row').exists()).toBe(true)
+
+    loadMonitorSnapshot.mockResolvedValue(registerSnapshot)
+    clearMonitor.mockResolvedValue(true)
+    await wrapper.vm.openRegisterMonitor()
+    await flushPromises()
+
+    expect(wrapper.find('.selected-parcel-row').exists()).toBe(false)
+  })
+
+  it('stays on same scope without navigation when scope is unchanged and reloadIfSame is false', async () => {
+    resolveMonitorTarget.mockResolvedValueOnce({
+      kind: 1,
+      area: 0,
+      boxId: null,
+      bucketIndex: null,
+      parcelId: null,
+      number: 'BOX-SAME'
+    })
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    const pushCallsBefore = mockPush.mock.calls.length
+    const replaceCallsBefore = mockReplace.mock.calls.length
+
+    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('BOX-SAME')
+    await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
+    await flushPromises()
+
+    expect(mockPush.mock.calls.length).toBe(pushCallsBefore)
+    expect(mockReplace.mock.calls.length).toBe(replaceCallsBefore)
+  })
+
   it('does not start a separate autofollow observer for the register panel', async () => {
     mount(ScanjobMonitor, {
       props: { scanjobId: 42 },

--- a/tests/Scanjob_Monitor.spec.js
+++ b/tests/Scanjob_Monitor.spec.js
@@ -493,7 +493,7 @@ describe('Scanjob_Monitor.vue', () => {
     expect(boxesTable.props('itemsPerPage')).toBe(25)
     expect(boxesTable.props('page')).toBe(2)
     expect(boxesTable.props('sortBy')).toEqual([{ key: 'boxCode', order: 'desc' }])
-    expect(wrapper.get('[data-testid="scanjob-monitor-jump"]').text()).toContain('Перейти к посылке или коробке по номеру:')
+    expect(wrapper.get('[data-testid="scanjob-monitor-jump"]').text()).toContain('Перейти к посылке или коробке')
   })
 
   it('navigates to resolved box by number', async () => {
@@ -552,6 +552,8 @@ describe('Scanjob_Monitor.vue', () => {
   })
 
   it('marks and scrolls resolved parcel in current box', async () => {
+    const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView
+    window.HTMLElement.prototype.scrollIntoView ??= vi.fn()
     const scrollIntoView = vi
       .spyOn(window.HTMLElement.prototype, 'scrollIntoView')
       .mockImplementation(() => {})
@@ -587,6 +589,9 @@ describe('Scanjob_Monitor.vue', () => {
       })
     } finally {
       scrollIntoView.mockRestore()
+      if (originalScrollIntoView === undefined) {
+        delete window.HTMLElement.prototype.scrollIntoView
+      }
     }
   })
 

--- a/tests/Scanjob_Monitor.spec.js
+++ b/tests/Scanjob_Monitor.spec.js
@@ -607,7 +607,7 @@ describe('Scanjob_Monitor.vue', () => {
     await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
     await flushPromises()
 
-    expect(alertError).toHaveBeenCalledWith('Посылка или коробка с номером «MISSING» не найдена')
+    expect(alertError).toHaveBeenCalledWith('Посылка или коробка не найдена')
   })
 
   it('alerts when jump input is empty', async () => {
@@ -706,7 +706,7 @@ describe('Scanjob_Monitor.vue', () => {
     await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
     await flushPromises()
 
-    expect(alertError).toHaveBeenCalledWith('Посылка или коробка с номером «BADBOX» не найдена')
+    expect(alertError).toHaveBeenCalledWith('Посылка или коробка не найдена')
     expect(mockPush).not.toHaveBeenCalled()
   })
 
@@ -729,7 +729,7 @@ describe('Scanjob_Monitor.vue', () => {
     await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
     await flushPromises()
 
-    expect(alertError).toHaveBeenCalledWith('Посылка или коробка с номером «BADPARCEL» не найдена')
+    expect(alertError).toHaveBeenCalledWith('Посылка или коробка не найдена')
     expect(mockPush).not.toHaveBeenCalled()
   })
 
@@ -752,7 +752,7 @@ describe('Scanjob_Monitor.vue', () => {
     await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
     await flushPromises()
 
-    expect(alertError).toHaveBeenCalledWith('Посылка или коробка с номером «P-55» не найдена')
+    expect(alertError).toHaveBeenCalledWith('Посылка или коробка не найдена')
     expect(mockPush).not.toHaveBeenCalled()
   })
 

--- a/tests/Scanjob_Monitor.spec.js
+++ b/tests/Scanjob_Monitor.spec.js
@@ -48,6 +48,7 @@ const monitorClosed = vi.hoisted(() => ({
   value: null
 }))
 const loadMonitorSnapshot = vi.hoisted(() => vi.fn())
+const resolveMonitorTarget = vi.hoisted(() => vi.fn())
 const startMonitor = vi.hoisted(() => vi.fn())
 const clearMonitor = vi.hoisted(() => vi.fn())
 const stopMonitor = vi.hoisted(() => vi.fn())
@@ -297,6 +298,7 @@ vi.mock('@/stores/scanjobs.store.js', () => ({
     },
     getById,
     loadMonitorSnapshot,
+    resolveMonitorTarget,
     startMonitor,
     clearMonitor,
     stopMonitor,
@@ -366,7 +368,11 @@ const monitorGlobalStubs = {
     name: 'v-data-table',
     template: `
       <div class="v-data-table-stub" data-testid="v-data-table" v-bind="$attrs">
-        <div v-for="(item, i) in items" :key="i" class="v-data-table-row">
+        <div
+          v-for="(item, i) in items"
+          :key="i"
+          :class="['v-data-table-row', rowProps ? rowProps({ item })?.class : '']"
+        >
           <div v-for="header in headers" :key="header.key" class="v-data-table-cell">
             <slot :name="'item.' + header.key" :item="item">
               {{ item[header.key] }}
@@ -387,7 +393,8 @@ const monitorGlobalStubs = {
       'itemsPerPageText',
       'pageText',
       'density',
-      'class'
+      'class',
+      'rowProps'
     ],
     inheritAttrs: false
   }
@@ -427,6 +434,7 @@ describe('Scanjob_Monitor.vue', () => {
     registerGetById.mockResolvedValue(true)
     getTransportationDocument.mockReturnValue('Авианакладная')
     loadMonitorSnapshot.mockResolvedValue(registerSnapshot)
+    resolveMonitorTarget.mockResolvedValue({ kind: 0, number: 'MISSING' })
     startMonitor.mockResolvedValue(true)
     clearMonitor.mockResolvedValue(true)
     stopMonitor.mockResolvedValue(true)
@@ -485,6 +493,110 @@ describe('Scanjob_Monitor.vue', () => {
     expect(boxesTable.props('itemsPerPage')).toBe(25)
     expect(boxesTable.props('page')).toBe(2)
     expect(boxesTable.props('sortBy')).toEqual([{ key: 'boxCode', order: 'desc' }])
+    expect(wrapper.get('[data-testid="scanjob-monitor-jump"]').text()).toContain('Перейти к посылке или коробке по номеру:')
+  })
+
+  it('navigates to resolved box by number', async () => {
+    resolveMonitorTarget.mockResolvedValueOnce({
+      kind: 1,
+      area: 1,
+      boxId: 7,
+      bucketIndex: null,
+      parcelId: null,
+      number: 'BOX-7',
+      boxCode: 'BOX-7',
+      parcelNumber: null
+    })
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue(' BOX-7 ')
+    await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
+    await flushPromises()
+
+    expect(resolveMonitorTarget).toHaveBeenCalledWith(42, 'BOX-7')
+    expect(mockPush).toHaveBeenCalledWith({
+      name: 'scanjob-monitor-box',
+      params: { id: 42, boxId: 7 }
+    })
+  })
+
+  it('navigates to resolved unassigned parcel bucket', async () => {
+    resolveMonitorTarget.mockResolvedValueOnce({
+      kind: 2,
+      area: 2,
+      boxId: null,
+      bucketIndex: 1,
+      parcelId: 90,
+      number: 'PU-90',
+      boxCode: 'Без коробки 2',
+      parcelNumber: 'PU-90'
+    })
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('PU-90')
+    await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
+    await flushPromises()
+
+    expect(mockPush).toHaveBeenCalledWith({
+      name: 'scanjob-monitor-unassigned',
+      params: { id: 42, bucketIndex: 1 }
+    })
+  })
+
+  it('marks and scrolls resolved parcel in current box', async () => {
+    const scrollIntoView = vi.fn()
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView
+    loadMonitorSnapshot.mockResolvedValue(boxSnapshot)
+    resolveMonitorTarget.mockResolvedValueOnce({
+      kind: 2,
+      area: 1,
+      boxId: 7,
+      bucketIndex: null,
+      parcelId: 71,
+      number: 'P-71',
+      boxCode: 'BOX-7',
+      parcelNumber: 'P-71'
+    })
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42, monitorScope: box7MonitorScope },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('P-71')
+    await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
+    await flushPromises()
+
+    expect(loadMonitorSnapshot).toHaveBeenLastCalledWith(42, { area: 1, boxId: 7 })
+    expect(wrapper.find('.selected-parcel-row').exists()).toBe(true)
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'center',
+      inline: 'nearest'
+    })
+  })
+
+  it('alerts when jump target is not found', async () => {
+    resolveMonitorTarget.mockResolvedValueOnce({ kind: 0, area: null, number: 'MISSING' })
+    const wrapper = mount(ScanjobMonitor, {
+      props: { scanjobId: 42 },
+      global: { stubs: monitorGlobalStubs }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="scanjob-monitor-jump-input"]').setValue('MISSING')
+    await wrapper.get('[data-testid="scanjob-monitor-jump-action"]').trigger('click')
+    await flushPromises()
+
+    expect(alertError).toHaveBeenCalledWith('Посылка или коробка с номером «MISSING» не найдена')
   })
 
   it('does not start a separate autofollow observer for the register panel', async () => {

--- a/tests/Scanjob_Parcels_Monitor_Table.spec.js
+++ b/tests/Scanjob_Parcels_Monitor_Table.spec.js
@@ -4,7 +4,7 @@
 // This file is a part of Logibooks UI application
 
 import { beforeEach, describe, it, expect, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { ref } from 'vue'
 import ScanjobOzonParcelsMonitorTable from '@/dialogs/Scanjob_Ozon_Parcels_Monitor_Table.vue'
 import ScanjobWbrParcelsMonitorTable from '@/dialogs/Scanjob_Wbr_Parcels_Monitor_Table.vue'
@@ -55,6 +55,9 @@ const global = { stubs: vuetifyStubs }
 
 describe('Scanjob parcel monitor typed tables', () => {
   beforeEach(() => {
+    scanjobmonitorParcelsPerPage.value = 50
+    scanjobmonitorParcelsSortBy.value = [{ key: 'id', order: 'asc' }]
+    scanjobmonitorParcelsPage.value = 1
     hasLogistRole.value = true
     isAdmin.value = false
     isWhManager.value = false
@@ -301,5 +304,38 @@ describe('Scanjob parcel monitor typed tables', () => {
 
     await clearButton.trigger('click')
     expect(wrapper.emitted('clear-defect')?.[0][0]).toEqual(expect.objectContaining({ id: 42 }))
+  })
+
+  it('marks selected parcel row and moves pagination to its page', async () => {
+    const scrollIntoView = vi.fn()
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView
+    scanjobmonitorParcelsPerPage.value = 2
+    scanjobmonitorParcelsSortBy.value = [{ key: 'parcelNumber', order: 'asc' }]
+
+    const wrapper = mount(ScanjobParcelsMonitorTable, {
+      props: {
+        headers: [
+          { title: 'Посылка', key: 'parcelNumber' },
+          { title: 'Товар', key: 'productName' }
+        ],
+        selectedParcelId: 3,
+        parcels: [
+          { id: 1, parcelId: 1, parcelNumber: 'P-001', productName: 'One' },
+          { id: 2, parcelId: 2, parcelNumber: 'P-002', productName: 'Two' },
+          { id: 3, parcelId: 3, parcelNumber: 'P-003', productName: 'Three' }
+        ]
+      },
+      global
+    })
+
+    await flushPromises()
+
+    expect(scanjobmonitorParcelsPage.value).toBe(2)
+    expect(wrapper.find('.selected-parcel-row').exists()).toBe(true)
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'center',
+      inline: 'nearest'
+    })
   })
 })

--- a/tests/Scanjob_Parcels_Monitor_Table.spec.js
+++ b/tests/Scanjob_Parcels_Monitor_Table.spec.js
@@ -311,11 +311,12 @@ describe('Scanjob parcel monitor typed tables', () => {
     const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView
     window.HTMLElement.prototype.scrollIntoView = scrollIntoView
 
+    let wrapper
     try {
       scanjobmonitorParcelsPerPage.value = 2
       scanjobmonitorParcelsSortBy.value = [{ key: 'parcelNumber', order: 'asc' }]
 
-      const wrapper = mount(ScanjobParcelsMonitorTable, {
+      wrapper = mount(ScanjobParcelsMonitorTable, {
         props: {
           headers: [
             { title: 'Посылка', key: 'parcelNumber' },
@@ -341,7 +342,339 @@ describe('Scanjob parcel monitor typed tables', () => {
         inline: 'nearest'
       })
     } finally {
+      wrapper?.unmount()
       window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView
+    }
+  })
+
+  it('does not change page or scroll when no selectedParcelId', async () => {
+    scanjobmonitorParcelsPerPage.value = 2
+    scanjobmonitorParcelsSortBy.value = [{ key: 'parcelNumber', order: 'asc' }]
+    scanjobmonitorParcelsPage.value = 1
+
+    const scrollIntoView = vi.spyOn(window.HTMLElement.prototype, 'scrollIntoView').mockImplementation(() => {})
+    let wrapper
+
+    try {
+      wrapper = mount(ScanjobParcelsMonitorTable, {
+        props: {
+          headers: [
+            { title: 'Посылка', key: 'parcelNumber' }
+          ],
+          selectedParcelId: null,
+          parcels: [
+            { id: 1, parcelId: 1, parcelNumber: 'P-001' },
+            { id: 2, parcelId: 2, parcelNumber: 'P-002' },
+            { id: 3, parcelId: 3, parcelNumber: 'P-003' }
+          ]
+        },
+        global
+      })
+
+      await flushPromises()
+
+      expect(scanjobmonitorParcelsPage.value).toBe(1)
+      expect(scrollIntoView).not.toHaveBeenCalled()
+    } finally {
+      wrapper?.unmount()
+      scrollIntoView.mockRestore()
+    }
+  })
+
+  it('does not change page when selectedParcelId is not found in parcels', async () => {
+    scanjobmonitorParcelsPerPage.value = 2
+    scanjobmonitorParcelsSortBy.value = [{ key: 'parcelNumber', order: 'asc' }]
+    scanjobmonitorParcelsPage.value = 1
+
+    let wrapper
+    try {
+      wrapper = mount(ScanjobParcelsMonitorTable, {
+        props: {
+          headers: [{ title: 'Посылка', key: 'parcelNumber' }],
+          selectedParcelId: 999,
+          parcels: [
+            { id: 1, parcelId: 1, parcelNumber: 'P-001' },
+            { id: 2, parcelId: 2, parcelNumber: 'P-002' }
+          ]
+        },
+        global
+      })
+
+      await flushPromises()
+
+      expect(scanjobmonitorParcelsPage.value).toBe(1)
+    } finally {
+      wrapper?.unmount()
+    }
+  })
+
+  it('moves to correct page when parcels are sorted in descending order', async () => {
+    const scrollIntoView = vi.spyOn(window.HTMLElement.prototype, 'scrollIntoView').mockImplementation(() => {})
+    let wrapper
+
+    try {
+      scanjobmonitorParcelsPerPage.value = 2
+      scanjobmonitorParcelsSortBy.value = [{ key: 'parcelNumber', order: 'desc' }]
+      scanjobmonitorParcelsPage.value = 1
+
+      wrapper = mount(ScanjobParcelsMonitorTable, {
+        props: {
+          headers: [{ title: 'Посылка', key: 'parcelNumber' }],
+          selectedParcelId: 1,
+          parcels: [
+            { id: 1, parcelId: 1, parcelNumber: 'P-001' },
+            { id: 2, parcelId: 2, parcelNumber: 'P-002' },
+            { id: 3, parcelId: 3, parcelNumber: 'P-003' }
+          ]
+        },
+        global
+      })
+
+      await flushPromises()
+
+      // Sorted desc: P-003 (id=3), P-002 (id=2), P-001 (id=1)
+      // id=1 is at index 2 → page 2 with 2 per page
+      expect(scanjobmonitorParcelsPage.value).toBe(2)
+    } finally {
+      wrapper?.unmount()
+      scrollIntoView.mockRestore()
+    }
+  })
+
+  it('applies selected-parcel-row class only to matching row', async () => {
+    scanjobmonitorParcelsPerPage.value = 50
+    scanjobmonitorParcelsSortBy.value = []
+
+    let wrapper
+    try {
+      wrapper = mount(ScanjobParcelsMonitorTable, {
+        props: {
+          headers: [{ title: 'Посылка', key: 'parcelNumber' }],
+          selectedParcelId: 2,
+          parcels: [
+            { id: 1, parcelId: 1, parcelNumber: 'P-001' },
+            { id: 2, parcelId: 2, parcelNumber: 'P-002' },
+            { id: 3, parcelId: 3, parcelNumber: 'P-003' }
+          ]
+        },
+        global
+      })
+
+      await flushPromises()
+
+      const selectedRows = wrapper.findAll('.selected-parcel-row')
+      expect(selectedRows).toHaveLength(1)
+      expect(selectedRows[0].text()).toContain('P-002')
+    } finally {
+      wrapper?.unmount()
+    }
+  })
+
+  it('uses custom header sort function when sorting parcels', async () => {
+    scanjobmonitorParcelsPerPage.value = 2
+    scanjobmonitorParcelsPage.value = 1
+
+    const customSort = vi.fn((a, b) => {
+      // Reverse numeric sort: higher numbers come first
+      return b - a
+    })
+
+    scanjobmonitorParcelsSortBy.value = [{ key: 'weight', order: 'asc' }]
+
+    let wrapper
+    try {
+      wrapper = mount(ScanjobParcelsMonitorTable, {
+        props: {
+          headers: [
+            {
+              title: 'Вес',
+              key: 'weight',
+              sort: customSort
+            }
+          ],
+          selectedParcelId: 1,
+          parcels: [
+            { id: 1, parcelId: 1, weight: 10 },
+            { id: 2, parcelId: 2, weight: 20 },
+            { id: 3, parcelId: 3, weight: 30 }
+          ]
+        },
+        global
+      })
+
+      await flushPromises()
+
+      // Custom sort reverses order: id=3 (30), id=2 (20), id=1 (10)
+      // id=1 is at index 2 → page 2 with 2 per page
+      expect(scanjobmonitorParcelsPage.value).toBe(2)
+      expect(customSort).toHaveBeenCalled()
+    } finally {
+      wrapper?.unmount()
+    }
+  })
+
+  it('uses item.id as fallback when item.parcelId is absent', async () => {
+    const scrollIntoView = vi.spyOn(window.HTMLElement.prototype, 'scrollIntoView').mockImplementation(() => {})
+    let wrapper
+
+    try {
+      scanjobmonitorParcelsPerPage.value = 50
+      scanjobmonitorParcelsSortBy.value = []
+
+      wrapper = mount(ScanjobParcelsMonitorTable, {
+        props: {
+          headers: [{ title: 'Посылка', key: 'parcelNumber' }],
+          selectedParcelId: 5,
+          parcels: [
+            { id: 5, parcelNumber: 'P-005' },
+            { id: 6, parcelNumber: 'P-006' }
+          ]
+        },
+        global
+      })
+
+      await flushPromises()
+
+      expect(wrapper.find('.selected-parcel-row').exists()).toBe(true)
+      expect(wrapper.find('.selected-parcel-row').text()).toContain('P-005')
+    } finally {
+      wrapper?.unmount()
+      scrollIntoView.mockRestore()
+    }
+  })
+
+  it('updates page when selectedParcelId changes reactively', async () => {
+    const scrollIntoView = vi.spyOn(window.HTMLElement.prototype, 'scrollIntoView').mockImplementation(() => {})
+    let wrapper
+
+    try {
+      scanjobmonitorParcelsPerPage.value = 2
+      scanjobmonitorParcelsSortBy.value = [{ key: 'parcelNumber', order: 'asc' }]
+      scanjobmonitorParcelsPage.value = 1
+
+      wrapper = mount(ScanjobParcelsMonitorTable, {
+        props: {
+          headers: [{ title: 'Посылка', key: 'parcelNumber' }],
+          selectedParcelId: null,
+          parcels: [
+            { id: 1, parcelId: 1, parcelNumber: 'P-001' },
+            { id: 2, parcelId: 2, parcelNumber: 'P-002' },
+            { id: 3, parcelId: 3, parcelNumber: 'P-003' }
+          ]
+        },
+        global
+      })
+
+      await flushPromises()
+      expect(scanjobmonitorParcelsPage.value).toBe(1)
+
+      await wrapper.setProps({ selectedParcelId: 3 })
+      await flushPromises()
+
+      expect(scanjobmonitorParcelsPage.value).toBe(2)
+    } finally {
+      wrapper?.unmount()
+      scrollIntoView.mockRestore()
+    }
+  })
+
+  it('updates page when parcels list changes reactively', async () => {
+    const scrollIntoView = vi.spyOn(window.HTMLElement.prototype, 'scrollIntoView').mockImplementation(() => {})
+    let wrapper
+
+    try {
+      scanjobmonitorParcelsPerPage.value = 2
+      scanjobmonitorParcelsSortBy.value = [{ key: 'parcelNumber', order: 'asc' }]
+      scanjobmonitorParcelsPage.value = 1
+
+      wrapper = mount(ScanjobParcelsMonitorTable, {
+        props: {
+          headers: [{ title: 'Посылка', key: 'parcelNumber' }],
+          selectedParcelId: 3,
+          parcels: [
+            { id: 1, parcelId: 1, parcelNumber: 'P-001' },
+            { id: 2, parcelId: 2, parcelNumber: 'P-002' }
+          ]
+        },
+        global
+      })
+
+      await flushPromises()
+      // id=3 not found yet → page stays at 1
+      expect(scanjobmonitorParcelsPage.value).toBe(1)
+
+      await wrapper.setProps({
+        parcels: [
+          { id: 1, parcelId: 1, parcelNumber: 'P-001' },
+          { id: 2, parcelId: 2, parcelNumber: 'P-002' },
+          { id: 3, parcelId: 3, parcelNumber: 'P-003' }
+        ]
+      })
+      await flushPromises()
+
+      expect(scanjobmonitorParcelsPage.value).toBe(2)
+    } finally {
+      wrapper?.unmount()
+      scrollIntoView.mockRestore()
+    }
+  })
+
+  it('does not change page when perPage is zero', async () => {
+    scanjobmonitorParcelsPerPage.value = 0
+    scanjobmonitorParcelsSortBy.value = []
+    scanjobmonitorParcelsPage.value = 1
+
+    let wrapper
+    try {
+      wrapper = mount(ScanjobParcelsMonitorTable, {
+        props: {
+          headers: [{ title: 'Посылка', key: 'parcelNumber' }],
+          selectedParcelId: 2,
+          parcels: [
+            { id: 1, parcelId: 1, parcelNumber: 'P-001' },
+            { id: 2, parcelId: 2, parcelNumber: 'P-002' }
+          ]
+        },
+        global
+      })
+
+      await flushPromises()
+
+      expect(scanjobmonitorParcelsPage.value).toBe(1)
+    } finally {
+      wrapper?.unmount()
+    }
+  })
+
+  it('sorts without rules returns original parcel order', async () => {
+    const scrollIntoView = vi.spyOn(window.HTMLElement.prototype, 'scrollIntoView').mockImplementation(() => {})
+    let wrapper
+
+    try {
+      scanjobmonitorParcelsPerPage.value = 2
+      scanjobmonitorParcelsSortBy.value = []
+      scanjobmonitorParcelsPage.value = 1
+
+      wrapper = mount(ScanjobParcelsMonitorTable, {
+        props: {
+          headers: [{ title: 'Посылка', key: 'parcelNumber' }],
+          selectedParcelId: 3,
+          parcels: [
+            { id: 1, parcelId: 1, parcelNumber: 'P-001' },
+            { id: 2, parcelId: 2, parcelNumber: 'P-002' },
+            { id: 3, parcelId: 3, parcelNumber: 'P-003' }
+          ]
+        },
+        global
+      })
+
+      await flushPromises()
+
+      // No sort rules → original order: id=3 at index 2 → page 2
+      expect(scanjobmonitorParcelsPage.value).toBe(2)
+    } finally {
+      wrapper?.unmount()
+      scrollIntoView.mockRestore()
     }
   })
 })

--- a/tests/Scanjob_Parcels_Monitor_Table.spec.js
+++ b/tests/Scanjob_Parcels_Monitor_Table.spec.js
@@ -308,34 +308,40 @@ describe('Scanjob parcel monitor typed tables', () => {
 
   it('marks selected parcel row and moves pagination to its page', async () => {
     const scrollIntoView = vi.fn()
+    const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView
     window.HTMLElement.prototype.scrollIntoView = scrollIntoView
-    scanjobmonitorParcelsPerPage.value = 2
-    scanjobmonitorParcelsSortBy.value = [{ key: 'parcelNumber', order: 'asc' }]
 
-    const wrapper = mount(ScanjobParcelsMonitorTable, {
-      props: {
-        headers: [
-          { title: 'Посылка', key: 'parcelNumber' },
-          { title: 'Товар', key: 'productName' }
-        ],
-        selectedParcelId: 3,
-        parcels: [
-          { id: 1, parcelId: 1, parcelNumber: 'P-001', productName: 'One' },
-          { id: 2, parcelId: 2, parcelNumber: 'P-002', productName: 'Two' },
-          { id: 3, parcelId: 3, parcelNumber: 'P-003', productName: 'Three' }
-        ]
-      },
-      global
-    })
+    try {
+      scanjobmonitorParcelsPerPage.value = 2
+      scanjobmonitorParcelsSortBy.value = [{ key: 'parcelNumber', order: 'asc' }]
 
-    await flushPromises()
+      const wrapper = mount(ScanjobParcelsMonitorTable, {
+        props: {
+          headers: [
+            { title: 'Посылка', key: 'parcelNumber' },
+            { title: 'Товар', key: 'productName' }
+          ],
+          selectedParcelId: 3,
+          parcels: [
+            { id: 1, parcelId: 1, parcelNumber: 'P-001', productName: 'One' },
+            { id: 2, parcelId: 2, parcelNumber: 'P-002', productName: 'Two' },
+            { id: 3, parcelId: 3, parcelNumber: 'P-003', productName: 'Three' }
+          ]
+        },
+        global
+      })
 
-    expect(scanjobmonitorParcelsPage.value).toBe(2)
-    expect(wrapper.find('.selected-parcel-row').exists()).toBe(true)
-    expect(scrollIntoView).toHaveBeenCalledWith({
-      behavior: 'smooth',
-      block: 'center',
-      inline: 'nearest'
-    })
+      await flushPromises()
+
+      expect(scanjobmonitorParcelsPage.value).toBe(2)
+      expect(wrapper.find('.selected-parcel-row').exists()).toBe(true)
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'center',
+        inline: 'nearest'
+      })
+    } finally {
+      window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView
+    }
   })
 })

--- a/tests/helpers/test-utils.js
+++ b/tests/helpers/test-utils.js
@@ -80,7 +80,11 @@ export const vuetifyStubs = {
             </slot>
           </div>
         </div>
-        <div v-for="(item, i) in items" :key="i" class="v-data-table-row">
+        <div
+          v-for="(item, i) in items"
+          :key="i"
+          :class="['v-data-table-row', rowProps ? rowProps({ item })?.class : '']"
+        >
           <div v-for="header in headers" :key="header.key" class="v-data-table-cell">
             <slot :name="'item.' + header.key" :item="item">
               {{ item[header.key] }}
@@ -90,7 +94,7 @@ export const vuetifyStubs = {
         <slot></slot>
       </div>
     `,
-    props: ['items', 'headers', 'loading', 'itemsLength', 'itemsPerPage', 'page', 'sortBy', 'itemsPerPageOptions', 'search', 'customFilter', 'density', 'style'],
+    props: ['items', 'headers', 'loading', 'itemsLength', 'itemsPerPage', 'page', 'sortBy', 'itemsPerPageOptions', 'search', 'customFilter', 'density', 'style', 'rowProps'],
     inheritAttrs: false
   },
   'v-data-table-server': {

--- a/tests/helpers/test-utils.js
+++ b/tests/helpers/test-utils.js
@@ -59,7 +59,7 @@ export const vuetifyStubs = {
     inheritAttrs: false
   },
   'v-text-field': {
-    template: '<label class="v-text-field-stub" data-testid="v-text-field"><span>{{ label }}</span><input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" @keydown="$emit(\'keydown\', $event)" /></label>',
+    template: '<label class="v-text-field-stub" data-testid="v-text-field"><span>{{ label }}</span><input v-bind="$attrs" :value="modelValue" :disabled="disabled" @input="$emit(\'update:modelValue\', $event.target.value)" @keydown="$emit(\'keydown\', $event)" /></label>',
     props: ['modelValue', 'label', 'clearable', 'prefix', 'type', 'variant', 'density', 'hideDetails', 'readonly', 'style', 'errorMessages', 'required', 'disabled', 'placeholder'],
     inheritAttrs: false,
     emits: ['input', 'update:modelValue', 'keydown']

--- a/tests/scanjob.monitor.helpers.spec.js
+++ b/tests/scanjob.monitor.helpers.spec.js
@@ -3,7 +3,10 @@
 // This file is a part of Logibooks UI application
 
 import { describe, expect, it } from 'vitest'
-import { compareScanjobCheckStatusProjection } from '@/helpers/scanjob.monitor.helpers.js'
+import {
+  compareScanjobCheckStatusProjection,
+  scanjobMonitorTargetKind
+} from '@/helpers/scanjob.monitor.helpers.js'
 
 describe('scanjob.monitor.helpers', () => {
   it('sorts check status projections by their visible title', () => {
@@ -21,5 +24,11 @@ describe('scanjob.monitor.helpers', () => {
   it('falls back to the rendered placeholder for missing projections', () => {
     expect(compareScanjobCheckStatusProjection(null, { title: 'Запрет' })).toBeLessThan(0)
     expect(compareScanjobCheckStatusProjection(null, null)).toBe(0)
+  })
+
+  it('exports scanjobMonitorTargetKind with expected numeric values', () => {
+    expect(scanjobMonitorTargetKind.None).toBe(0)
+    expect(scanjobMonitorTargetKind.Box).toBe(1)
+    expect(scanjobMonitorTargetKind.Parcel).toBe(2)
   })
 })

--- a/tests/scanjobs.store.spec.js
+++ b/tests/scanjobs.store.spec.js
@@ -580,6 +580,16 @@ describe('scanjobs store', () => {
       expect(store.monitorError).toBeNull()
     })
 
+    it('resolveMonitorTarget throws and sets monitorError on failure', async () => {
+      const fetchError = new Error('Resolve error')
+      fetchWrapper.get.mockRejectedValue(fetchError)
+
+      const store = useScanjobsStore()
+
+      await expect(store.resolveMonitorTarget(42, 'UNKNOWN')).rejects.toThrow('Resolve error')
+      expect(store.monitorError).toBe(fetchError)
+    })
+
     it('starts SignalR monitor and forwards snapshots', async () => {
       const onSnapshot = vi.fn()
       const store = useScanjobsStore()

--- a/tests/scanjobs.store.spec.js
+++ b/tests/scanjobs.store.spec.js
@@ -568,6 +568,18 @@ describe('scanjobs store', () => {
       expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/scanjobs/42/monitor?area=2&bucketIndex=3`)
     })
 
+    it('resolves monitor target by number', async () => {
+      const target = { kind: 1, area: 1, boxId: 7, number: 'BOX-7' }
+      fetchWrapper.get.mockResolvedValue(target)
+      const store = useScanjobsStore()
+
+      const result = await store.resolveMonitorTarget(42, 'BOX-7')
+
+      expect(fetchWrapper.get).toHaveBeenCalledWith(`${apiUrl}/scanjobs/42/monitor/resolve?number=BOX-7`)
+      expect(result).toEqual(target)
+      expect(store.monitorError).toBeNull()
+    })
+
     it('starts SignalR monitor and forwards snapshots', async () => {
       const onSnapshot = vi.fn()
       const store = useScanjobsStore()


### PR DESCRIPTION
Adds "jump to box/parcel by number" functionality to the scanjob monitor and improves parcel-table UX by auto-highlighting/scrolling the resolved parcel and moving pagination to the correct page.

## Changes Made

- **`resolveMonitorTarget` store action** + **`scanjobMonitorTargetKind` enum** to support resolving a box/parcel by its number via the backend.
- **Jump-by-number UI** in `Scanjob_Monitor.vue`: text field + action button (also submittable via Enter key), route navigation to the resolved box/unassigned bucket, parcel row highlighting with `selectedParcelId`, and loading spinner during resolution.
- **Enhanced parcels monitor table** (`Scanjob_Parcels_Monitor_Table.vue`): accepts `selectedParcelId` prop, computes its page based on current sorting, applies `selected-parcel-row` CSS class, and scrolls the selected row into view.

## Testing

25 new tests added across 4 files targeting ≥95% coverage of new and updated code:

- `scanjob.monitor.helpers.spec.js` — `scanjobMonitorTargetKind` enum values
- `scanjobs.store.spec.js` — `resolveMonitorTarget` success and error paths
- `Scanjob_Monitor.spec.js` — all branches of `handleJumpToNumber` (empty input, loading guard, `isJumpDisabled`, loading spinner, null `boxId`/`parcelId`, `area=Boxes` guard, error message with/without `.message`, Enter key, `selectedParcelId` cleared on navigation, same-scope no-navigation)
- `Scanjob_Parcels_Monitor_Table.spec.js` — no selection, parcel not found, descending sort, custom sort function, row class isolation, `item.id` fallback, reactive `selectedParcelId` and parcels changes, `perPage=0` guard, no-sort-rules order

Test isolation improved by adding `wrapper.unmount()` in `try/finally` blocks for all table tests that mutate shared reactive refs, preventing `immediate: true` watch contamination across tests.